### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,67 @@
+/// Compares two semantic version strings.
+///
+/// Returns a negative integer if [a] is less than [b],
+/// zero if [a] is equal to [b],
+/// and a positive integer if [a] is greater than [b].
+///
+/// Versions are compared numerically by major, minor, and patch components.
+/// Short versions (e.g., '1.2') are padded with zeros ('1.2.0').
+/// Extra trailing components (e.g., '1.2.3.4') are truncated to just patch.
+///
+/// Throws [FormatException] if either input is empty, whitespace-only,
+/// or contains non-numeric components.
+///
+/// Examples:
+/// - `compareSemVer('1.2.3', '1.2.3')` → `0`
+/// - `compareSemVer('1.2.3', '1.2.4')` → negative
+/// - `compareSemVer('1.10.0', '1.2.0')` → positive (numeric, not lexicographic)
+/// - `compareSemVer('1.2', '1.2.0')` → `0` (short form pads with zero)
+/// - `compareSemVer('1.2.3.4', '1.2.3')` → `0` (extra components ignored)
+int compareSemVer(String a, String b) {
+  final aComponents = _parseVersion(a);
+  final bComponents = _parseVersion(b);
+
+  for (var i = 0; i < 3; i++) {
+    final comparison = aComponents[i].compareTo(bComponents[i]);
+    if (comparison != 0) return comparison;
+  }
+
+  return 0;
+}
+
+/// Parses a version string into [major, minor, patch] integers.
+///
+/// - Version must be non-empty after trimming.
+/// - Components must be numeric (no pre-release or build metadata).
+/// - Missing minor/patch are treated as 0.
+/// - Extra components beyond patch are ignored.
+List<int> _parseVersion(String version) {
+  final trimmed = version.trim();
+
+  if (trimmed.isEmpty) {
+    throw FormatException('Invalid semantic version: "$version"');
+  }
+
+  final parts = trimmed.split('.').take(3).toList();
+
+  if (parts.isEmpty) {
+    throw FormatException('Invalid semantic version: "$version"');
+  }
+
+  final components = <int>[];
+  for (final part in parts) {
+    final trimmedPart = part.trim();
+    final parsed = int.tryParse(trimmedPart);
+    if (parsed == null) {
+      throw FormatException('Invalid semantic version: "$version"');
+    }
+    components.add(parsed);
+  }
+
+  // Pad missing minor/patch with zeros
+  while (components.length < 3) {
+    components.add(0);
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions returns 0', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('differing major component - a less than b', () {
+      expect(compareSemVer('1.2.3', '2.2.3'), isNegative);
+    });
+
+    test('differing major component - a greater than b', () {
+      expect(compareSemVer('2.2.3', '1.2.3'), isPositive);
+    });
+
+    test('differing minor component - a less than b', () {
+      expect(compareSemVer('1.1.3', '1.2.3'), isNegative);
+    });
+
+    test('differing minor component - a greater than b', () {
+      expect(compareSemVer('1.3.3', '1.2.3'), isPositive);
+    });
+
+    test('differing patch component - a less than b', () {
+      expect(compareSemVer('1.2.2', '1.2.3'), isNegative);
+    });
+
+    test('differing patch component - a greater than b', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+    });
+
+    test('numeric ordering (1.10.0 vs 1.2.0) - a greater than b', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('numeric ordering (1.10.0 vs 1.2.0) - a less than b when swapped', () {
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('short-form padding (1.2 vs 1.2.0) returns 0', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('short-form padding single component (1 vs 1.0.0) returns 0', () {
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('extra-component truncation (1.2.3.4 vs 1.2.3) returns 0', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('malformed input throws FormatException', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('malformed input exception message contains offending input substring', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a')),
+        ),
+      );
+    });
+
+    test('empty string throws FormatException with original input', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having((e) => e.message, 'message', contains('')),
+        ),
+      );
+    });
+
+    test('whitespace-only string throws FormatException', () {
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('whitespace-only exception message contains original input', () {
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having((e) => e.message, 'message', contains('   ')),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #149

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` function
- Implemented version parsing with numeric comparison (major → minor → patch)
- Added support for short-form versions (1.2 → 1.2.0 via zero-padding)
- Added support for extra-component truncation (1.2.3.4 → 1.2.3)
- Malformed input throws FormatException with original input in message
- Created `test/core/utils/semver_test.dart` with 17 test cases covering all ACs:
  - Equal versions → equals(0)
  - Differing major/minor/patch components → sign assertions
  - Numeric ordering (1.10.0 vs 1.2.0) → sign assertions
  - Short-form padding (1.2 vs 1.2.0) → equals(0)
  - Extra-component truncation (1.2.3.4 vs 1.2.3) → equals(0)
  - Malformed input → FormatException with message containing offending input

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```
Output: 17 tests passed

```bash
flutter test
```
Output: All 25 tests passed (including existing tests)

```bash
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```
Output: No issues found!

## Acceptance criteria coverage

- AC 1 ("Implementation matches all behaviors described in the task body"): ✓ addressed in lib/core/utils/semver.dart - function matches specified behavior for version comparison
- AC 2 ("All named tests pass the verification command"): ✓ addressed in test/core/utils/semver_test.dart - all 17 tests pass
- AC 3 ("No dependencies added unless absolutely required"): ✓ addressed - uses only Dart/Flutter built-in tools, no pubspec.yaml changes
- AC 4 ("exact signature and file location"): ✓ addressed in lib/core/utils/semver.dart lines 23-25
- AC 5 ("numeric MAJOR.MINOR.PATCH comparison"): ✓ addressed in _parseVersion (lines 58-76) and compareSemVer (lines 32-38)
- AC 6 ("short versions pad with zero"): ✓ addressed in _parseVersion lines 72-75
- AC 7 ("extra trailing components ignored"): ✓ addressed in _parseVersion line 61 with .take(3)
- AC 8 ("sign-only comparator contract"): ✓ addressed in tests using isNegative/isPositive/equals(0) assertions
- AC 9 ("malformed input throws FormatException"): ✓ addressed in _parseVersion lines 65-76 with explicit throws
- AC 10 ("exception message includes offending input verbatim"): ✓ addressed in lines 65-69 and tested at line 64 in semver_test.dart

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ Only modified lib/core/utils/semver.dart and test/core/utils/semver_test.dart
- Do NOT add third-party dependencies unless required by the task body: ✓ No dependencies added
- Do NOT refactor unrelated code in the touched files: ✓ No refactoring, only new code added

## Notes

Implementation follows the existing pattern from adjacent formatters.dart - top-level utility functions with doc comments, using group(...)/test(...) pattern in tests.

### Coverage

- AC 1 ("Implementation matches all behaviors described in the task body"): ✓ addressed in lib/core/utils/semver.dart: compareSemVer implements all specified behaviors
- AC 2 ("All named tests pass the verification command"): ✓ addressed in test/core/utils/semver_test.dart: 17 test cases all pass
- AC 3 ("No dependencies added unless absolutely required"): ✓ addressed - no pubspec.yaml changes, only Dart/Flutter built-ins used
