### PR TITLE
[BENCH t02 qwen3-coder-480b-c] feat(strings): Add truncateMiddle() helper for long strings (#148)

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,56 @@
+/// Utility functions for string manipulation.
+library string_utils;
+
+/// Truncates a string in the middle with an ellipsis when it exceeds [maxLength].
+///
+/// If [input.length] is less than or equal to [maxLength], returns [input] unchanged.
+/// Otherwise, replaces the middle portion with [ellipsis] such that the result
+/// length is less than or equal to [maxLength].
+///
+/// When [maxLength] - [ellipsis.length] leaves an odd visible character budget,
+/// the extra character is allocated to the start of the string.
+///
+/// Examples:
+/// ```dart
+/// truncateMiddle('hello', 10) // 'hello'
+/// truncateMiddle('abcdefghijklmn', 8) // 'abcd…lmn'
+/// truncateMiddle('', 5) // ''
+/// truncateMiddle('abcdef', 3) // 'a…f'
+/// truncateMiddle('abcdef', 0) // ''
+/// truncateMiddle('abcdefghij', 7, ellipsis: '...') // 'ab...ij'
+/// truncateMiddle('abcdef', 2, ellipsis: '...') // '..'
+/// ```
+///
+/// Args:
+///   input: The string to potentially truncate
+///   maxLength: Maximum allowed length of the output string (including ellipsis)
+///   ellipsis: String to insert in place of the middle portion (defaults to '…')
+///
+/// Returns: A string with length <= [maxLength]
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // Guard clause for non-positive maxLength
+  if (maxLength <= 0) return '';
+  
+  // If input fits within maxLength, return unchanged
+  if (input.length <= maxLength) return input;
+  
+  // If maxLength is smaller than ellipsis, return truncated ellipsis
+  if (maxLength < ellipsis.length) return ellipsis.substring(0, maxLength);
+  
+  // Calculate the visible character budget (excluding ellipsis)
+  final visibleCharacterBudget = maxLength - ellipsis.length;
+  
+  // If no visible characters can be shown, return just the ellipsis
+  if (visibleCharacterBudget <= 0) return ellipsis;
+  
+  // Split the visible character budget
+  // For odd budgets, give the extra character to the start (leading)
+  final leadingCount = (visibleCharacterBudget + 1) ~/ 2;
+  final trailingCount = visibleCharacterBudget ~/ 2;
+  
+  // Build the result string
+  final leading = input.substring(0, leadingCount);
+  final trailing = input.substring(input.length - trailingCount);
+  
+  return '$leading$ellipsis$trailing';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns unchanged short string when input length is less than maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+    });
+
+    test('returns empty string when input is empty', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('truncates middle with odd visible budget favoring the start', () {
+      // 14 chars input, maxLength=8, ellipsis='…' (1 char)
+      // Visible budget = 8 - 1 = 7 chars
+      // leadingCount = (7 + 1) ~/ 2 = 4, trailingCount = 7 ~/ 2 = 3
+      // Result: 'abcd' + '…' + 'lmn' = 'abcd…lmn'
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abcd…lmn');
+    });
+
+    test('handles short max length that still leaves room for one leading and one trailing character', () {
+      // 6 chars input, maxLength=3, ellipsis='…' (1 char)
+      // Visible budget = 3 - 1 = 2 chars
+      // leadingCount = (2 + 1) ~/ 2 = 1, trailingCount = 2 ~/ 2 = 1
+      // Result: 'a' + '…' + 'f' = 'a…f'
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+
+    test('returns empty string when maxLength is zero or negative', () {
+      expect(truncateMiddle('abcdef', 0), '');
+      expect(truncateMiddle('abcdef', -1), '');
+    });
+
+    test('handles custom ellipsis length consideration', () {
+      // 10 chars input, maxLength=7, ellipsis='...' (3 chars)
+      // Visible budget = 7 - 3 = 4 chars
+      // leadingCount = (4 + 1) ~/ 2 = 2, trailingCount = 4 ~/ 2 = 2
+      // Result: 'ab' + '...' + 'ij' = 'ab...ij'
+      expect(truncateMiddle('abcdefghij', 7, ellipsis: '...'), 'ab...ij');
+    });
+
+    test('truncates ellipsis when custom ellipsis itself is too long', () {
+      // 6 chars input, maxLength=2, ellipsis='...' (3 chars)
+      // Since maxLength < ellipsis.length, return ellipsis.substring(0, maxLength)
+      // Result: '..' (first 2 chars of '...')
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+    });
+
+    test('handles single character input with sufficient maxLength', () {
+      expect(truncateMiddle('a', 5), 'a');
+    });
+
+    test('handles single character input with insufficient maxLength', () {
+      expect(truncateMiddle('a', 0), '');
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #148

## What changed

- Added `lib/core/utils/string_utils.dart` with `truncateMiddle` function implementation
- Added `test/core/utils/string_utils_test.dart` with comprehensive test suite for `truncateMiddle`

The implementation follows the exact requirements specified in the issue:
- If `input.length <= maxLength`, returns `input` unchanged
- Otherwise, replaces the middle portion with `ellipsis`, keeping the start and end visible
- `maxLength` includes the length of the ellipsis
- Return value length is `<= maxLength`
- Handles edge cases: empty string, single char, maxLength shorter than ellipsis (returns ellipsis alone, truncated)

When `maxLength - ellipsis.length` is odd, the extra character is consistently allocated to the start of the string.

## How verified

```bash
$ flutter test test/core/utils/string_utils_test.dart
Resolving dependencies...
...
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart
00:00 +0: truncateMiddle returns unchanged short string when input length is less than maxLength
00:00 +1: truncateMiddle returns empty string when input is empty
00:00 +2: truncateMiddle truncates middle with odd visible budget favoring the start
00:00 +3: truncateMiddle handles short max length that still leaves room for one leading and one trailing character
00:00 +4: truncateMiddle returns empty string when maxLength is zero or negative
00:00 +5: truncateMiddle handles custom ellipsis length consideration
00:00 +6: truncateMiddle truncates ellipsis when custom ellipsis itself is too long
00:00 +7: truncateMiddle handles single character input with sufficient maxLength
00:00 +8: truncateMiddle handles single character input with insufficient maxLength
00:00 +9: All tests passed!

$ flutter test
Resolving dependencies...
...
00:02 +17: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body - ✓ addressed in `lib/core/utils/string_utils.dart`
- AC 2: All named tests pass the verification command - ✓ addressed in `test/core/utils/string_utils_test.dart`
- AC 3: No dependencies added unless absolutely required - ✓ no new dependencies added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below - not violated
- Do NOT add third-party dependencies unless required by the task body - not violated
- Do NOT refactor unrelated code in the touched files - not violated

## Notes

None

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/string_utils.dart
- [ ] All named tests pass the verification command: ✓ addressed in test/core/utils/string_utils_test.dart
- [ ] No dependencies added unless absolutely required: ✓ addressed in lib/core/utils/string_utils.dart