### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,41 @@
+/// Extension methods for List collections.
+library list_extensions;
+
+/// Extension that provides chunking capabilities to Lists.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// [size] must be >= 1; throws [ArgumentError] if not.
+  /// 
+  /// Returns an empty list if the source list is empty.
+  /// The last chunk may be smaller than [size].
+  /// 
+  /// Each returned chunk is independent of the original list (modifying a chunk
+  /// does not affect the original list).
+  ///
+  /// Examples:
+  /// ```dart
+  /// [1,2,3,4,5].chunked(2) // [[1,2],[3,4],[5]]
+  /// [1,2,3].chunked(10)    // [[1,2,3]]
+  /// [].chunked(3)           // []
+  /// [1].chunked(1)          // [[1]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'must be >= 1');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final List<List<T>> chunks = [];
+    for (int i = 0; i < length; i += size) {
+      final end = i + size < length ? i + size : length;
+      // Using sublist creates independent lists
+      chunks.add(sublist(i, end));
+    }
+    
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    group('chunked', () {
+      test('returns consecutive chunks of the requested size', () {
+        final list = [1, 2, 3, 4, 5];
+        final result = list.chunked(2);
+        
+        expect(result, [
+          [1, 2],
+          [3, 4],
+          [5]
+        ]);
+        
+        // Verify chunks are independent of original list
+        result[0][0] = 999;
+        expect(list[0], 1); // Original unchanged
+      });
+      
+      test('returns a single chunk when chunk size equals list length', () {
+        final list = [1, 2, 3];
+        final result = list.chunked(3);
+        
+        expect(result, [
+          [1, 2, 3]
+        ]);
+      });
+      
+      test('returns a single chunk when chunk size exceeds list length', () {
+        final list = [1, 2, 3];
+        final result = list.chunked(10);
+        
+        expect(result, [
+          [1, 2, 3]
+        ]);
+      });
+      
+      test('returns an empty list for an empty source list', () {
+        final list = <int>[];
+        final result = list.chunked(3);
+        
+        expect(result, []);
+      });
+      
+      test('returns the single element when chunk size is one', () {
+        final list = [42];
+        final result = list.chunked(1);
+        
+        expect(result, [
+          [42]
+        ]);
+      });
+      
+      test('throws ArgumentError when chunk size is zero', () {
+        final list = [1, 2, 3];
+        
+        expect(() => list.chunked(0), throwsArgumentError);
+      });
+      
+      test('throws ArgumentError when chunk size is negative', () {
+        final list = [1, 2, 3];
+        
+        expect(() => list.chunked(-1), throwsArgumentError);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #147

## What changed

- Added `ChunkedList<T>` extension with `chunked(int size)` method in `lib/core/utils/list_extensions.dart`
- Implementation validates the size parameter (must be >= 1) and throws ArgumentError for invalid values
- Returns independent chunks using sublist() so mutations don't affect the original list
- Created comprehensive tests in `test/core/utils/list_extensions_test.dart` covering:
  - Happy path: [1,2,3,4,5].chunked(2) returns [[1,2],[3,4],[5]]
  - Boundary case: chunk size equal to list length
  - Boundary case: chunk size greater than list length
  - Empty list returns empty result
  - Single element with size 1
  - Invalid size (0 or negative) throws ArgumentError
  - Independence verification: mutating a returned chunk doesn't affect the original list

## How verified

```bash
$ cd ~/workspace/infiquetra/mimir
$ flutter test test/core/utils/list_extensions_test.dart
00:00 +7: All tests passed!
```

Analyzer also passes with no issues found:
```bash
$ dart analyze lib/core/utils/list_extensions.dart
Analyzing list_extensions.dart...
No issues found!
```

## Acceptance criteria coverage

- AC 1: ✓ addressed in lib/core/utils/list_extensions.dart - Implementation matches all behaviors described in the task body with proper validation and chunk independence
- AC 2: ✓ addressed in test/core/utils/list_extensions_test.dart - All named tests pass the verification command covering all specified cases
- AC 3: ✓ addressed in both files - No dependencies added, only core Dart functionality used

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

None

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- [ ] All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- [ ] No dependencies added unless absolutely required: ✓ addressed - only using core Dart functionality