### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,33 @@
+/// Extension methods for List operations.
+library list_extensions;
+
+/// Extension that adds utility methods to Lists.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Example:
+  /// ```dart
+  /// [1,2,3,4,5].chunked(2) // [[1,2],[3,4],[5]]
+  /// [1,2,3].chunked(10)    // [[1,2,3]]
+  /// [].chunked(3)          // []
+  /// [1].chunked(1)         // [[1]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'Must be greater than or equal to 1');
+    }
+
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final List<List<T>> chunks = <List<T>>[];
+    for (int i = 0; i < length; i += size) {
+      final int end = (i + size < length) ? i + size : length;
+      chunks.add(sublist(i, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      final List<int> list = [1, 2, 3, 4, 5];
+      final List<List<int>> result = list.chunked(2);
+      expect(result, [
+        [1, 2],
+        [3, 4],
+        [5]
+      ]);
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      final List<int> list = [1, 2, 3];
+      final List<List<int>> result = list.chunked(3);
+      expect(result, [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      final List<int> list = [1, 2, 3];
+      final List<List<int>> result = list.chunked(10);
+      expect(result, [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      final List<int> list = <int>[];
+      final List<List<int>> result = list.chunked(3);
+      expect(result, <List<int>>[]);
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      final List<int> list = [1];
+      final List<List<int>> result = list.chunked(1);
+      expect(result, [
+        [1]
+      ]);
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      final List<int> list = [1, 2, 3];
+      expect(() => list.chunked(0), throwsArgumentError);
+    });
+
+    test('chunked throws ArgumentError when size is negative', () {
+      final List<int> list = [1, 2, 3];
+      expect(() => list.chunked(-1), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final List<int> list = [1, 2, 3, 4];
+      final List<List<int>> result = list.chunked(2);
+      
+      // Mutate one of the chunks
+      result[0][0] = 99;
+      
+      // Original list should remain unchanged
+      expect(list, [1, 2, 3, 4]);
+      
+      // The result should reflect our mutation
+      expect(result[0], [99, 2]);
+      expect(result[1], [3, 4]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #139

## What changed

- Added `lib/core/utils/list_extensions.dart` with the `ChunkedList` extension containing the `chunked(int size)` method
- Added `test/core/utils/list_extensions_test.dart` with comprehensive tests covering all required scenarios:
  - Happy path: splitting a list into consecutive chunks
  - Boundary cases: chunk size equal to list length, chunk size greater than list length
  - Edge cases: empty list, single element list
  - Error handling: ArgumentError when size is zero or negative
  - Independence verification: ensuring mutations to chunks don't affect the original list

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```
Output:
```
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: ChunkedList chunked splits a list into consecutive chunks
00:00 +1: ChunkedList chunked returns one chunk when size equals list length
00:00 +2: ChunkedList chunked returns one chunk when size exceeds list length
00:00 +3: ChunkedList chunked returns an empty list for an empty source list
00:00 +4: ChunkedList chunked returns a single-item chunk for a one-element list
00:00 +5: ChunkedList chunked throws ArgumentError when size is zero
00:00 +6: ChunkedList chunked throws ArgumentError when size is negative
00:00 +7: ChunkedList chunked returns independent chunk lists
00:00 +8: All tests passed!
```

```bash
cd ~/workspace/infiquetra/mimir
flutter test
```
Output:
```
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/widget_test.dart
...
00:01 +8: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList chunked splits a list into consecutive chunks
00:01 +9: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList chunked returns one chunk when size equals list length
00:01 +10: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList chunked returns one chunk when size exceeds list length
00:01 +11: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList chunked returns an empty list for an empty source list
00:01 +12: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList chunked returns a single-item chunk for a one-element list
00:01 +13: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList chunked throws ArgumentError when size is zero
00:01 +14: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList chunked throws ArgumentError when size is negative
00:01 +15: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList chunked returns independent chunk lists
00:01 +16: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) - ✓ addressed by the `chunked()` method implementation in `lib/core/utils/list_extensions.dart` which covers all requirements: proper signature, size validation, empty list handling, consecutive chunking with proper bounds, and independent chunk lists
- AC 2: All named tests pass the verification command - ✓ verified by successfully running `flutter test test/core/utils/list_extensions_test.dart` and `flutter test` with all tests passing
- AC 3: No dependencies added unless absolutely required - ✓ addressed as no new dependencies were added, only core Dart list operations are used

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only created the two expected files
- Do NOT add third-party dependencies unless required by the task body: not violated - no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - created new files with no refactoring

## Notes

Implementation follows the specification exactly:
- Signature: `extension ChunkedList<T> on List<T> { List<List<T>> chunked(int size) }`
- Size validation: throws `ArgumentError` when size < 1
- Empty list handling: returns empty list of lists
- Chunking logic: creates consecutive sublists with proper boundary checking
- Independence: uses `sublist()` to ensure mutations don't affect the original list
- Test coverage: includes all required test cases plus an additional negative size test

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- [ ] All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- [ ] No dependencies added unless absolutely required: ✓ addressed by using only core Dart functionality