### PR TITLE
feat(strings): add truncateMiddle() helper

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -15,7 +15,7 @@
 ///
 /// Examples:
 /// - `truncateMiddle('hello', 10)` → `'hello'`
-/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abcd…lmn'`
 /// - `truncateMiddle('', 5)` → `''`
 /// - `truncateMiddle('abcdef', 3)` → `'a…f'`
 /// - `truncateMiddle('abcdef', 5)` → `'ab…ef'`

--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -18,7 +18,7 @@
 /// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
 /// - `truncateMiddle('', 5)` → `''`
 /// - `truncateMiddle('abcdef', 3)` → `'a…f'`
-/// - `truncateMiddle('abcdef', 4)` → `'ab…ef'`
+/// - `truncateMiddle('abcdef', 5)` → `'ab…ef'`
 String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
   // Guard: non-positive maxLength → empty string
   if (maxLength <= 0) return '';

--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,52 @@
+/// Utility functions for string manipulation.
+
+/// Truncates a string to [maxLength] by replacing the middle portion with
+/// [ellipsis], keeping the start and end portions visible.
+///
+/// The total returned length (including ellipsis) is always <= [maxLength].
+///
+/// - If [input] is empty or [input.length] <= [maxLength], returns [input] unchanged.
+/// - If [maxLength] <= 0, returns an empty string.
+/// - If [maxLength] < [ellipsis].length, returns [ellipsis] truncated to [maxLength].
+/// - If fewer than 2 visible characters fit ([maxLength] - [ellipsis].length < 2),
+///   returns the [ellipsis] alone.
+/// - When the visible budget is odd, the extra character goes to the prefix
+///   (prefixCount = ceil(visibleCount / 2), suffixCount = floor(visibleCount / 2)).
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'…'`
+/// - `truncateMiddle('abcdef', 4)` → `'ab…ef'`
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // Guard: non-positive maxLength → empty string
+  if (maxLength <= 0) return '';
+
+  // Guard: input already within limit → unchanged
+  if (input.length <= maxLength) return input;
+
+  // Guard: empty ellipsis → plain truncation to maxLength
+  if (ellipsis.isEmpty) {
+    return input.substring(0, maxLength);
+  }
+
+  // Guard: ellipsis longer than budget → truncate ellipsis to fit
+  if (maxLength < ellipsis.length) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  // Compute visible character budget (excluding ellipsis)
+  final visibleCount = maxLength - ellipsis.length;
+
+  // Guard: not enough room for both start and end → ellipsis alone
+  if (visibleCount < 2) {
+    return ellipsis;
+  }
+
+  // Split visible budget: odd budgets favor the prefix (extra char goes to start)
+  final prefixCount = (visibleCount / 2).ceil();
+  final suffixCount = visibleCount ~/ 2;
+
+  return '${input.substring(0, prefixCount)}$ellipsis${input.substring(input.length - suffixCount, input.length)}';
+}

--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -17,7 +17,7 @@
 /// - `truncateMiddle('hello', 10)` → `'hello'`
 /// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
 /// - `truncateMiddle('', 5)` → `''`
-/// - `truncateMiddle('abcdef', 3)` → `'…'`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'`
 /// - `truncateMiddle('abcdef', 4)` → `'ab…ef'`
 String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
   // Guard: non-positive maxLength → empty string

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -7,6 +7,9 @@ void main() {
       expect(truncateMiddle('hello', 10), 'hello');
       expect(truncateMiddle('abc', 5), 'abc');
       expect(truncateMiddle('', 5), '');
+      // Single-character input
+      expect(truncateMiddle('a', 1), 'a');
+      expect(truncateMiddle('a', 0), '');
     });
 
     test('truncates the middle and keeps both ends visible', () {

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -25,6 +25,8 @@ void main() {
       expect(truncateMiddle('abcdef', 2), '…');
       expect(truncateMiddle('abcdef', 1), '…');
       expect(truncateMiddle('abcdef', 0), '');
+      // maxLength < ellipsis.length → truncate ellipsis to fit
+      expect(truncateMiddle('abcdef', 2, ellipsis: '....'), '..');
     });
 
     test('counts custom ellipsis length in the max length budget', () {
@@ -39,6 +41,8 @@ void main() {
       expect(truncateMiddle('abcdefgh', 5), 'ab…gh');
       // maxLength=6, ellipsis=1, visible=5, prefix=3, suffix=2
       expect(truncateMiddle('abcdefgh', 6), 'abc…gh');
+      // maxLength=3, ellipsis=1, visible=2, prefix=1, suffix=1 → 'a…f'
+      expect(truncateMiddle('abcdef', 3), 'a…f');
     });
   });
 }

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when already within max length', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('abc', 5), 'abc');
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('truncates the middle and keeps both ends visible', () {
+      // maxLength=7: visibleCount=6, prefix=3, suffix=3 → 'abc…hij' (7 chars)
+      expect(truncateMiddle('abcdefghij', 7), 'abc…hij');
+      // maxLength=8: visibleCount=7, prefix=4, suffix=3 → 'abcd…lmn' (8 chars)
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abcd…lmn');
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+      expect(truncateMiddle('', 0), '');
+    });
+
+    test('returns truncated ellipsis when max length is shorter than ellipsis', () {
+      expect(truncateMiddle('abcdef', 2), '…');
+      expect(truncateMiddle('abcdef', 1), '…');
+      expect(truncateMiddle('abcdef', 0), '');
+    });
+
+    test('counts custom ellipsis length in the max length budget', () {
+      // '..' is 2 chars, input 8 chars, budget=6, visible=4, prefix=2, suffix=2
+      expect(truncateMiddle('abcdefgh', 6, ellipsis: '..'), 'ab..gh');
+      // maxLength=3, ellipsis='...' (3 chars), budget exhausted, returns '...'
+      expect(truncateMiddle('abcdef', 3, ellipsis: '...'), '...');
+    });
+
+    test('distributes odd visible budget to prefix consistently', () {
+      // maxLength=5, ellipsis=1, visible=4, prefix=2, suffix=2
+      expect(truncateMiddle('abcdefgh', 5), 'ab…gh');
+      // maxLength=6, ellipsis=1, visible=5, prefix=3, suffix=2
+      expect(truncateMiddle('abcdefgh', 6), 'abc…gh');
+    });
+  });
+}


### PR DESCRIPTION
## Plan

Implement `truncateMiddle(input, maxLength, ellipsis)` utility that truncates a string in the middle, keeping equal-length prefix and suffix visible.

## Changes

- **`lib/core/utils/string_utils.dart`** — `truncateMiddle()` implementation
- **`test/core/utils/string_utils_test.dart`** — 6 test cases covering:
  - Input already within max length (unchanged)
  - Middle truncation with `…` (happy path)
  - Empty string
  - Max length shorter than ellipsis
  - Custom ellipsis length counted in budget
  - Odd visible budget distribution

## Test results

```
flutter test test/core/utils/string_utils_test.dart --name truncateMiddle
00:00 +6: All tests passed!
```

## Follow-up suggestion

The current implementation operates on code-units (UTF-16), not grapheme clusters. Multi-codepoint Unicode sequences (e.g., flag emojis, emoji ZWJ sequences, accented characters composed of combining marks) may not truncate at visually intuitive positions. A follow-up card could explore grapheme-cluster-aware truncation if the project has i18n needs.
