### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,34 @@
+/// Utility extension for splitting lists into chunks.
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Returns a list of chunks, each containing up to [size] elements.
+  /// The final chunk may have fewer than [size] elements if the original
+  /// list length is not a multiple of [size].
+  ///
+  /// Throws an [ArgumentError] if [size] is less than 1.
+  ///
+  /// Examples:
+  /// ```dart
+  /// [1, 2, 3, 4, 5].chunked(2) // [[1, 2], [3, 4], [5]]
+  /// [1, 2, 3].chunked(10)       // [[1, 2, 3]]
+  /// [].chunked(3)               // []
+  /// [1].chunked(1)              // [[1]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('size must be >= 1, but was $size');
+    }
+
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final result = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = start + size < length ? start + size : length;
+      result.add(sublist(start, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('chunked', () {
+    test('splits a list into consecutive chunks', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [
+        [1, 2],
+        [3, 4],
+        [5]
+      ]);
+      expect([1, 2, 3, 4, 5, 6].chunked(3), [
+        [1, 2, 3],
+        [4, 5, 6]
+      ]);
+      expect([1, 2, 3].chunked(2), [
+        [1, 2],
+        [3]
+      ]);
+    });
+
+    test('returns a single chunk when size equals list length', () {
+      expect([1, 2, 3].chunked(3), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('returns a single chunk when size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('returns an empty list for empty input', () {
+      expect(<int>[].chunked(3), []);
+    });
+
+    test('returns a single-element chunk for a one-item list', () {
+      expect([42].chunked(1), [
+        [42]
+      ]);
+    });
+
+    test('returns independent chunk lists', () {
+      final original = [1, 2, 3, 4];
+      final chunks = original.chunked(2);
+
+      expect(chunks, [
+        [1, 2],
+        [3, 4]
+      ]);
+
+      // Modify a chunk and ensure the original list is unchanged
+      chunks[0][0] = 99;
+      expect(original, [1, 2, 3, 4]);
+
+      // Also ensure modifying the original list does not affect the chunk
+      original[0] = 100;
+      expect(chunks[0], [99, 2]);
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+      expect(() => [].chunked(0), throwsArgumentError);
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+      expect(() => [].chunked(-5), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #179

## What changed

- Created `lib/core/utils/list_extensions.dart` with extension `ChunkedList<T>` providing `chunked(int size)` method
- Created `test/core/utils/list_extensions_test.dart` with 8 test cases covering:
  - Happy path splits (`[1,2,3,4,5].chunked(2)`)
  - Edge cases: size equals length, size exceeds length, empty list, single-element list
  - Independent chunk guarantee (mutating a chunk does not affect original list; mutating original does not affect chunks)
  - Validation: throws `ArgumentError` for `size = 0` and `size < 0`

## How verified

Exact commands run (from the card's `verification` field) and their output digest:

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```
Output: 8 tests passed.

```bash
flutter test
```
Output: 16 tests total passed (existing widget tests + new extension tests).

Both commands exited with code 0.

## Acceptance criteria coverage

- AC: Implementation matches all behaviors described in the task body (see Notes) ✓ addressed in `lib/core/utils/list_extensions.dart` lines 12–38 and validated by tests in `test/core/utils/list_extensions_test.dart`
- AC: All named tests pass the verification command ✓ verified by `flutter test test/core/utils/list_extensions_test.dart` (8/8 passing) and `flutter test` (16/16 passing)
- AC: No dependencies added unless absolutely required ✓ no changes to `pubspec.yaml` or new imports beyond `package:flutter_test` in test file

## Non-goals acknowledged

Each non-goal from the linked card, confirmed not violated:

- Do NOT modify files beyond the expected set below — not violated; only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` were touched.
- Do NOT add third-party dependencies unless required by the task body — not violated; no dependencies added.
- Do NOT refactor unrelated code in the touched files — not violated; files created fresh with only the required extension and tests.

## Notes

No deviations from plan. Implementation strictly follows signature `extension ChunkedList<T> on List<T> { List<List<T>> chunked(int size) }` with size validation, empty‑list handling, independent chunks via `sublist`, and the exact test cases described.
