### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,58 @@
+/// Compares two semantic version strings.
+///
+/// Returns a comparator-style integer: negative if `a < b`, zero if `a == b`,
+/// positive if `a > b`. Versions are compared numerically by major, minor,
+/// then patch components.
+///
+/// Short versions (e.g., `1.2`) are padded with zeros to `1.2.0`.
+/// Extra components beyond patch (e.g., `1.2.3.4`) are ignored.
+///
+/// Throws [FormatException] if either input is empty, whitespace-only,
+/// or contains non-numeric components.
+int compareSemVer(String a, String b) {
+  final versionA = _parseVersion(a);
+  final versionB = _parseVersion(b);
+
+  for (var i = 0; i < 3; i++) {
+    final comparison = versionA[i].compareTo(versionB[i]);
+    if (comparison != 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into a list of [major, minor, patch].
+///
+/// Missing components are padded with 0.
+/// Extra components beyond patch are ignored.
+/// Throws [FormatException] for malformed input.
+List<int> _parseVersion(String version) {
+  final trimmed = version.trim();
+  if (trimmed.isEmpty) {
+    throw FormatException('Invalid semantic version: "$version"');
+  }
+
+  final parts = trimmed.split('.');
+  if (parts.isEmpty) {
+    throw FormatException('Invalid semantic version: "$version"');
+  }
+
+  // Parse up to 3 components, ignore the rest
+  final result = <int>[];
+  for (var i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final parsed = int.tryParse(parts[i]);
+      if (parsed == null) {
+        throw FormatException('Invalid semantic version: "$version"');
+      }
+      result.add(parsed);
+    } else {
+      // Pad missing components with 0
+      result.add(0);
+    }
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares differing major versions by sign', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares differing minor versions by sign', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares differing patch versions by sign', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares numeric components rather than lexicographic order', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads missing patch component with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1.2.0', '1.2'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.4'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '1.2.a'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', ''), throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+      expect(
+        () => compareSemVer('1.2.3', 'invalid'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('invalid'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #150

## What changed

- Created `lib/core/utils/semver.dart` with the public function `int compareSemVer(String a, String b)`
- Implemented semantic version comparison that:
  - Compares major → minor → patch numerically (not lexicographically)
  - Pads missing components with zero (e.g., `1.2` → `1.2.0`)
  - Ignores extra components beyond patch (e.g., `1.2.3.4` → `1.2.3`)
  - Throws `FormatException` for malformed input with offending string in message
- Created `test/core/utils/semver_test.dart` with 9 test cases covering all acceptance criteria

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

**Output:**
```
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/semver_test.dart
00:00 +0: compareSemVer returns zero for equal versions
00:00 +1: compareSemVer compares differing major versions by sign
00:00 +2: compareSemVer compares differing minor versions by sign
00:00 +3: compareSemVer compares differing patch versions by sign
00:00 +4: compareSemVer compares numeric components rather than lexicographic order
00:00 +5: compareSemVer pads missing patch component with zero
00:00 +6: compareSemVer ignores components beyond patch
00:00 +7: compareSemVer throws FormatException for malformed input
00:00 +8: compareSemVer includes offending input in FormatException message
00:00 +9: All tests passed!
```

**Static analysis:** `dart analyze lib/core/utils/semver.dart` - No issues found!

## Acceptance criteria coverage

- **AC 1** (Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`): ✓ addressed in `lib/core/utils/semver.dart` lines 10-24
- **AC 2** (Accepts versions and compares major → minor → patch NUMERICALLY): ✓ addressed in `_parseVersion()` which uses `int.tryParse()` and `compareTo()`
- **AC 3** (Short version treated as padded with zero): ✓ addressed in `_parseVersion()` lines 43-46
- **AC 4** (Extra components beyond patch ignored): ✓ addressed in `_parseVersion()` line 40 which only processes first 3 components
- **AC 5** (Return value contract mirrors Comparable.compareTo): ✓ addressed in `compareSemVer()` returning `compareTo()` results; tests use `isPositive`/`isNegative`/`equals(0)` matchers
- **AC 6** (Malformed input throws FormatException): ✓ addressed in `_parseVersion()` lines 31-33; tests verify with `throwsA(isA<FormatException>())`
- **AC 7** (FormatException message includes offending input verbatim): ✓ addressed in `_parseVersion()` including `"$version"` in exception message; tests verify with `.having((e) => e.message, 'message', contains(...))`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` modified
- Do NOT add third-party dependencies: not violated — no new dependencies added
- Do NOT refactor unrelated code: not violated — only new files created

## Notes

No deviations from plan. Implementation uses pure Dart core library (no external dependencies). Total implementation is 58 lines + 71 lines of tests = 129 lines.
