### PR TITLE
[BENCH t01] feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -19,7 +19,9 @@
 
   int parseComponent(String component, String originalVersion) {
     if (component.isEmpty) {
-      return 0;
+      throw FormatException(
+        'Empty version component in "$originalVersion"',
+      );
     }
     final parsed = int.tryParse(component);
     if (parsed == null) {

--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,65 @@
+/// Parses a semantic version string into numeric components.
+///
+/// Accepts versions of the form "MAJOR.MINOR.PATCH" and handles:
+/// - Short forms: "1.2" is treated as "1.2.0"
+/// - Extra components: "1.2.3.4" is treated as "1.2.3"
+///
+/// Throws [FormatException] if the input is empty, whitespace-only,
+/// or contains non-numeric components.
+({int major, int minor, int patch}) _parseSemVer(String version) {
+  final trimmed = version.trim();
+  if (trimmed.isEmpty) {
+    throw FormatException('Empty or whitespace-only version string: "$version"');
+  }
+
+  final parts = trimmed.split('.');
+  if (parts.isEmpty || parts.length > 3 && parts.take(3).any((p) => p.isEmpty)) {
+    throw FormatException('Invalid version format: "$version"');
+  }
+
+  int parseComponent(String component, String originalVersion) {
+    if (component.isEmpty) {
+      return 0;
+    }
+    final parsed = int.tryParse(component);
+    if (parsed == null) {
+      throw FormatException(
+        'Non-numeric version component in "$originalVersion"',
+      );
+    }
+    return parsed;
+  }
+
+  final major = parseComponent(parts[0], version);
+  final minor = parts.length > 1 ? parseComponent(parts[1], version) : 0;
+  final patch = parts.length > 2 ? parseComponent(parts[2], version) : 0;
+
+  return (major: major, minor: minor, patch: patch);
+}
+
+/// Compares two semantic version strings.
+///
+/// Returns a comparator-style integer:
+/// - negative if [a] < [b]
+/// - zero if [a] == [b]
+/// - positive if [a] > [b]
+///
+/// Versions are compared numerically by major, minor, then patch.
+/// Short forms (e.g., "1.2") are padded with zeros.
+/// Extra components (e.g., "1.2.3.4") are truncated.
+///
+/// Throws [FormatException] if either input is empty, whitespace-only,
+/// or contains non-numeric components. The exception message includes
+/// the offending input string.
+int compareSemVer(String a, String b) {
+  final versionA = _parseSemVer(a);
+  final versionB = _parseSemVer(b);
+
+  final majorComparison = versionA.major.compareTo(versionB.major);
+  if (majorComparison != 0) return majorComparison;
+
+  final minorComparison = versionA.minor.compareTo(versionB.minor);
+  if (minorComparison != 0) return minorComparison;
+
+  return versionA.patch.compareTo(versionB.patch);
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions returns equals(0)', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('major difference - first version is smaller', () {
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('major difference - first version is larger', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+    });
+
+    test('minor difference - first version is smaller', () {
+      expect(compareSemVer('1.2.0', '1.5.0'), isNegative);
+    });
+
+    test('minor difference - first version is larger', () {
+      expect(compareSemVer('1.5.0', '1.2.0'), isPositive);
+    });
+
+    test('patch difference - first version is smaller', () {
+      expect(compareSemVer('1.2.3', '1.2.5'), isNegative);
+    });
+
+    test('patch difference - first version is larger', () {
+      expect(compareSemVer('1.2.5', '1.2.3'), isPositive);
+    });
+
+    test('numeric ordering - 1.10.0 is greater than 1.2.0', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('short-form padding - 1.2 is treated as 1.2.0', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1.2.0', '1.2'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('extra-component truncation - 1.2.3.4 is treated as 1.2.3', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.4'), equals(0));
+    });
+
+    test('malformed input throws FormatException', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '1.2.a'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', ''), throwsA(isA<FormatException>()));
+      expect(
+        () => compareSemVer('  ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('1.2.3', '  '),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('malformed input message contains offending input substring', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+      expect(
+        () => compareSemVer('1.2.3', 'invalid'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('invalid'),
+          ),
+        ),
+      );
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('""'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #169

## What changed

- Created `lib/core/utils/semver.dart` with `compareSemVer(String a, String b)` helper function
- Created `test/core/utils/semver_test.dart` with comprehensive test coverage
- Implementation supports numeric comparison of semantic versions (major → minor → patch)
- Handles short forms (e.g., "1.2" treated as "1.2.0") via zero-padding
- Handles extra components (e.g., "1.2.3.4" treated as "1.2.3") via truncation
- Throws `FormatException` with offending input verbatim on malformed data

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
flutter test
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

All 12 tests passed:
- equal versions → equals(0)
- major/minor/patch differences → isPositive/isNegative sign assertions
- numeric ordering (1.10.0 > 1.2.0)
- short-form padding (1.2 vs 1.2.0)
- extra-component truncation (1.2.3.4 vs 1.2.3)
- FormatException thrown on malformed input
- FormatException message contains offending input substring

## Acceptance criteria coverage

- AC 1: ✓ addressed in `lib/core/utils/semver.dart` - function signature is exactly `int compareSemVer(String a, String b)`
- AC 2: ✓ addressed in `lib/core/utils/semver.dart` - numeric comparison of major→minor→patch (uses int.compareTo)
- AC 3: ✓ addressed in `lib/core/utils/semver.dart` lines 22-23 - missing components default to 0
- AC 4: ✓ addressed in `lib/core/utils/semver.dart` lines 22-23 - only first 3 components are parsed
- AC 5: ✓ addressed in `lib/core/utils/semver.dart` lines 53-62 - returns signed comparison results; tests use isNegative/isPositive/equals(0)
- AC 6: ✓ addressed in `lib/core/utils/semver.dart` lines 13-14, 27-30 - throws FormatException on empty/whitespace/non-numeric input
- AC 7: ✓ addressed in `lib/core/utils/semver.dart` line 29 - FormatException message includes original input verbatim; tested in `test/core/utils/semver_test.dart`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ not violated - only 2 files changed
- Do NOT add third-party dependencies unless required by the task body: ✓ not violated - no new dependencies
- Do NOT refactor unrelated code in the touched files: ✓ not violated - only new files created

## Notes

Implementation follows the Dart/Flutter coding constitution and matches the pattern seen in `lib/core/utils/formatters.dart`. The solution is pure Dart standard library with no external dependencies.

### Coverage

1. "Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`": ✓ addressed in `lib/core/utils/semver.dart` line 48
2. "Accepts versions of the form `MAJOR.MINOR.PATCH` and compares major → minor → patch NUMERICALLY": ✓ addressed in `lib/core/utils/semver.dart` lines 53-62
3. "A short version (e.g. `1.2`) is treated as `1.2.0`": ✓ addressed in `lib/core/utils/semver.dart` lines 22-23
4. "A version with extra trailing components (e.g. `1.2.3.4`) is treated as `1.2.3`": ✓ addressed in `lib/core/utils/semver.dart` lines 22-23
5. "Return value contract mirrors `Comparable.compareTo`": ✓ addressed in `lib/core/utils/semver.dart` lines 53-62; tests use isNegative/isPositive/equals(0)
6. "**Malformed input throws `FormatException`": ✓ addressed in `lib/core/utils/semver.dart` lines 13-14, 27-30
7. "**The `FormatException` message MUST include the offending input string verbatim": ✓ addressed in `lib/core/utils/semver.dart` line 29; tested in `test/core/utils/semver_test.dart`