### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,34 @@
+/// Extension methods for [List] utilities.
+library list_extensions;
+
+/// Extension that adds chunking functionality to Lists.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws an [ArgumentError] if [size] is less than 1.
+  ///
+  /// Example:
+  /// ```dart
+  /// final list = [1, 2, 3, 4, 5];
+  /// final chunked = list.chunked(2);
+  /// // chunked is [[1, 2], [3, 4], [5]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'must be >= 1');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final chunks = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      final end = i + size < length ? i + size : length;
+      // Using sublist creates a new list, ensuring chunks are independent
+      chunks.add(sublist(i, end));
+    }
+
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('chunked', () {
+    test('happy path: splits list into chunks of specified size', () {
+      final list = [1, 2, 3, 4, 5];
+      final result = list.chunked(2);
+      expect(result, [
+        [1, 2],
+        [3, 4],
+        [5]
+      ]);
+    });
+
+    test('boundary: chunk size equals list length', () {
+      final list = [1, 2, 3];
+      final result = list.chunked(3);
+      expect(result, [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('boundary: chunk size greater than list length', () {
+      final list = [1, 2, 3];
+      final result = list.chunked(10);
+      expect(result, [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('empty list returns empty list', () {
+      final list = <int>[];
+      final result = list.chunked(3);
+      expect(result, []);
+    });
+
+    test('single element with size 1', () {
+      final list = [1];
+      final result = list.chunked(1);
+      expect(result, [
+        [1]
+      ]);
+    });
+
+    test('error case: size == 0 throws ArgumentError', () {
+      final list = [1, 2, 3];
+      expect(() => list.chunked(0), throwsA(isA<ArgumentError>()));
+    });
+
+    test('error case: size < 0 throws ArgumentError', () {
+      final list = [1, 2, 3];
+      expect(() => list.chunked(-1), throwsA(isA<ArgumentError>()));
+    });
+
+    test('returned chunks are independent from the original list', () {
+      final list = [1, 2, 3, 4, 5];
+      final result = list.chunked(2);
+
+      // Mutate a returned chunk
+      if (result.isNotEmpty) {
+        result[0].add(999);
+      }
+
+      // Original list should be unchanged
+      expect(list, [1, 2, 3, 4, 5]);
+
+      // First chunk should have the additional element
+      expect(result[0], [1, 2, 999]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #154

## What changed

- Added  extension with  method in 
- Added comprehensive tests in  covering:
  - Happy path chunking behavior
  - Boundary cases (chunk size equals/greater than list length)
  - Empty list handling
  - Single element handling
  - Error handling for invalid size values
  - Independence of returned chunks from original list

## How verified

```bash
$ flutter test test/core/utils/list_extensions_test.dart
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: chunked happy path: splits list into chunks of specified size
00:00 +1: chunked boundary: chunk size equals list length
00:00 +2: chunked boundary: chunk size greater than list length
00:00 +3: chunked empty list returns empty list
00:00 +4: chunked single element with size 1
00:00 +5: chunked error case: size == 0 throws ArgumentError
00:00 +6: chunked error case: size < 0 throws ArgumentError
00:00 +7: chunked returned chunks are independent from the original list
00:00 +8: All tests passed!
```

All tests passed successfully.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) - ✓ addressed in  and 
- AC 2: All named tests pass the verification command - ✓ verified by running Resolving dependencies...
Downloading packages...
  async 2.11.0 (2.13.1 available)
  boolean_selector 2.1.1 (2.1.2 available)
> characters 1.4.1 (was 1.3.0)
> clock 1.1.2 (was 1.1.1)
> collection 1.19.1 (was 1.18.0)
  cupertino_icons 1.0.8 (1.0.9 available)
> fake_async 1.3.3 (was 1.3.1)
  flutter_lints 3.0.2 (6.0.0 available)
> leak_tracker 11.0.2 (was 10.0.0)
> leak_tracker_flutter_testing 3.0.10 (was 2.0.1)
> leak_tracker_testing 3.0.2 (was 2.0.1)
  lints 3.0.0 (6.1.0 available)
> matcher 0.12.19 (was 0.12.16+1)
> material_color_utilities 0.13.0 (was 0.8.0)
> meta 1.17.0 (was 1.11.0) (1.18.2 available)
> path 1.9.1 (was 1.9.0)
< sky_engine 0.0.0 from sdk flutter (was 0.0.99 from sdk flutter)
  source_span 1.10.0 (1.10.2 available)
> stack_trace 1.12.1 (was 1.11.1)
> stream_channel 2.1.4 (was 2.1.2)
  string_scanner 1.2.0 (1.4.1 available)
  term_glyph 1.2.1 (1.2.2 available)
> test_api 0.7.10 (was 0.6.1) (0.7.11 available)
> vector_math 2.2.0 (was 2.1.4) (2.3.0 available)
  vm_service 13.0.0 (15.1.0 available)
Changed 16 dependencies!
12 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: chunked happy path: splits list into chunks of specified size
00:00 +1: chunked boundary: chunk size equals list length
00:00 +2: chunked boundary: chunk size greater than list length
00:00 +3: chunked empty list returns empty list
00:00 +4: chunked single element with size 1
00:00 +5: chunked error case: size == 0 throws ArgumentError
00:00 +6: chunked error case: size < 0 throws ArgumentError
00:00 +7: chunked returned chunks are independent from the original list
00:00 +8: All tests passed! 
- AC 3: No dependencies added unless absolutely required - ✓ no new dependencies added, only used existing Dart/Flutter features

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

Implementation follows the exact signature and behavior described in the task:
- Signature: 
- Proper error handling for size < 1
- Empty list returns empty list
- Last chunk may be smaller than size
- Returned chunks are independent from original list

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- [ ] All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- [ ] No dependencies added unless absolutely required: ✓ addressed by not adding any new dependencies