### PR TITLE
[bench-a1a87812] feat(formatters): Add formatBytes() helper for file size display

### DIFF
--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -40,7 +40,9 @@ String formatBytes(int bytes) {
   }
 
   // Format with up to 2 decimal places
-  String formatted = value.toStringAsFixed(2);
+  // Floor to 2 decimal places to avoid premature rounding up
+  double floored = (value * 100).floor() / 100;
+  String formatted = floored.toStringAsFixed(2);
 
   // Trim trailing zeros and potential trailing dot
   if (formatted.contains('.')) {

--- a/test/core/utils/formatters_test.dart
+++ b/test/core/utils/formatters_test.dart
@@ -54,11 +54,13 @@ void main() {
       // Just below 1 KB boundary
       expect(formatBytes(1023), '1023 B');
       // Just below 1 MB boundary
-      expect(formatBytes(1048575), '1024 KB'); // 1024^2 - 1
+      expect(formatBytes(1048575), '1023.99 KB'); // 1048575 / 1024 ≈ 1023.999
       // Just below 1 GB boundary
-      expect(formatBytes(1073741823), '1024 MB'); // 1024^3 - 1
+      expect(formatBytes(1073741823),
+          '1023.99 MB'); // 1073741823 / 1024^2 ≈ 1023.999
       // Just below 1 TB boundary
-      expect(formatBytes(1099511627775), '1024 GB'); // 1024^4 - 1
+      expect(formatBytes(1099511627775),
+          '1023.99 GB'); // 1099511627775 / 1024^3 ≈ 1023.999
     });
 
     // Edge case: Negative values


### PR DESCRIPTION
Implementation of formatBytes helper with proper flooring to prevent premature rounding up.

## Summary

Added  operation before formatting to ensure values just below unit boundaries stay in the smaller unit (e.g., 1048575 bytes → 1023.99 KB, not 1 MB).

## Changes

1. ****: Added  before  to floor to two decimal places, preventing premature rounding up to the next unit.

2. ****: Updated boundary test expectations:
   -  →  (was )
   -  →  (was )
   -  →  (was )

Edge cases now correctly stay within their unit thresholds.

## Testing

All existing tests pass. The function maintains:
- Binary units (1024‑based)
- Trailing‑zero trimming
- Negative‑value handling
- No scientific notation for large TB values

Closes #99