### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,65 @@
+/// Utility functions for semantic version comparison.
+///
+/// Follows Semantic Versioning 2.0.0 specification for version comparison.
+int compareSemVer(String a, String b) {
+  final versionA = _parseVersion(a);
+  final versionB = _parseVersion(b);
+
+  // Compare major version
+  final majorComparison = versionA[0].compareTo(versionB[0]);
+  if (majorComparison != 0) return majorComparison;
+
+  // Compare minor version
+  final minorComparison = versionA[1].compareTo(versionB[1]);
+  if (minorComparison != 0) return minorComparison;
+
+  // Compare patch version
+  return versionA[2].compareTo(versionB[2]);
+}
+
+/// Parses a semantic version string into a list of three integers.
+///
+/// Validates that the input is non-empty and all components are numeric.
+/// Throws FormatException with the original input if validation fails.
+List<int> _parseVersion(String input) {
+  final trimmedInput = input.trim();
+  
+  // Check for empty or whitespace-only input
+  if (trimmedInput.isEmpty) {
+    throw FormatException('Invalid version string: "$input"', input);
+  }
+
+  // Split the version string by dots
+  final components = trimmedInput.split('.');
+  
+  // Parse each component as integer
+  final parsedComponents = <int>[];
+  for (int i = 0; i < components.length && i < 3; i++) {
+    final component = components[i];
+    if (!_isNumeric(component)) {
+      throw FormatException('Invalid version string: "$input"', input);
+    }
+    parsedComponents.add(int.parse(component));
+  }
+  
+  // Pad with zeros if fewer than 3 components
+  while (parsedComponents.length < 3) {
+    parsedComponents.add(0);
+  }
+  
+  return parsedComponents;
+}
+
+/// Checks if a string represents a valid non-negative integer.
+bool _isNumeric(String s) {
+  if (s.isEmpty) return false;
+  for (int i = 0; i < s.length; i++) {
+    if (!_isDigit(s.codeUnitAt(i))) return false;
+  }
+  return true;
+}
+
+/// Checks if a code unit represents a digit character.
+bool _isDigit(int codeUnit) {
+  return codeUnit >= 0x30 && codeUnit <= 0x39; // '0' to '9'
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns 0 for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('returns positive/negative when major differs', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('returns positive/negative when minor differs', () {
+      expect(compareSemVer('1.2.0', '1.1.0'), isPositive);
+      expect(compareSemVer('1.1.0', '1.2.0'), isNegative);
+    });
+
+    test('returns positive/negative when patch differs', () {
+      expect(compareSemVer('1.2.3', '1.2.2'), isPositive);
+      expect(compareSemVer('1.2.2', '1.2.3'), isNegative);
+    });
+
+    test('compares numerically, not lexicographically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads short versions with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores trailing components after patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.4'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer(' ', '1.2.3'),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+          () => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()
+              .having((e) => e.message, 'message', contains('1.2.a'))));
+      expect(
+          () => compareSemVer('', '1.2.3'),
+          throwsA(isA<FormatException>()
+              .having((e) => e.message, 'message', contains('""'))));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #145

## What changed

- Created `lib/core/utils/semver.dart` with `compareSemVer(String a, String b)` function that compares semantic version strings numerically
- Created `test/core/utils/semver_test.dart` with comprehensive test coverage for all requirements:
  - Equal versions returning `0`
  - Different major/minor/patch components with sign assertions
  - Numeric ordering (`1.10.0` vs `1.2.0`)
  - Short-form padding (`1.2` vs `1.2.0`)
  - Extra-component truncation (`1.2.3.4` vs `1.2.3`)
  - Malformed input throwing `FormatException` with proper message content

## How verified

```bash
$ flutter test test/core/utils/semver_test.dart
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/semver_test.dart
00:00 +0: compareSemVer returns 0 for equal versions
00:00 +1: compareSemVer returns positive/negative when major differs
00:00 +2: compareSemVer returns positive/negative when minor differs
00:00 +3: compareSemVer returns positive/negative when patch differs
00:00 +4: compareSemVer compares numerically, not lexicographically
00:00 +5: compareSemVer pads short versions with zero
00:00 +6: compareSemVer ignores trailing components after patch
00:00 +7: compareSemVer throws FormatException for malformed input
00:00 +8: compareSemVer includes offending input in FormatException message
00:00 +9: All tests passed!
```

Analyzer also shows no issues:
```bash
$ dart analyze lib/core/utils/semver.dart
Analyzing semver.dart...
No issues found!
```

## Acceptance criteria coverage

- AC 1: Implementation matches exact signature `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart` ✓
- AC 2: Compares major → minor → patch numerically (not lexicographically) ✓
- AC 3: Short versions pad with zero (e.g. `1.2` treated as `1.2.0`) ✓
- AC 4: Extra trailing components ignored (e.g. `1.2.3.4` treated as `1.2.3`) ✓
- AC 5: Return value contract mirrors `Comparable.compareTo` with sign-based assertions in tests ✓
- AC 6: Malformed input throws `FormatException` for non-numeric components, empty strings, or whitespace-only strings ✓
- AC 7: `FormatException.message` includes the offending input string verbatim ✓
- All named tests pass the verification command ✓
- No dependencies added unless absolutely required ✓

## Non-goals acknowledged

- Did NOT modify files beyond `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` ✓
- Did NOT add third-party dependencies ✓
- Did NOT refactor unrelated code in the touched files ✓

## Notes

Followed the repository's existing patterns from `lib/core/utils/formatters.dart` for consistent helper function implementation. Used `_parseVersion` and `_isNumeric` private helpers to keep the main function clean and readable.

### Coverage

- [ ] Implementation matches all behaviors described in the task body: ✓ addressed in lib/core/utils/semver.dart
- [ ] All named tests pass the verification command: ✓ addressed in test/core/utils/semver_test.dart
- [ ] No dependencies added unless absolutely required: ✓ addressed by using only Dart core libraries