### PR TITLE
feat(formatters): Add formatBytes() helper for file size display

### DIFF
--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -1,0 +1,56 @@
+/// Utility functions for formatting various data types.
+library formatters;
+
+/// Formats bytes into a human-readable string with appropriate units.
+///
+/// Converts bytes to the largest unit (B, KB, MB, GB, TB) that keeps the value >= 1.
+/// Trims trailing zeros from decimal places (e.g., 1.00 KB becomes 1 KB).
+/// Handles negative numbers with a minus prefix.
+/// 
+/// Example:
+/// ```dart
+/// formatBytes(0);      // '0 B'
+/// formatBytes(1);      // '1 B'
+/// formatBytes(1023);   // '1023 B'
+/// formatBytes(1024);   // '1 KB'
+/// formatBytes(1536);   // '1.5 KB'
+/// formatBytes(-1024);  // '-1 KB'
+/// formatBytes(1024 * 1024);  // '1 MB'
+/// ```
+String formatBytes(int bytes) {
+  // Handle negative values by working with absolute value and adding minus sign
+  final isNegative = bytes < 0;
+  var absBytes = isNegative ? -bytes : bytes;
+  
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const divider = 1024;
+  
+  // Handle special case for 0 bytes
+  if (absBytes == 0) return '0 B';
+  
+  var value = absBytes.toDouble();
+  var unitIndex = 0;
+  
+  // Divide until we get to an appropriately sized unit or reach max unit
+  while (value >= divider && unitIndex < units.length - 1) {
+    value /= divider;
+    unitIndex++;
+  }
+  
+  // Format the value with appropriate decimal places and trim trailing zeros
+  String formattedValue;
+  if (value == value.roundToDouble()) {
+    // Whole number, show without decimal places
+    formattedValue = value.round().toString();
+  } else {
+    // Fractional number, show up to 2 decimal places
+    formattedValue = value.toStringAsFixed(2).replaceAll(RegExp(r'\.?0*$'), '');
+  }
+  
+  // Add minus sign for negative values
+  if (isNegative) {
+    formattedValue = '-$formattedValue';
+  }
+  
+  return '$formattedValue ${units[unitIndex]}';
+}

--- a/lib/core/utils/utils.dart
+++ b/lib/core/utils/utils.dart
@@ -1,0 +1,1 @@
+export 'formatters.dart';

--- a/test/formatters_test.dart
+++ b/test/formatters_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/formatters.dart';
+
+void main() {
+  group('formatBytes', () {
+    test('handles zero bytes', () {
+      expect(formatBytes(0), '0 B');
+    });
+
+    test('handles single byte', () {
+      expect(formatBytes(1), '1 B');
+    });
+
+    test('handles multiple bytes', () {
+      expect(formatBytes(2), '2 B');
+      expect(formatBytes(100), '100 B');
+      expect(formatBytes(1023), '1023 B');
+    });
+
+    test('converts to KB at boundary', () {
+      expect(formatBytes(1024), '1 KB');
+      expect(formatBytes(1536), '1.5 KB'); // 1.5 * 1024 = 1536
+    });
+
+    test('formats KB with proper decimal places', () {
+      expect(formatBytes(1500), '1.46 KB'); // ~1.4648, rounded and trimmed
+      expect(formatBytes(2048), '2 KB'); // Exact 2 KB
+    });
+
+    test('converts to MB at boundary', () {
+      expect(formatBytes(1024 * 1024), '1 MB');
+      expect(formatBytes((1024 * 1024 * 3) ~/ 2).toString().startsWith('1.5'), isTrue); // 1.5 MB
+    });
+
+    test('converts to GB at boundary', () {
+      expect(formatBytes(1024 * 1024 * 1024), '1 GB');
+    });
+
+    test('converts to TB at boundary', () {
+      expect(formatBytes(1024 * 1024 * 1024 * 1024), '1 TB');
+    });
+
+    test('handles values larger than TB', () {
+      // Should continue scaling numerically within TB unit
+      expect(formatBytes(1024 * 1024 * 1024 * 1024 * 2), '2 TB');
+      expect(formatBytes(1024 * 1024 * 1024 * 1024 * 1024), '1024 TB');
+    });
+
+    test('trims trailing zeros properly', () {
+      // Values that result in .00 should be trimmed to whole numbers
+      expect(formatBytes(1024), '1 KB'); // Exactly 1 KB
+      expect(formatBytes(2048), '2 KB'); // Exactly 2 KB
+      
+      // Values with significant decimals should keep them
+      expect(formatBytes(1536), '1.5 KB'); // Exactly 1.5 KB
+      
+      // Values with insignificant trailing zeros should be trimmed
+      expect(formatBytes(1075), '1.05 KB'); // ~1.0503 KB, should be 1.05 KB
+    });
+
+    test('handles exact boundary transitions', () {
+      // Test boundaries for each unit transition
+      expect(formatBytes(1023), '1023 B');
+      expect(formatBytes(1024), '1 KB');
+      expect(formatBytes(1024 * 1024 - 1), '1024 KB'); // 1048575 bytes = 1024 KB
+      expect(formatBytes(1024 * 1024), '1 MB'); // 1048576 bytes = 1 MB
+      expect(formatBytes(1024 * 1024 * 1024 - 1), '1024 MB'); // One byte less than 1 GB
+      expect(formatBytes(1024 * 1024 * 1024), '1 GB'); // Exactly 1 GB
+      expect(formatBytes(1024 * 1024 * 1024 * 1024 - 1), '1024 GB'); // One byte less than 1 TB
+      expect(formatBytes(1024 * 1024 * 1024 * 1024), '1 TB'); // Exactly 1 TB
+    });
+    
+    test('handles negative values correctly', () {
+      expect(formatBytes(-1), '-1 B');
+      expect(formatBytes(-1023), '-1023 B');
+      expect(formatBytes(-1024), '-1 KB');
+      expect(formatBytes(-1536), '-1.5 KB');
+      expect(formatBytes(-2048), '-2 KB');
+      expect(formatBytes(-1024 * 1024), '-1 MB');
+      expect(formatBytes(-1024 * 1024 * 1024), '-1 GB');
+      expect(formatBytes(-1024 * 1024 * 1024 * 1024), '-1 TB');
+    });
+
+    // Boundary test cases for verifying exact transition points
+    test('boundary cases for accurate rounding', () {
+      // Make sure values are displayed correctly at transitions
+      expect(formatBytes(1023), '1023 B');
+      expect(formatBytes(1024), '1 KB');
+      expect(formatBytes(1024 * 1024 - 1), '1024 KB'); // 1048575 bytes = 1024 KB (just under 1 MB)
+      expect(formatBytes(1024 * 1024), '1 MB'); // Exactly 1 MB
+      expect(formatBytes(1024 * 1024 * 1024 - 1), '1024 MB'); // Just under 1 GB
+      expect(formatBytes(1024 * 1024 * 1024), '1 GB'); // Exactly 1 GB
+      expect(formatBytes(1024 * 1024 * 1024 * 1024 - 1), '1024 GB'); // Just under 1 TB
+      expect(formatBytes(1024 * 1024 * 1024 * 1024), '1 TB'); // Exactly 1 TB
+    });
+
+    test('very large values stay expressed in TB', () {
+      expect(formatBytes(1024 * 1024 * 1024 * 1024 * 1024), '1024 TB');
+      expect(formatBytes(1024 * 1024 * 1024 * 1024 * 2048), '2048 TB');
+    });
+  });
+}


### PR DESCRIPTION
Added formatBytes() helper function to format file sizes in a human-readable format with appropriate units (B, KB, MB, GB, TB).

## Changes

- Added `formatBytes(int bytes)` function in `lib/core/utils/formatters.dart`
- Added comprehensive test coverage in `test/formatters_test.dart`
- Updated export in `lib/core/utils/utils.dart`

## Features

- Converts bytes to the largest unit that keeps the value >= 1
- Trims trailing zeros from decimal places
- Handles negative values with a minus prefix
- Handles values up to and beyond TB scale
- Proper boundary handling for unit transitions

## Test Coverage

- Zero bytes: `0 B`
- Single bytes: `1 B`
- Multiple bytes: `2 B`, `100 B`, `1023 B`
- KB boundary: `1024 B` becomes `1 KB`
- Decimal precision: `1536 B` becomes `1.5 KB`
- MB/GB/TB boundaries
- Negative values: `-1024` becomes `-1 KB`
- Very large values stay expressed in TB: `1024^5` becomes `1024 TB`