### PR TITLE
[BENCH t01 minimax-m2.7-c] feat(formatters): Add formatBytes() helper for file size display

### DIFF
--- a/lib/core/utils/formatters.dart
+++ b/lib/core/utils/formatters.dart
@@ -5,6 +5,8 @@
 /// Scales through B, KB, MB, GB, and TB. To maintain readability for very
 /// large values, counts exceeding 1024 TB do not transition to a new unit;
 /// they continue to use the 'TB' suffix while scaling numerically (e.g., '1024 TB').
+/// For values above 1 TB, the function stops dividing once it reaches TB and 
+/// expresses larger magnitudes numerically (e.g. 1 PB = 1024 TB, not 1 TB).
 ///
 /// Examples:
 /// - `formatBytes(0)` → `'0 B'`


### PR DESCRIPTION
## Linked card

Closes #118

## What changed

- Enhanced documentation for `formatBytes()` to clarify behavior for values above 1 TB
- Added explanation that values above 1 TB are expressed numerically with the TB suffix (e.g., "1024 TB") rather than collapsing to "1 TB"

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/formatters_test.dart
# Output: 00:00 +6: All tests passed!
flutter test
# Output: 00:00 +7: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body - verified through existing comprehensive test suite covering all specified behaviors
- AC 2: All named tests pass the verification command - verified with both targeted and full test suite runs
- AC 3: No dependencies added unless absolutely required - no new dependencies needed

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: only modified `lib/core/utils/formatters.dart` 
- Do NOT add third-party dependencies unless required by the task body: no dependencies added
- Do NOT refactor unrelated code in the touched files: only added documentation clarification

## Notes

The core implementation of `formatBytes()` was already present and functioning correctly, having been previously implemented to match all requirements specified in the issue. The primary contribution in this PR is enhanced documentation clarity regarding the behavior for values above 1 TB, ensuring the intent is explicitly clear to future maintainers.