### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,18 @@
+extension ChunkedList<T> on List<T> {
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('size must be >= 1, got $size');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final result = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      final end = i + size > length ? length : i + size;
+      result.add(sublist(i, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('chunked', () {
+    test('splits a list into consecutive chunks of the requested size', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [[1, 2], [3, 4], [5]]);
+    });
+
+    test('returns one chunk when chunk size equals list length', () {
+      expect([1, 2, 3].chunked(3), [[1, 2, 3]]);
+    });
+
+    test('returns one chunk when chunk size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), [[1, 2, 3]]);
+    });
+
+    test('returns an empty list for an empty source list', () {
+      expect([].chunked(3), []);
+    });
+
+    test('returns a single-element chunk for a single-element list', () {
+      expect([1].chunked(1), [[1]]);
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('returned chunks are independent of the source list', () {
+      final source = [1, 2, 3, 4, 5];
+      final chunks = source.chunked(2);
+      chunks[0][0] = 999;
+      expect(source, [1, 2, 3, 4, 5]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #183

## What changed

- Created `lib/core/utils/list_extensions.dart` with `ChunkedList<T>` extension
- Implemented `chunked(int size)` method that splits lists into consecutive sub-lists
- Added guard throwing `ArgumentError` when size < 1
- Used `sublist()` to ensure returned chunks are independent copies
- Created `test/core/utils/list_extensions_test.dart` with 7 test cases covering:
  - Happy path (consecutive chunks)
  - Chunk size equals list length
  - Chunk size exceeds list length
  - Empty list returns empty list
  - Single element list
  - ArgumentError on size = 0
  - Chunk independence (mutation test)

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
# 00:00 +7: All tests passed!

flutter test
# 00:01 +15: All tests passed!

dart analyze lib/core/utils/list_extensions.dart
# No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/list_extensions.dart` - `chunked(int size)` method with ArgumentError guard, empty list handling, and independent chunks via sublist()
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/list_extensions_test.dart` - 7 tests covering all named cases, all passing
- AC 3 (No dependencies added unless absolutely required): ✓ addressed - implementation uses only Dart core list operations, no new dependencies

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated - only touched `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart`
- Do NOT add third-party dependencies unless required by the task body: not violated - no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - new files only, no refactoring

## Notes

None - implementation follows the approved plan exactly.

### Coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- AC 2: All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- AC 3: No dependencies added unless absolutely required: ✓ addressed - no new dependencies