### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,33 @@
+/// Extensions for [List] collections.
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The returned chunks are independent copies - mutating a chunk will not
+  /// affect the original list.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Example:
+  /// ```dart
+  /// [1, 2, 3, 4, 5].chunked(2) // [[1, 2], [3, 4], [5]]
+  /// [1, 2, 3].chunked(10) // [[1, 2, 3]]
+  /// [].chunked(3) // []
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('size must be >= 1, was $size');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final result = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      final end = (i + size < length) ? i + size : length;
+      result.add(sublist(i, end));
+    }
+
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList.chunked', () {
+    test('happy path splits list into chunks of specified size', () {
+      final input = [1, 2, 3, 4, 5];
+      final result = input.chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('chunk size equal to list length returns single chunk', () {
+      final input = [1, 2, 3];
+      final result = input.chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('chunk size greater than list length returns single chunk', () {
+      final input = [1, 2, 3];
+      final result = input.chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('empty list returns empty list', () {
+      final input = <int>[];
+      final result = input.chunked(3);
+      expect(result, []);
+    });
+
+    test('single element with size 1 returns [[element]]', () {
+      final input = [1];
+      final result = input.chunked(1);
+      expect(result, [[1]]);
+    });
+
+    test('throws ArgumentError when size is 0', () {
+      final input = [1, 2, 3];
+      expect(() => input.chunked(0), throwsArgumentError);
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      final input = [1, 2, 3];
+      expect(() => input.chunked(-1), throwsArgumentError);
+    });
+
+    test('returned chunks are independent of original list', () {
+      final input = [1, 2, 3, 4];
+      final chunks = input.chunked(2);
+      
+      // Mutate the first element of the first chunk
+      chunks.first[0] = 999;
+      
+      // Original list should be unchanged
+      expect(input[0], 1);
+      expect(chunks.first[0], 999);
+    });
+
+    test('returned chunks are independent of each other', () {
+      final input = [1, 2, 3, 4];
+      final chunks = input.chunked(2);
+      
+      // Mutate the first chunk
+      chunks[0][0] = 999;
+      
+      // Second chunk should be unchanged
+      expect(chunks[1][0], 3);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #176

## What changed

- Added  with  extension
- Implemented  method that splits lists into consecutive sub-lists
- Added  with comprehensive tests

## How verified

Exact commands run (from the card's `verification` field) and their output digest:

```bash
cd ~/workspace/infiquetra/mimir
flutter test

dart analyze lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart
```

Output:
- All tests passed (17 total: 9 in new test file + 8 in existing)
- No analyzer issues found

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes)
  - ✓ Addressed in lib/core/utils/list_extensions.dart: 
  - ✓ Validates size >= 1, throws ArgumentError when size < 1
  - ✓ Empty list returns empty list
  - ✓ Last chunk may be smaller than size
  - ✓ Returns independent copies using sublist()

- AC 2: All named tests pass the verification command
  - ✓ Addressed in test/core/utils/list_extensions_test.dart
  - ✓ Happy path:  → 
  - ✓ Boundary: chunk size equals list length
  - ✓ Boundary: chunk size greater than list length
  - ✓ Empty list
  - ✓ Single element
  - ✓ ArgumentError on size=0 (and negative values)
  - ✓ Bonus: chunk independence assertion

- AC 3: No dependencies added unless absolutely required
  - ✓ Addressed: No pubspec.yaml changes, used only Dart core collections APIs

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

- Followed existing test patterns from formatters_test.dart (package:flutter_test, group/test structure)
- Verified chunk independence with dedicated test cases ensuring mutations don't propagate
- Implementation is ~33 lines, tests ~69 lines, total ~102 lines (under scope limit)