### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,84 @@
+/// Utility functions for semantic version comparison.
+///
+/// Implements comparison of semantic version strings according to SemVer 2.0.0
+/// specification, with support for major.minor.patch format.
+library semver;
+
+/// Compares two semantic version strings.
+///
+/// Parses each input string into major.minor.patch components and compares
+/// them numerically from left to right.
+///
+/// Returns:
+/// * a negative integer if [a] is less than [b]
+/// * zero if [a] equals [b]
+/// * a positive integer if [a] is greater than [b]
+///
+/// Examples:
+/// ```dart
+/// compareSemVer('1.2.3', '1.2.3'); // 0
+/// compareSemVer('1.2.3', '1.2.4'); // negative
+/// compareSemVer('1.10.0', '1.2.0'); // positive
+/// compareSemVer('1.2', '1.2.0'); // 0 (short form padding)
+/// ```
+///
+/// Throws [FormatException] for malformed input:
+/// * Empty or whitespace-only strings
+/// * Non-numeric components (e.g., '1.2.a')
+int compareSemVer(String a, String b) {
+  final componentsA = _parseSemVerComponents(a);
+  final componentsB = _parseSemVerComponents(b);
+
+  // Compare major, then minor, then patch
+  for (int i = 0; i < 3; i++) {
+    final result = componentsA[i].compareTo(componentsB[i]);
+    if (result != 0) return result;
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into exactly three integer components.
+///
+/// Normalizes by:
+/// * Taking only the first three dot-separated components
+/// * Padding with zeros if fewer than three components exist
+/// * Converting components to integers
+///
+/// Throws [FormatException] for invalid input strings.
+List<int> _parseSemVerComponents(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Invalid semantic version: "$input"');
+  }
+
+  final parts = input.split('.');
+  
+  // Take only first three components, pad with zeros if needed
+  final components = <int>[];
+  for (int i = 0; i < 3; i++) {
+    final part = i < parts.length ? parts[i] : '0';
+    
+    // Validate that component is numeric
+    if (!_isNumeric(part)) {
+      throw FormatException('Invalid semantic version: "$input"');
+    }
+    
+    components.add(int.parse(part));
+  }
+  
+  return components;
+}
+
+/// Checks if a string represents a valid non-negative integer.
+bool _isNumeric(String str) {
+  if (str.isEmpty) return false;
+  for (int i = 0; i < str.length; i++) {
+    if (!_isDigit(str.codeUnitAt(i))) return false;
+  }
+  return true;
+}
+
+/// Checks if a code unit represents a digit (0-9).
+bool _isDigit(int codeUnit) {
+  return codeUnit >= 0x30 && codeUnit <= 0x39;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions returns zero', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('major difference returns sign-only result', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('minor difference returns sign-only result', () {
+      expect(compareSemVer('1.2.0', '1.1.0'), isPositive);
+      expect(compareSemVer('1.1.0', '1.2.0'), isNegative);
+    });
+
+    test('patch difference returns sign-only result', () {
+      expect(compareSemVer('1.2.3', '1.2.2'), isPositive);
+      expect(compareSemVer('1.2.2', '1.2.3'), isNegative);
+    });
+
+    test('compares numeric components, not lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads short versions with zero patch', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1.2.0', '1.2'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.4'), equals(0));
+    });
+
+    test('throws FormatException for empty input', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', ''), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException for whitespace-only input', () {
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '\t\n'), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException for non-numeric components', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '1.b.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException.message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('1.2.a')),
+        ),
+      );
+      
+      expect(
+        () => compareSemVer('1.2.3', 'x.2.3'),
+        throwsA(
+          isA<FormatException>()
+              .having((e) => e.message, 'message', contains('x.2.3')),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #157

## What changed

- Added `lib/core/utils/semver.dart` with `compareSemVer` function for semantic version comparison
- Added `test/core/utils/semver_test.dart` with comprehensive tests covering all requirements

## How verified

```bash
$ flutter test test/core/utils/semver_test.dart
00:00 +11: All tests passed!

$ flutter test
00:02 +19: All tests passed!

$ dart analyze lib/core/utils/semver.dart
No issues found!
```

## Acceptance criteria coverage

- AC 1: Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` function
- AC 2: Implemented numeric comparison of components (not lexicographic) 
- AC 3: Added support for short versions by padding with zero (e.g., `1.2` → `1.2.0`)
- AC 4: Implemented ignoring of components beyond patch (e.g., `1.2.3.4` → `1.2.3`)
- AC 5: Return value follows `Comparable.compareTo` contract with proper signs
- AC 6: Malformed input throws `FormatException` with appropriate validation
- AC 7: `FormatException` messages include the offending input string verbatim

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

Implementation follows the existing code style from `lib/core/utils/formatters.dart` and `test/core/utils/formatters_test.dart`. The function handles all edge cases specified in the issue description and includes comprehensive test coverage.

### Coverage

- [ ] Implementation matches all behaviors described in the task body: ✓ addressed in lib/core/utils/semver.dart AND test/core/utils/semver_test.dart
- [ ] All named tests pass the verification command: ✓ addressed in test run output above
- [ ] No dependencies added unless absolutely required: ✓ addressed - no dependencies added