### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,74 @@
+/// Utility functions for semantic version comparison.
+
+/// Compares two semantic version strings and returns a comparator-style integer.
+///
+/// Returns a negative value if [a] < [b], zero if equal, or a positive value if [a] > [b].
+///
+/// Versions are compared numerically component by component (major, minor, patch).
+/// Short versions (e.g., '1.2') are padded with zeros (becomes '1.2.0').
+/// Extra components beyond patch are ignored (e.g., '1.2.3.4' treated as '1.2.3').
+///
+/// Throws [FormatException] if either version string is malformed:
+/// - Empty or whitespace-only string
+/// - Non-numeric component (e.g., '1.2.a')
+/// - Empty component (e.g., '1..2' or '.1.2')
+///
+/// The exception message includes the offending input string verbatim.
+///
+/// Examples:
+/// - `compareSemVer('1.2.3', '1.2.3')` → `0`
+/// - `compareSemVer('1.2.3', '1.2.4')` → negative
+/// - `compareSemVer('1.10.0', '1.2.0')` → positive (numeric comparison)
+/// - `compareSemVer('1.2', '1.2.0')` → `0` (short form pads with zero)
+/// - `compareSemVer('1.2.3.4', '1.2.3')` → `0` (extra components ignored)
+int compareSemVer(String a, String b) {
+  final aParts = _parseVersion(a);
+  final bParts = _parseVersion(b);
+
+  // Compare major
+  final majorCompare = aParts[0].compareTo(bParts[0]);
+  if (majorCompare != 0) return majorCompare;
+
+  // Compare minor
+  final minorCompare = aParts[1].compareTo(bParts[1]);
+  if (minorCompare != 0) return minorCompare;
+
+  // Compare patch
+  return aParts[2].compareTo(bParts[2]);
+}
+
+/// Parses a version string into exactly three numeric components [major, minor, patch].
+///
+/// Throws [FormatException] with the original input in the message if:
+/// - Input is empty or whitespace-only
+/// - Any of the first three components is empty or non-numeric
+List<int> _parseVersion(String input) {
+  // Validate input is not empty or whitespace-only
+  if (input.trim().isEmpty) {
+    throw FormatException('Invalid version string: "$input" (empty or whitespace-only)');
+  }
+
+  final parts = input.split('.');
+  final result = <int>[];
+
+  for (int i = 0; i < 3; i++) {
+    if (i >= parts.length) {
+      // Pad missing components with zero
+      result.add(0);
+    } else {
+      final component = parts[i];
+      // Check for empty component (e.g., '1..2' or '.1.2')
+      if (component.isEmpty) {
+        throw FormatException('Invalid version string: "$input" (empty component at position $i)');
+      }
+      // Check for non-numeric component
+      final parsed = int.tryParse(component);
+      if (parsed == null) {
+        throw FormatException('Invalid version string: "$input" (non-numeric component: "$component")');
+      }
+      result.add(parsed);
+    }
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    group('equal versions', () {
+      test('returns zero for identical versions', () {
+        expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+      });
+
+      test('returns zero for short form padded version', () {
+        expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      });
+
+      test('returns zero when extra components are ignored', () {
+        expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      });
+    });
+
+    group('major difference', () {
+      test('returns negative when a has smaller major', () {
+        expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+      });
+
+      test('returns positive when a has larger major', () {
+        expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+      });
+    });
+
+    group('minor difference', () {
+      test('returns negative when a has smaller minor', () {
+        expect(compareSemVer('1.2.0', '1.3.0'), isNegative);
+      });
+
+      test('returns positive when a has larger minor', () {
+        expect(compareSemVer('1.3.0', '1.2.0'), isPositive);
+      });
+    });
+
+    group('patch difference', () {
+      test('returns negative when a has smaller patch', () {
+        expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+      });
+
+      test('returns positive when a has larger patch', () {
+        expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      });
+    });
+
+    group('numeric ordering', () {
+      test('compares numerically not lexicographically', () {
+        expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      });
+
+      test('handles large version numbers correctly', () {
+        expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      });
+    });
+
+    group('malformed input', () {
+      test('throws FormatException for non-numeric component', () {
+        expect(
+          () => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('FormatException message contains offending input for non-numeric component', () {
+        expect(
+          () => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('1.2.a'),
+            ),
+          ),
+        );
+      });
+
+      test('throws FormatException for empty string', () {
+        expect(
+          () => compareSemVer('', '1.2.3'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('FormatException message contains offending input for empty string', () {
+        expect(
+          () => compareSemVer('', '1.2.3'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains(''),
+            ),
+          ),
+        );
+      });
+
+      test('throws FormatException for whitespace-only string', () {
+        expect(
+          () => compareSemVer('   ', '1.2.3'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('FormatException message contains offending input for whitespace-only string', () {
+        expect(
+          () => compareSemVer('   ', '1.2.3'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('   '),
+            ),
+          ),
+        );
+      });
+
+      test('throws FormatException for empty component', () {
+        expect(
+          () => compareSemVer('1..2', '1.2.3'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('FormatException message contains offending input for empty component', () {
+        expect(
+          () => compareSemVer('1..2', '1.2.3'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('1..2'),
+            ),
+          ),
+        );
+      });
+
+      test('throws FormatException for leading dot (empty first component)', () {
+        expect(
+          () => compareSemVer('.1.2', '1.2.3'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('FormatException message contains offending input for leading dot', () {
+        expect(
+          () => compareSemVer('.1.2', '1.2.3'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('.1.2'),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #185

## What changed

- Created `lib/core/utils/semver.dart` with `compareSemVer(String a, String b)` function
- Created `test/core/utils/semver_test.dart` with comprehensive test coverage
- Compares semantic versions numerically (major → minor → patch)
- Short versions padded with zeros (e.g., `"1.2"` → `"1.2.0"`)
- Extra components beyond patch ignored (e.g., `"1.2.3.4"` → `"1.2.3"`)
- Throws `FormatException` with offending input verbatim in message for malformed versions

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

Output:
```
00:00 +21: All tests passed!
```

```bash
flutter test
```

Output:
```
00:02 +29: All tests passed!
```

```bash
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

Output:
```
1 issue found (info-level only: dangling_library_doc_comments)
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body → ✓ addressed in `lib/core/utils/semver.dart` (compareSemVer function with exact signature)
- AC 2: All named tests pass the verification command → ✓ addressed in `test/core/utils/semver_test.dart` (21 tests covering all scenarios)
- AC 3: No dependencies added unless absolutely required → ✓ addressed (no pubspec.yaml changes, pure Dart implementation)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ not violated (only semver.dart and semver_test.dart modified)
- Do NOT add third-party dependencies unless required by the task body: ✓ not violated (no dependencies added)
- Do NOT refactor unrelated code in the touched files: ✓ not violated (new files only, no refactoring)

## Notes

None. Implementation follows the approved plan exactly.

### Coverage

- AC 1 (verbatim): Implementation matches all behaviors described in the task body → ✓ addressed in lib/core/utils/semver.dart (compareSemVer function)
- AC 2 (verbatim): All named tests pass the verification command → ✓ addressed in test/core/utils/semver_test.dart (21 tests pass)
- AC 3 (verbatim): No dependencies added unless absolutely required → ✓ addressed (no dependency changes)
