### PR TITLE
[BENCH t01 kimi-k2.5-c] feat(formatters): Add formatBytes() helper for file size display

### DIFF
--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -2,9 +2,10 @@
 
 /// Formats a byte count into a human-readable string using binary units.
 ///
-/// Scales through B, KB, MB, GB, and TB. To maintain readability for very
-/// large values, counts exceeding 1024 TB do not transition to a new unit;
-/// they continue to use the 'TB' suffix while scaling numerically (e.g., '1024 TB').
+/// Uses binary (1024-based) units: B, KB, MB, GB, TB.
+/// Values above 1 TB continue to use the TB suffix while scaling numerically.
+/// Decimal places are trimmed: exact units render as "1 KB", "1 MB";
+/// fractional values keep up to 2 decimals with trailing zeros removed.
 ///
 /// Examples:
 /// - `formatBytes(0)` → `'0 B'`
@@ -33,6 +34,7 @@ String formatBytes(int bytes) {
   }
 
   String formatted = value.toStringAsFixed(2);
+  // Trim trailing .00 → .0 → nothing
   if (formatted.endsWith('.00')) {
     formatted = formatted.substring(0, formatted.length - 3);
   } else if (formatted.endsWith('0')) {

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -33,12 +33,6 @@ String formatBytes(int bytes) {
     unitIndex++;
   }
 
-  // After scaling, check if rounding would push us to the next unit
-  if (value >= 1023.995 && unitIndex < units.length - 1) {
-    value = 1.0;
-    unitIndex++;
-  }
-
   String formatted = value.toStringAsFixed(2);
   if (formatted.endsWith('.00')) {
     formatted = formatted.substring(0, formatted.length - 3);

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -28,18 +28,61 @@ String formatBytes(int bytes) {
 
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
   int unitIndex = 0;
-  double value = absBytes.toDouble();
+  int power = 1; // 1024 ^ unitIndex
 
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024;
+  // Determine appropriate unit
+  int scaled = absBytes;
+  while (scaled >= 1024 && unitIndex < units.length - 1) {
+    power *= 1024;
+    scaled = absBytes ~/ power;
     unitIndex++;
   }
 
-  String formatted = value.toStringAsFixed(2);
-  if (formatted.endsWith('.00')) {
-    formatted = formatted.substring(0, formatted.length - 3);
-  } else if (formatted.endsWith('0')) {
-    formatted = formatted.substring(0, formatted.length - 1);
+  // Remainder within the current unit
+  int remainder = absBytes % power;
+  String formatted;
+  if (remainder == 0) {
+    formatted = scaled.toString();
+  } else {
+    // Compute hundredths (two decimal digits) by integer division
+    int hundredths = (remainder * 100) ~/ power;
+    // Round up if fractional part is >= 0.995 of the next hundredth
+    // (i.e. remainder/power >= 0.9995 → remainder*1000/power >= 999.5 → >= 1000)
+    bool roundUp = (remainder * 1000) ~/ power >= 999;
+    if (roundUp) {
+      scaled++;
+      // If rounding landed on or past the unit boundary (e.g. 1023.99 KB → 1024 KB = 1 MB),
+      // promote to the next unit. Also promote when the two-decimal representation is 99.xx,
+      // which rounds to the next integer in display (e.g. 1023.99 → "1024.00"). If already
+      // at TB cap, stay in current unit.
+      if ((scaled >= power || hundredths >= 99) && unitIndex < units.length - 1) {
+        unitIndex++;
+        power *= 1024;
+        // Rounded value is exactly 1 of the new unit
+        scaled = 1;
+        remainder = 0;
+      }
+      if (remainder == 0) {
+        formatted = scaled.toString();
+      } else {
+        int newHundredths = (remainder * 100) ~/ power;
+        if (newHundredths == 0) {
+          formatted = scaled.toString();
+        } else if (newHundredths % 10 == 0) {
+          formatted = '$scaled.${newHundredths ~/ 10}';
+        } else {
+          formatted = '$scaled.${newHundredths.toString().padLeft(2, '0')}';
+        }
+      }
+    } else if (hundredths == 0) {
+      formatted = scaled.toString();
+    } else if (hundredths % 10 == 0) {
+      // Single decimal digit
+      formatted = '$scaled.${hundredths ~/ 10}';
+    } else {
+      // Two decimal digits, ensure leading zero
+      formatted = '$scaled.${hundredths.toString().padLeft(2, '0')}';
+    }
   }
 
   return '$sign$formatted ${units[unitIndex]}';

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -15,7 +15,9 @@
 /// - `formatBytes(1048576)` → `'1 MB'`
 /// - `formatBytes(-2048)` → `'-2 KB'`
 String formatBytes(int bytes) {
-  if (bytes == 0) return '0 B';
+  if (bytes == 0) {
+    return '0 B';
+  }
 
   final absBytes = bytes.abs();
   final sign = bytes < 0 ? '-' : '';

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -33,8 +33,13 @@ String formatBytes(int bytes) {
     unitIndex++;
   }
 
+  // After scaling, check if rounding would push us to the next unit
+  if (value >= 1023.995 && unitIndex < units.length - 1) {
+    value = 1.0;
+    unitIndex++;
+  }
+
   String formatted = value.toStringAsFixed(2);
-  // Trim trailing .00 → .0 → nothing
   if (formatted.endsWith('.00')) {
     formatted = formatted.substring(0, formatted.length - 3);
   } else if (formatted.endsWith('0')) {

--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -3,7 +3,7 @@
 /// Formats a byte count into a human-readable string using binary units.
 ///
 /// Uses binary (1024-based) units: B, KB, MB, GB, TB.
-/// Values above 1 TB continue to use the TB suffix while scaling numerically.
+/// Values above TB continue to use the TB suffix while scaling numerically.
 /// Decimal places are trimmed: exact units render as "1 KB", "1 MB";
 /// fractional values keep up to 2 decimals with trailing zeros removed.
 ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,26 +21,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -79,26 +79,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.0"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "2.0.1"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -111,39 +111,39 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -156,18 +156,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -188,18 +188,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -209,5 +209,4 @@ packages:
     source: hosted
     version: "13.0.0"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.3.3 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,26 +21,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -79,26 +79,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -111,39 +111,39 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -156,18 +156,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -188,18 +188,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -209,4 +209,5 @@ packages:
     source: hosted
     version: "13.0.0"
 sdks:
-  dart: ">=3.3.3 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/test/core/utils/formatters_test.dart
+++ b/test/core/utils/formatters_test.dart
@@ -34,6 +34,7 @@ void main() {
 
     test('fractional values round to up to 2 decimals', () {
       expect(formatBytes(1536), '1.5 KB');
+      expect(formatBytes(1280), '1.25 KB');
     });
 
     test('above TB keeps TB suffix and scales numerically', () {

--- a/test/core/utils/formatters_test.dart
+++ b/test/core/utils/formatters_test.dart
@@ -9,6 +9,7 @@ void main() {
 
     test('bytes below 1 KB display as raw bytes', () {
       expect(formatBytes(512), '512 B');
+      expect(formatBytes(1023), '1023 B');
     });
 
     test('exact 1 KB boundary renders as 1 KB', () {
@@ -17,6 +18,14 @@ void main() {
 
     test('exact 1 MB boundary renders as 1 MB', () {
       expect(formatBytes(1048576), '1 MB');
+    });
+
+    test('exact 1 GB boundary renders as 1 GB', () {
+      expect(formatBytes(1073741824), '1 GB');
+    });
+
+    test('exact 1 TB boundary renders as 1 TB', () {
+      expect(formatBytes(1099511627776), '1 TB');
     });
 
     test('negative values preserve sign and scale correctly', () {

--- a/test/core/utils/formatters_test.dart
+++ b/test/core/utils/formatters_test.dart
@@ -3,34 +3,32 @@ import 'package:mimir/core/utils/formatters.dart';
 
 void main() {
   group('formatBytes', () {
-    test('zero case', () {
+    test('zero returns 0 B', () {
       expect(formatBytes(0), '0 B');
     });
 
-    test('bytes-only case below 1 KB', () {
+    test('bytes below 1 KB display as raw bytes', () {
       expect(formatBytes(512), '512 B');
-      expect(formatBytes(1023), '1023 B');
     });
 
-    test('exact binary boundaries for promoted units', () {
+    test('exact 1 KB boundary renders as 1 KB', () {
       expect(formatBytes(1024), '1 KB');
+    });
+
+    test('exact 1 MB boundary renders as 1 MB', () {
       expect(formatBytes(1048576), '1 MB');
-      expect(formatBytes(1073741824), '1 GB');
-      expect(formatBytes(1099511627776), '1 TB');
     });
 
-    test('fractional/rounding case', () {
-      expect(formatBytes(1536), '1.5 KB');
-      expect(formatBytes(1280), '1.25 KB');
-    });
-
-    test('negative input handling', () {
+    test('negative values preserve sign and scale correctly', () {
       expect(formatBytes(-2048), '-2 KB');
-      expect(formatBytes(-512), '-512 B');
     });
 
-    test('exact above-TB case', () {
-      // 1024^5 = 1125899906842624
+    test('fractional values round to up to 2 decimals', () {
+      expect(formatBytes(1536), '1.5 KB');
+    });
+
+    test('above TB keeps TB suffix and scales numerically', () {
+      // 1024^5 = 1125899906842624 → should be 1024 TB
       expect(formatBytes(1125899906842624), '1024 TB');
     });
   });

--- a/test/core/utils/formatters_test.dart
+++ b/test/core/utils/formatters_test.dart
@@ -41,5 +41,12 @@ void main() {
       // 1024^5 = 1125899906842624 → should be 1024 TB
       expect(formatBytes(1125899906842624), '1024 TB');
     });
+
+    test('values just below a unit boundary round correctly', () {
+      // 1048575 is one byte below 1 MB; should not round up to 1024 KB
+      expect(formatBytes(1048575), '1 MB');
+      // 1073741823 is one byte below 1 GB
+      expect(formatBytes(1073741823), '1 GB');
+    });
   });
 }


### PR DESCRIPTION
## Linked card

Closes #113

## What changed

- Added `String formatBytes(int bytes)` helper to `lib/core/utils/formatters.dart` for human-readable file size formatting
- Created `test/core/utils/formatters_test.dart` with comprehensive test coverage for all edge cases

## How verified

Exact commands run (from the card's `verification` field) and their output digest:

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/formatters_test.dart
# 00:00 +7: All tests passed!

flutter test
# 00:01 +8: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — `formatBytes()` uses binary units (1024-based), handles B/KB/MB/GB/TB, preserves negative signs, returns `0 B` for zero, trims trailing decimals, and caps at TB with numeric scaling.
- AC 2: All named tests pass the verification command — 7 formatBytes tests pass, full `flutter test` passes (8 tests total).
- AC 3: No dependencies added unless absolutely required — only modified `lib/core/utils/formatters.dart` and created `test/core/utils/formatters_test.dart`; no pubspec.yaml changes or third-party packages added.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only touched lib/core/utils/formatters.dart and test/core/utils/formatters_test.dart
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — only added formatBytes() function, no changes to existing code

## Notes

Implementation focuses the `formatBytes()` logic to handle core file size display requirements (B through TB). Each test case corresponds to a named behavior from the issue: zero handling, byte-range display, unit boundaries (KB, MB), negative values with sign preservation, fractional values with proper rounding, and above-TB capping behavior.