### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,56 @@
+
+
+
+
+
+
+
+
+/// String manipulation utilities.
+
+/// Shortens a string by replacing the middle with an ellipsis.
+///
+/// If [input] length ≤ [maxLength], returns [input] unchanged.
+/// Otherwise, replaces characters in the middle with [ellipsis],
+/// keeping as many characters from the start and end as possible,
+/// such that the resulting string length ≤ [maxLength].
+///
+/// The [ellipsis] length counts against [maxLength]; if [maxLength]
+/// is shorter than [ellipsis].length, only the first [maxLength]
+/// characters of [ellipsis] are used.
+///
+/// When [maxLength] - [ellipsis].length is odd, the leftover
+/// character is given to the start side.
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abcd…lmn'`
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'`
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // If input fits within maxLength, return unchanged.
+  if (input.length <= maxLength) return input;
+
+  // If maxLength is non-positive, nothing can be shown.
+  if (maxLength <= 0) return '';
+
+  // If maxLength is shorter than ellipsis, use only the first maxLength chars.
+  final effectiveEllipsis = ellipsis.length > maxLength
+      ? ellipsis.substring(0, maxLength)
+      : ellipsis;
+
+  // If the ellipsis alone fills the entire maxLength, there's no room for input.
+  if (effectiveEllipsis.length == maxLength) return effectiveEllipsis;
+
+  final remaining = maxLength - effectiveEllipsis.length;
+
+  // Split visible characters between start and end, giving the extra
+  // character to the start when remaining is odd.
+  final leadingLength = (remaining + 1) ~/ 2;
+  final trailingLength = remaining ~/ 2;
+
+  final start = input.substring(0, leadingLength);
+  final end = input.substring(input.length - trailingLength);
+
+  return start + effectiveEllipsis + end;
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,74 @@
+
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('abc', 3), 'abc');
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns empty when maxLength <= 0', () {
+      expect(truncateMiddle('hello', 0), '');
+      expect(truncateMiddle('world', -1), '');
+      expect(truncateMiddle('', 0), '');
+    });
+
+    test('truncates the middle and preserves both ends', () {
+      // Example from spec – allocate‑odd‑to‑start yields 'abcd…lmn' (not 'abc…lmn')
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abcd…lmn');
+      // Additional cases
+      expect(truncateMiddle('1234567890', 6), '123…90');
+      expect(truncateMiddle('abcdefgh', 5), 'ab…gh');
+    });
+
+    test('counts multi‑character ellipsis against maxLength', () {
+      // When input fits within maxLength, it's returned unchanged per spec
+      expect(truncateMiddle('abcdefgh', 8, ellipsis: '...'), 'abcdefgh');
+      // Truncation cases where input exceeds maxLength
+      expect(truncateMiddle('1234567890', 7, ellipsis: '...'), '12...90');
+      expect(truncateMiddle('abcdefghijklmnop', 10, ellipsis: '...'), 'abcd...nop');
+    });
+
+    test('returns truncated ellipsis when maxLength is shorter than ellipsis', () {
+      expect(truncateMiddle('hello', 2, ellipsis: '...'), '..');
+      expect(truncateMiddle('world', 1, ellipsis: '…'), '…');
+      // Empty input with maxLength=1 returns '' per spec (input.length <= maxLength)
+      expect(truncateMiddle('', 1, ellipsis: '...'), '');
+    });
+
+    test('distributes odd visible‑budget extra character to the start', () {
+      // maxLength=3, ellipsis='…'(length=1), visibleBudget=2 → 2 visible chars
+      // leadingLength=(2+1)~/2=1, trailingLength=2~/2=1 → "a" + "…" + "f"
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+      // Additional odd‑budget example
+      expect(truncateMiddle('1234567', 5), '12…67'); // maxLength=5, ellipsis length=1, visibleBudget=4 → leadingLength=2, trailingLength=2
+    });
+
+    test('result length never exceeds maxLength', () {
+      final cases = [
+        ['hello', 10],
+        ['abcdefghijklmn', 8],
+        ['', 5],
+        ['abcdef', 3],
+        ['1234567890', 6],
+        ['abcdefgh', 5],
+        ['abcdefgh', 8, '...'],
+        ['hello', 2, '...'],
+        ['world', 1, '…'],
+        ['', 1, '...'],
+      ];
+      for (final c in cases) {
+        final input = c[0] as String;
+        final maxLength = c[1] as int;
+        final ellipsis = c.length > 2 ? c[2] as String : '…';
+        final result = truncateMiddle(input, maxLength, ellipsis: ellipsis);
+        expect(result.length <= maxLength, isTrue,
+            reason: 'Input "$input", maxLength $maxLength, result "$result" length ${result.length}');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #182

## What changed

- Created `lib/core/utils/string_utils.dart` with `truncateMiddle()` function
- Created `test/core/utils/string_utils_test.dart` with 7 test cases covering:
  - Unchanged short strings (input.length <= maxLength)
  - Middle truncation with prefix/suffix preservation
  - Empty input handling
  - maxLength <= 0 edge case
  - Multi-character ellipsis counting toward maxLength
  - Truncated ellipsis when maxLength < ellipsis.length
  - Odd visible-budget distribution (extra char to start)
  - Length invariant (result.length <= maxLength)

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
```

Output:
```
00:00 +7: All tests passed!
```

```bash
dart analyze lib/core/utils/string_utils.dart
```

Output: 1 info (dangling_library_doc_comments - minor style, not an error)

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/string_utils.dart` - `truncateMiddle()` function
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/string_utils_test.dart` - 7 tests, all passing
- AC 3 (No dependencies added unless absolutely required): ✓ no dependencies added - uses only core Dart string operations

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only 2 files changed
- Do NOT add third-party dependencies unless required by the task body: not violated - no new deps
- Do NOT refactor unrelated code in the touched files: not violated - new files only

## Notes

- Implementation uses prefix-biased split for odd visible budgets: `startLength = (remaining + 1) ~/ 2`
- Per spec: if `input.length <= maxLength`, returns input unchanged (even when custom ellipsis is provided)
- The test `truncateMiddle('abcdefgh', 8, ellipsis: '...')` returns `'abcdefgh'` unchanged because input fits within maxLength

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in lib/core/utils/string_utils.dart - truncateMiddle()
- AC 2 (All named tests pass the verification command): ✓ addressed in test/core/utils/string_utils_test.dart - 7 passing tests
- AC 3 (No dependencies added unless absolutely required): ✓ addressed - no pubspec.yaml changes