### PR TITLE
feat(templates): deploy hermes-ready issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/capability.yml
+++ b/.github/ISSUE_TEMPLATE/capability.yml
@@ -1,0 +1,128 @@
+name: Capability
+description: Complete end-to-end functionality for a hermes agent to deliver
+title: "[CAPABILITY] "
+labels: ["capability", "hermes-task", "needs-plan"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Capability
+        A complete, deployable unit of functionality — end-to-end value
+        delivery (typically 1-4 weeks of agent work, XS → L sizing). The
+        hermes orchestrator plans the capability and dispatches to an
+        agent when this card moves to "Ready" on the board. All required
+        fields below must be filled before planning starts.
+
+  - type: input
+    id: objective
+    attributes:
+      label: Objective
+      description: One sentence stating what the capability delivers.
+      placeholder: "Add schema validator that gates plan-review on structured card fields"
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Testable checklist. Each item is something the reviewer will verify the plan addresses.
+      placeholder: |
+        - [ ] Validator runs on `projects_v2_item` webhook when status becomes Ready
+        - [ ] Cards missing required fields get a `needs-author-action` label + failure comment
+        - [ ] Cards passing validation transition to Planning and invoke the planner
+        - [ ] Existing orchestrator tests pass
+      value: "- [ ] "
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Out-of-scope / non-goals
+      description: |
+        Explicit list of things the agent MUST NOT do. If there are no non-goals,
+        write "None" rather than leaving blank — the reviewer uses this list to
+        reject scope-creep critiques.
+      placeholder: |
+        - Do NOT change the planner prompt in this card
+        - Do NOT add new required fields beyond those in the plan spec
+        - Do NOT gate on author allow-list in this card (separate work)
+      value: "- "
+    validations:
+      required: true
+
+  - type: textarea
+    id: files_expected
+    attributes:
+      label: Files expected to change
+      description: Path list, one per line. Planner verifies each parent directory exists.
+      placeholder: |
+        ansible/roles/hermes_orchestrator/files/card_validator.py
+        ansible/roles/hermes_orchestrator/files/handlers.py
+        ansible/roles/hermes_orchestrator/files/comment_formats/validator_failure_github.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests_required
+    attributes:
+      label: Tests to add or update
+      description: File path + test function name, OR "No new tests required" with a one-line rationale.
+      placeholder: |
+        tests/test_card_validator.py::test_accepts_fully_populated_card
+        tests/test_card_validator.py::test_rejects_missing_acceptance_criteria
+        tests/test_card_validator.py::test_skips_non_hermes_task_label
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Exact commands the agent runs to prove success. Shell code block.
+      placeholder: |
+        cd ansible/roles/hermes_orchestrator/files
+        pytest tests/test_card_validator.py -v
+        pytest tests/test_handlers.py -v
+      render: bash
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / conventions
+      description: Free-form. Pattern-to-follow hints, constraints, or context about why the card exists.
+      placeholder: |
+        - GitHub issue forms render fields as `### <Field Label>` headers — parse on those
+        - Semantic checks: acceptance_criteria needs ≥1 `- [ ]` line; verification needs ≥1 fenced code block
+    validations:
+      required: false
+
+  - type: textarea
+    id: context_library_links
+    attributes:
+      label: Context library links
+      description: |
+        Deep-links into the project's long-running context-library repo
+        (requirements, specifications, ADRs, discovery docs). Optional.
+      placeholder: |
+        - Design: ~/.claude/plans/as-i-understand-it-gentle-lamport.md
+    validations:
+      required: false
+
+  - type: dropdown
+    id: capability_size
+    attributes:
+      label: Capability size (human planning hint)
+      description: |
+        Optional rough size estimate for human planning. Not consumed by the
+        planner — it's only a sizing signal for the board.
+      options:
+        - "XS (< 1 week)"
+        - "S (1 week)"
+        - "M (1-2 weeks)"
+        - "L (2-4 weeks)"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/context-update.yml
+++ b/.github/ISSUE_TEMPLATE/context-update.yml
@@ -1,0 +1,279 @@
+name: Context Update
+description: Blueprint repository documentation maintenance (hours to 1 day)
+title: "[CONTEXT] "
+labels: ["context-update", "documentation", "hermes-not-actionable"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Context Update Issue
+        A Context Update maintains the infiquetra-blueprint repository's accuracy and completeness.
+        This is essential for AI effectiveness - Claude Code relies on up-to-date context.
+
+        **Important**: Every Capability should create a Context Update to document what was built.
+
+  - type: checkboxes
+    id: update_type
+    attributes:
+      label: What's Being Updated?
+      description: Select all that apply
+      options:
+        - label: Requirements document
+        - label: Technical specification
+        - label: Architecture Decision Record (ADR)
+        - label: API contract (OpenAPI spec)
+        - label: Data model
+        - label: Best practice / pattern
+        - label: AI prompt library
+        - label: Architecture diagram
+        - label: Integration guide
+    validations:
+      required: true
+
+  - type: textarea
+    id: why_update
+    attributes:
+      label: Why This Update?
+      description: What triggered this update?
+      placeholder: |
+        - Related Capability: #123 (Implement auth service)
+        - Gap discovered during: Development
+        - Issue: Specification didn't include webhook callback pattern
+        - Impact: Future developers will face same confusion
+    validations:
+      required: true
+
+  - type: textarea
+    id: files_to_update
+    attributes:
+      label: Files to Update
+      description: List all Blueprint repository files that need changes
+      placeholder: |
+        - `specifications/services/auth-service.md`
+        - `specifications/api/auth-api.yaml`
+        - `patterns/webhook-callbacks.md`
+        - `architecture/diagrams/auth-flow.py` (regenerate diagram)
+    validations:
+      required: true
+
+  - type: textarea
+    id: changes_description
+    attributes:
+      label: Changes Description
+      description: What specifically are you adding/changing?
+      placeholder: |
+        **Adding**:
+        - Webhook callback section to auth spec
+        - Example webhook payload
+        - Retry logic requirements
+        - Security requirements for webhook auth
+
+        **Updating**:
+        - API contract to include webhook registration endpoint
+        - Architecture diagram to show webhook flow
+
+        **Removing**:
+        - None
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What must be complete for this update?
+      placeholder: |
+        - [ ] Specification updated with webhook section
+        - [ ] OpenAPI spec includes new endpoint
+        - [ ] Example payloads provided
+        - [ ] Architecture diagram regenerated
+        - [ ] Changes reviewed by tech lead
+        - [ ] Linked to originating capability
+        - [ ] No broken links in documentation
+    validations:
+      required: true
+
+  - type: dropdown
+    id: context_gap
+    attributes:
+      label: Critical Context Gap?
+      description: Is this filling a gap that blocks work?
+      options:
+        - "Yes - this is blocking current/future work"
+        - "No - this is improving existing documentation"
+    validations:
+      required: true
+
+  - type: textarea
+    id: ai_prompt
+    attributes:
+      label: AI Prompt to Save (if applicable)
+      description: If this is documenting a successful Claude Code interaction, paste the prompt
+      placeholder: |
+        **Prompt that worked well**:
+        ```
+        Using the context from:
+        - /specifications/services/auth-service.md
+        - /patterns/webhook-callbacks.md
+
+        Generate an endpoint for registering webhooks that:
+        1. Validates webhook URL is HTTPS
+        2. Performs test callback to verify endpoint
+        3. Stores webhook configuration in database
+        4. Returns registration confirmation
+
+        Include comprehensive error handling and tests.
+        ```
+
+        **Results**:
+        - Generated working code in 45 seconds
+        - 92% test coverage achieved
+        - Only minor adjustments needed (validation logic)
+        - Would reuse this pattern for other webhook endpoints
+
+  - type: textarea
+    id: related_issues
+    attributes:
+      label: Related Issues
+      description: Link to capabilities or issues that triggered this update
+      placeholder: |
+        - Capability that revealed this gap: #123
+        - Capabilities that will benefit from this: #145, #167
+        - Related Context Updates: #89
+
+  - type: dropdown
+    id: documentation_type
+    attributes:
+      label: Documentation Type
+      description: What kind of documentation is this?
+      options:
+        - Requirements (what and why)
+        - Specification (how - technical details)
+        - Decision (why we chose this approach - ADR)
+        - Pattern (reusable approach)
+        - Anti-pattern (what NOT to do)
+        - AI Prompt (successful Claude interaction)
+        - Integration Guide (how to integrate)
+        - Architecture (system design)
+    validations:
+      required: true
+
+  - type: input
+    id: parent_objective
+    attributes:
+      label: Parent Objective (optional)
+      description: If this documentation supports a specific Objective/Milestone
+      placeholder: "objective:mvp-launch"
+
+  - type: input
+    id: parent_initiative
+    attributes:
+      label: Parent Initiative (optional)
+      description: Strategic initiative this documentation supports
+      placeholder: "initiative:platform-launch"
+
+  - type: textarea
+    id: review_checklist
+    attributes:
+      label: Documentation Quality Checklist
+      description: Self-review before submitting
+      value: |
+        - [ ] Clear and concise writing
+        - [ ] No jargon without explanation
+        - [ ] Code examples included where helpful
+        - [ ] Links to related documents included
+        - [ ] Diagrams included or updated if needed
+        - [ ] Sufficient for AI (Claude) to understand
+        - [ ] Reviewed for accuracy
+        - [ ] Spell-checked and grammar-checked
+
+  - type: textarea
+    id: automated_tests
+    attributes:
+      label: Automated Tests (for documentation validation)
+      description: What automated checks validate this documentation? (if applicable)
+      placeholder: |
+        - [ ] Link validation (no broken links)
+        - [ ] Markdown linting passes
+        - [ ] Code examples compile/run successfully
+        - [ ] Mermaid diagrams render correctly
+        - [ ] OpenAPI specs validate
+        - Note: Most context updates don't require automated tests
+
+  - type: textarea
+    id: manual_tests
+    attributes:
+      label: Manual/E2E Tests (for documentation review)
+      description: How will this documentation be manually verified?
+      placeholder: |
+        - [ ] Technical accuracy review by subject matter expert
+        - [ ] Clarity review - can new team member understand it?
+        - [ ] Cross-reference verification with related docs
+        - [ ] Example code tested in actual environment
+        - [ ] Diagrams accurately reflect current architecture
+        - [ ] AI prompt tested (if documenting prompt library)
+
+  - type: textarea
+    id: ai_instructions
+    attributes:
+      label: AI Generation Instructions
+      description: Guidance for AI-assisted documentation creation (optional)
+      placeholder: |
+        **Claude Code guidance:**
+        - Reference existing documentation patterns in infiquetra-blueprint
+        - Generate mermaid diagrams for architecture/flow visualization
+        - Cross-reference related specifications and ADRs
+        - Maintain consistent terminology across documents
+        - Test code examples in actual environment before documenting
+
+        **AI Tooling Resources:**
+        - Plugins: https://github.com/infiquetra/infiquetra-claude-plugins
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ### Documentation Best Practices
+
+        **Good Documentation for AI**:
+        - Specific examples and code snippets
+        - Clear success criteria
+        - Anti-patterns documented
+        - Links to related context
+        - Diagrams where helpful
+
+        **What Makes Bad Documentation**:
+        - Vague descriptions
+        - No examples
+        - Outdated information
+        - Broken links
+        - Missing context
+
+        ### Where to Document
+
+        | Content Type | Location |
+        |--------------|----------|
+        | Business Requirements | `blueprint/requirements/` |
+        | Technical Specifications | `blueprint/specifications/` |
+        | Architecture Decisions | `blueprint/architecture/decisions/` |
+        | Reusable Patterns | `blueprint/patterns/` |
+        | API Contracts | `blueprint/specifications/api/` |
+        | Data Models | `blueprint/specifications/models/` |
+        | AI Prompts | `blueprint/ai-prompts/` |
+        | Integration Guides | `blueprint/integration/` |
+
+        ### Next Steps
+
+        1. Issue created in Blueprint repository until team identifies it for milestone
+        2. Moved to **Ready** when team prioritizes during milestone planning
+        3. Pull to **In Development** when you have capacity
+           - Make changes in infiquetra-blueprint repository
+           - Create PR linking to this issue
+           - Get review from tech lead
+        4. **Deployment Ready** -> Merge and close issue
+        5. Context immediately available for future work
+
+        **Note**: Context Updates can be paired with Capabilities - document as you build!
+        **Note**: Context Updates typically skip E2E Testing (documentation doesn't deploy)
+
+        See the [Kanban Workflow Guide](https://github.com/infiquetra/infiquetra-sdlc/blob/main/docs/process/kanban-workflow.md) for complete process.

--- a/.github/ISSUE_TEMPLATE/defect.yml
+++ b/.github/ISSUE_TEMPLATE/defect.yml
@@ -1,0 +1,110 @@
+name: Defect
+description: Bug or broken functionality for a hermes agent to fix
+title: "[DEFECT] "
+labels: ["defect", "hermes-task", "needs-plan"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Defect
+        Broken functionality. The hermes orchestrator plans the fix and
+        dispatches to an agent when this card moves to "Ready" on the
+        board. All required fields below must be filled before planning
+        starts.
+
+  - type: input
+    id: objective
+    attributes:
+      label: Objective
+      description: One sentence stating what the fix delivers.
+      placeholder: "Make the ansible@pam API token creation in proxmox_base idempotent"
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Testable checklist. Each item is something the reviewer will verify the plan addresses.
+      placeholder: |
+        - [ ] Re-running the role on a provisioned host reports `ok`, not `changed`, for the token task
+        - [ ] Running on a fresh host still creates the token
+        - [ ] Existing role tests pass
+      value: "- [ ] "
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Out-of-scope / non-goals
+      description: |
+        Explicit list of things the agent MUST NOT do. If there are no non-goals,
+        write "None" rather than leaving blank — the reviewer uses this list to
+        reject scope-creep critiques.
+      placeholder: |
+        - Do NOT refactor how the token is stored in the vault
+        - Do NOT change the token's permission scope
+        - Do NOT add new test files beyond the idempotency check
+      value: "- "
+    validations:
+      required: true
+
+  - type: textarea
+    id: files_expected
+    attributes:
+      label: Files expected to change
+      description: Path list, one per line. Planner verifies each parent directory exists.
+      placeholder: |
+        ansible/roles/proxmox_base/tasks/setup.yml
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests_required
+    attributes:
+      label: Tests to add or update
+      description: File path + test function name, OR "No new tests required" with a one-line rationale.
+      placeholder: |
+        No new automated tests required. Manual verification via second-run idempotency check (see Verification).
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Exact commands the agent runs to prove success. Shell code block.
+      placeholder: |
+        cd ansible
+        ansible-playbook -i inventory/hosts.yml proxmox_cluster.yml \
+          --tags proxmox_base --limit r420 \
+          --vault-password-file ~/.vault_pass.txt --check
+        # Second run: token task reports 'ok', not 'changed'
+      render: bash
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / conventions
+      description: Free-form. Pattern-to-follow hints, constraints, or context about why the card exists.
+      placeholder: |
+        - Use the `when:`-guard idempotency pattern from the repo-disable task
+        - Query tokens via `pveum user token list ansible@pam --output-format json`
+    validations:
+      required: false
+
+  - type: textarea
+    id: context_library_links
+    attributes:
+      label: Context library links
+      description: |
+        Deep-links into the project's long-running context-library repo
+        (requirements, specifications, ADRs, discovery docs). Optional.
+      placeholder: |
+        - Requirements: https://github.com/infiquetra/campps-blueprint/blob/main/requirements/auth.md#section-3
+        - ADR: https://github.com/infiquetra/campps-blueprint/blob/main/architecture/decisions/002-session-tokens.md
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,109 @@
+name: Enhancement
+description: Improvement to existing functionality for a hermes agent to implement
+title: "[ENHANCEMENT] "
+labels: ["enhancement", "hermes-task", "needs-plan"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Enhancement
+        An improvement to existing capability — refinement, optimization,
+        or incremental addition (typically 2-5 days of agent work). The
+        hermes orchestrator plans the change and dispatches to an agent
+        when this card moves to "Ready" on the board. All required fields
+        below must be filled before planning starts.
+
+  - type: input
+    id: objective
+    attributes:
+      label: Objective
+      description: One sentence stating what the enhancement delivers.
+      placeholder: "Add structured AC telemetry to plan_reviewer JSON output"
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Testable checklist. Each item is something the reviewer will verify the plan addresses.
+      placeholder: |
+        - [ ] Reviewer JSON includes `ac_coverage` object keyed by AC number
+        - [ ] Orchestrator persists `ac_coverage` to SQLite `plan_round_reviews`
+        - [ ] Existing plan-review tests still pass
+      value: "- [ ] "
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Out-of-scope / non-goals
+      description: |
+        Explicit list of things the agent MUST NOT do. If there are no non-goals,
+        write "None" rather than leaving blank — the reviewer uses this list to
+        reject scope-creep critiques.
+      placeholder: |
+        - Do NOT change the overall PROCEED/REVISE/BLOCK contract
+        - Do NOT add new reviewer rubrics
+        - Do NOT refactor the prompt-rendering pipeline
+      value: "- "
+    validations:
+      required: true
+
+  - type: textarea
+    id: files_expected
+    attributes:
+      label: Files expected to change
+      description: Path list, one per line. Planner verifies each parent directory exists.
+      placeholder: |
+        ansible/roles/hermes_orchestrator/files/prompts/plan_reviewer.md
+        ansible/roles/hermes_orchestrator/files/handlers.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests_required
+    attributes:
+      label: Tests to add or update
+      description: File path + test function name, OR "No new tests required" with a one-line rationale.
+      placeholder: |
+        tests/test_handlers.py::test_plan_review_persists_ac_coverage
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Exact commands the agent runs to prove success. Shell code block.
+      placeholder: |
+        cd ansible/roles/hermes_orchestrator/files
+        pytest tests/test_handlers.py -v
+        # New test passes; no existing tests regress
+      render: bash
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / conventions
+      description: Free-form. Pattern-to-follow hints, constraints, or context about why the card exists.
+      placeholder: |
+        - Follow the existing `_SafeMap`-based JSON-loading pattern
+        - AC numbering matches the card's acceptance_criteria order (1-indexed)
+    validations:
+      required: false
+
+  - type: textarea
+    id: context_library_links
+    attributes:
+      label: Context library links
+      description: |
+        Deep-links into the project's long-running context-library repo
+        (requirements, specifications, ADRs, discovery docs). Optional.
+      placeholder: |
+        - Design: ~/.claude/plans/as-i-understand-it-gentle-lamport.md
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/exploration.yml
+++ b/.github/ISSUE_TEMPLATE/exploration.yml
@@ -1,0 +1,243 @@
+name: Exploration
+description: Research, POC, or architectural investigation (1-3 days)
+title: "[EXPLORATION] "
+labels: ["exploration", "research", "hermes-not-actionable"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Exploration Issue
+        An Exploration is research, proof-of-concept, or architectural investigation that informs decisions.
+        It produces knowledge and recommendations, not production code.
+        **Timebox**: 1-3 days maximum
+
+  - type: textarea
+    id: research_question
+    attributes:
+      label: Research Question
+      description: What do we need to learn?
+      placeholder: "Which authentication SDK should we use: Auth0 vs. Clerk vs. Supabase Auth?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why do we need to know this?
+      placeholder: |
+        - Related Capability: #234 (Implement authentication)
+        - Decision to Inform: Which SDK to integrate
+        - Business Driver: Need to choose vendor by end of week
+        - Current State: No authentication implemented
+        - Requirement: OAuth2 compliance, multi-tenant support
+    validations:
+      required: true
+
+  - type: textarea
+    id: success_criteria
+    attributes:
+      label: Success Criteria
+      description: What will make this exploration successful?
+      placeholder: |
+        - [ ] All options evaluated against criteria
+        - [ ] Options documented with pros/cons
+        - [ ] Clear recommendation made with rationale
+        - [ ] Cost comparison completed
+        - [ ] Prototype validates feasibility (if needed)
+        - [ ] Decision documented in ADR
+    validations:
+      required: true
+
+  - type: dropdown
+    id: timebox
+    attributes:
+      label: Timebox
+      description: Maximum time to spend on this exploration
+      options:
+        - "1 day"
+        - "2 days"
+        - "3 days"
+    validations:
+      required: true
+
+  - type: textarea
+    id: evaluation_criteria
+    attributes:
+      label: Evaluation Criteria
+      description: What criteria will you use to evaluate options?
+      placeholder: |
+        1. **Technical Fit**
+           - SDK quality and developer experience
+           - API simplicity
+           - Documentation quality
+
+        2. **Compliance**
+           - OAuth2/OIDC certified
+           - SOC2 compliant
+           - Audit trail available
+
+        3. **Cost**
+           - Per-user cost
+           - Monthly minimum
+           - Volume discounts
+
+        4. **Integration Effort**
+           - Estimated time to integrate
+           - Code examples available
+           - Support quality
+
+        5. **Performance**
+           - Auth latency
+           - Uptime SLA
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables
+      description: What will you produce from this exploration?
+      placeholder: |
+        - [ ] Comparison document in infiquetra-blueprint/explorations/
+        - [ ] Recommendation for path forward
+        - [ ] Prototype code (if applicable) - throw-away quality
+        - [ ] Cost analysis
+        - [ ] ADR (Architecture Decision Record) if decision made
+        - [ ] Update related Capability with findings
+    validations:
+      required: true
+
+  - type: textarea
+    id: questions_to_answer
+    attributes:
+      label: Key Questions to Answer
+      description: Specific questions to investigate
+      placeholder: |
+        1. Which SDK has the best developer experience?
+        2. Can all options achieve <500ms auth latency?
+        3. What is the total cost per 10,000 users?
+        4. Which has the fastest integration path?
+        5. Are there any deal-breaker limitations?
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Investigation Approach
+      description: How will you conduct this exploration?
+      placeholder: |
+        **Day 1**: Research and Documentation Review
+        - Review all vendor docs
+        - Review case studies and customer reviews
+        - Compare feature matrices
+        - Initial cost analysis
+
+        **Day 2**: Hands-On Evaluation
+        - Create trial accounts for all options
+        - Build simple prototype with each SDK
+        - Test auth flow
+        - Measure performance
+
+        **Day 3**: Analysis and Decision
+        - Complete comparison matrix
+        - Draft recommendation
+        - Write ADR
+        - Present to team for feedback
+
+  - type: input
+    id: parent_objective
+    attributes:
+      label: Parent Objective (optional)
+      description: If this exploration informs a larger Objective/Milestone
+      placeholder: "objective:mvp-launch"
+
+  - type: input
+    id: parent_initiative
+    attributes:
+      label: Parent Initiative (optional)
+      description: Strategic initiative this exploration supports
+      placeholder: "initiative:platform-launch"
+
+  - type: textarea
+    id: automated_tests
+    attributes:
+      label: Automated Tests (for POC validation)
+      description: What tests validate the POC or prototype? (if applicable)
+      placeholder: |
+        - [ ] Basic functional tests for prototype code
+        - [ ] Performance benchmarks for comparison
+        - [ ] Integration tests for feasibility validation
+        - Note: Prototype code is throwaway quality
+
+  - type: textarea
+    id: manual_tests
+    attributes:
+      label: Manual/E2E Tests (for POC evaluation)
+      description: How will you manually evaluate the options? (if applicable)
+      placeholder: |
+        - [ ] Manual testing of each SDK/option
+        - [ ] User experience evaluation
+        - [ ] Performance testing under different conditions
+        - [ ] Edge case exploration
+
+  - type: textarea
+    id: ai_instructions
+    attributes:
+      label: AI Generation Instructions
+      description: Guidance for AI-assisted research (optional)
+      placeholder: |
+        **Claude Code guidance:**
+        - Research similar patterns in infiquetra-blueprint
+        - Generate comparison matrices and evaluation frameworks
+        - Create prototype code for evaluation (throwaway quality)
+        - Document findings in structured format
+
+        **AI Tooling Resources:**
+        - Plugins: https://github.com/infiquetra/infiquetra-claude-plugins
+
+  - type: textarea
+    id: related_work
+    attributes:
+      label: Related Issues
+      description: Links to related capabilities or context
+      placeholder: |
+        - Will inform: Capability #234 (Implement authentication)
+        - Context: https://github.com/infiquetra/infiquetra-blueprint/blob/main/requirements/authentication.md
+        - Previous exploration: #189 (Authentication methods evaluation)
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ### Next Steps
+
+        1. Team identifies exploration need during milestone planning
+        2. Move to **Ready** when prioritized
+        3. Pull to **In Development** when ready to start research
+        4. **Timebox is strict** - don't exceed the limit
+        5. Document findings in `infiquetra-blueprint/explorations/`
+        6. Create follow-up Capability or Enhancement based on recommendation
+        7. Close this Exploration once findings are documented
+
+        **Note**: Explorations typically skip E2E Testing column (research doesn't deploy)
+
+        ### Possible Outcomes
+
+        **Option 1: Clear Recommendation**
+        - Document findings in Blueprint
+        - Create ADR if architectural decision
+        - Create Capability or Enhancement to implement
+        - Close Exploration
+
+        **Option 2: Need More Research**
+        - Document what was learned
+        - Create follow-up Exploration with refined questions
+        - Close this Exploration
+
+        **Option 3: Not Feasible**
+        - Document why approach won't work
+        - Propose alternative approaches
+        - Close Exploration
+        - Inform stakeholders
+
+        See the [Kanban Workflow Guide](https://github.com/infiquetra/infiquetra-sdlc/blob/main/docs/process/kanban-workflow.md) for complete process.

--- a/.github/ISSUE_TEMPLATE/objective.yml
+++ b/.github/ISSUE_TEMPLATE/objective.yml
@@ -1,0 +1,239 @@
+name: Objective
+description: Time-bounded deliverable set (Pilots, MVPs, Releases)
+title: "[OBJECTIVE] "
+labels: ["objective", "hermes-not-actionable"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Objective Issue Template
+
+        An **Objective** coordinates multiple Capabilities toward a common goal with a specific target date. Use for Pilots, MVPs, Releases, and Program milestones.
+
+        **Resources**:
+        - [Work Hierarchy Guide](https://github.com/infiquetra/infiquetra-sdlc/blob/main/docs/process/work-hierarchy.md)
+        - [Quarterly Planning Guide](https://github.com/infiquetra/infiquetra-sdlc/blob/main/docs/process/quarterly-planning.md)
+        - [Issue Types Guide](https://github.com/infiquetra/infiquetra-sdlc/blob/main/docs/process/issue-types.md)
+
+  - type: input
+    id: objective_name
+    attributes:
+      label: Objective Name
+      description: Clear, descriptive name for this Objective
+      placeholder: "Platform MVP Launch"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: objective_type
+    attributes:
+      label: Objective Type
+      description: Select the type of Objective
+      options:
+        - "Pilot (customer validation)"
+        - "MVP (minimum viable product)"
+        - "Release (versioned delivery)"
+        - "Program (OKR/initiative milestone)"
+    validations:
+      required: true
+
+  - type: input
+    id: target_date
+    attributes:
+      label: Target Date
+      description: Target completion date (YYYY-MM-DD)
+      placeholder: "2025-03-15"
+    validations:
+      required: true
+
+  - type: input
+    id: initiative
+    attributes:
+      label: Parent Initiative (optional)
+      description: Strategic initiative this Objective belongs to
+      placeholder: "initiative:platform-launch"
+
+  - type: textarea
+    id: success_criteria
+    attributes:
+      label: Success Criteria
+      description: What must be true for this Objective to be considered complete?
+      placeholder: |
+        - [ ] 5 pilot users onboarded and trained
+        - [ ] Complete core flow operational
+        - [ ] Operations team has dashboard visibility
+        - [ ] No critical defects during pilot period
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Product Manager: Outcome Measurement
+
+        Define measurable outcomes (not outputs). Create Outcome Scorecard in `infiquetra-blueprint/metrics/outcomes/[objective-name]-scorecard.md`
+
+  - type: textarea
+    id: outcome_metrics
+    attributes:
+      label: Outcome Metrics (PM)
+      description: Define leading and lagging indicators to measure success
+      placeholder: |
+        **Leading Indicators** (predict success):
+        - User engagement rate: Baseline 0%, Target 80% active use
+        - Time to complete core flow: Baseline N/A, Target <5 minutes
+
+        **Lagging Indicators** (confirm success):
+        - Pilot completion rate: Target 100% (5/5 users complete pilot)
+        - Customer satisfaction: Target >4/5 rating
+
+        **Measurement Approach**: Weekly surveys + system analytics
+
+  - type: textarea
+    id: included_capabilities
+    attributes:
+      label: Included Capabilities
+      description: List capabilities that will be created/grouped under this Objective
+      placeholder: |
+        - [ ] Auth Service (to be created)
+        - [ ] Core API (to be created)
+        - [ ] Operations Dashboard MVP (to be created)
+        - [ ] Onboarding Flow (to be created)
+      value: |
+        - [ ]
+
+  - type: textarea
+    id: business_value
+    attributes:
+      label: Business Value
+      description: Why does this Objective matter to customers or the business?
+      placeholder: |
+        Enables first customer pilot of the platform, validating core functionality with real users before broader rollout.
+
+  - type: textarea
+    id: stakeholders
+    attributes:
+      label: Stakeholders
+      description: Who are the key stakeholders for this Objective?
+      placeholder: |
+        - Business Owner: [Name]
+        - Tech Lead: [Name]
+        - External: [Customer/Partner contacts]
+      value: |
+        - Business Owner:
+        - Tech Lead:
+        - External:
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Quality Engineer: Risk Assessment
+
+        Assess quality risks for this Objective. Define test strategy for high-risk Capabilities.
+
+  - type: dropdown
+    id: risk_level
+    attributes:
+      label: Overall Risk Level (QE)
+      description: Quality and delivery risk assessment
+      options:
+        - "Low"
+        - "Medium"
+        - "High"
+        - "Critical"
+    validations:
+      required: true
+
+  - type: textarea
+    id: quality_risks
+    attributes:
+      label: Quality Risks (QE)
+      description: What quality risks exist for this Objective?
+      placeholder: |
+        **Technical Complexity**: High - New third-party integrations, unfamiliar APIs
+        **Integration Points**: 3 external services, 2 internal dependencies
+        **Security/Compliance**: Medium - PII handling requires extra validation
+        **Test Environment Needs**: Staging environment with test accounts
+        **Performance Concerns**: Load testing required for 100+ concurrent users
+
+  - type: textarea
+    id: test_strategy
+    attributes:
+      label: Test Strategy Overview (QE)
+      description: High-level testing approach for this Objective
+      placeholder: |
+        - Unit tests: 90%+ coverage for all new services
+        - Integration tests: Focus on third-party API integrations
+        - E2E tests: Complete user flow scenarios
+        - Performance tests: Load test with 200 concurrent users
+        - Security tests: Penetration testing for PII handling
+        - Special considerations: Coordinate with SRE for test environment
+
+  - type: textarea
+    id: learning_plan
+    attributes:
+      label: Learning Plan (PM)
+      description: How will we validate assumptions and measure learning throughout this Objective?
+      placeholder: |
+        **Hypotheses to Test**:
+        - H1: Users will complete core flow in <5 minutes
+        - H2: Operations team needs real-time dashboard
+
+        **Learning Milestones**:
+        - Week 2: First user interview after using MVP
+        - Week 4: Mid-pilot retrospective with all users
+        - Week 6: Operations team feedback session
+
+        **Success Metrics** (from Outcome Scorecard):
+        - Leading: User engagement rate, flow completion time
+        - Lagging: Pilot completion rate, customer satisfaction
+
+        **Pivot Triggers**:
+        - If engagement <50% by Week 3 -> Interview users, investigate friction
+        - If completion time >8min by Week 4 -> Simplify flow or add training
+
+  - type: textarea
+    id: risk_description
+    attributes:
+      label: Delivery Risks (All)
+      description: What could prevent achieving the target date?
+      placeholder: |
+        - Dependency on external contact list (Medium risk, 2-week delay possible)
+        - New integration with third-party API (Low risk, well-documented)
+        - Team capacity during holiday season (Low risk, planned around)
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: External dependencies or prerequisites
+      placeholder: |
+        - External: User contact list from business team
+        - Infrastructure: Staging environment ready
+        - Other: Training materials created
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        ## Next Steps After Creation
+
+        1. **Create GitHub Milestone** with the same name and target date
+        2. **Apply labels** to this issue: `objective:{short-name}` and parent Initiative label
+        3. **Create Capabilities** for this Objective (just-in-time, 2-3 weeks before work starts)
+        4. **Link Capabilities** to this Objective's milestone
+        5. **Track progress** via milestone completion percentage
+
+        ## AI Tooling
+
+        **Claude Code Resources**:
+        - [Infiquetra Claude Plugins](https://github.com/infiquetra/infiquetra-claude-plugins) - Claude Code plugins for automation
+
+        **Mount Olympus Agents**:
+        - **Hermes**: Task routing and coordination
+        - **Zeus**: Strategic scoping and prioritization
+        - **Athena**: Architecture review and design
+        - **Apollo**: Quality assurance and testing


### PR DESCRIPTION
## PR 1 of 9 (mimir propagation): hermes-ready issue templates

Part of the 9-PR planning-phase refinement sequence from
`/Users/jefcox/.claude/plans/as-i-understand-it-gentle-lamport.md`.

This is the mimir propagation of
[infiquetra/infiquetra-sdlc#4](https://github.com/infiquetra/infiquetra-sdlc/pull/4)
(already merged). 6 YAML files copied verbatim from infiquetra-sdlc@main.

## Summary

- Adds 6 templates to `.github/ISSUE_TEMPLATE/`: `defect.yml`,
  `enhancement.yml`, `capability.yml`, `objective.yml`, `exploration.yml`,
  `context-update.yml`
- `defect/enhancement/capability` use the 8-field hermes-task contract
  with `hermes-task` + `needs-plan` labels
- `objective/exploration/context-update` carry `hermes-not-actionable`
- Legacy `bug_report.md` and `feature_request.md` left in place — they
  can be retired in a follow-on pass once the hermes pipeline is validated
  for mimir's repo

**Note:** mimir's default branch in repo settings is `develop`; this PR
targets `main` per the team-lead instruction that all 9 plan PRs land on
each repo's `main`.

## Test plan

- [ ] After merge, open Issues → New issue page; confirm 6 hermes
      templates render alongside the 2 legacy templates
- [ ] File a test Defect issue, confirm `hermes-task` + `needs-plan`
      labels are auto-applied