### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,21 @@
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('Chunk size must be at least 1');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final List<List<T>> chunks = [];
+    for (var i = 0; i < length; i += size) {
+      chunks.add(sublist(i, i + size > length ? length : i + size));
+    }
+
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList.chunked', () {
+    test('happy path: splits list into specified sizes', () {
+      final list = [1, 2, 3, 4, 5];
+      final result = list.chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('mutation safety: returned chunks are independent copies', () {
+      final list = [1, 2, 3, 4];
+      final result = list.chunked(2);
+      
+      // Mutate a chunk
+      result[0][0] = 99;
+      
+      expect(list[0], 1, reason: 'Original list should not be mutated');
+    });
+
+    test('boundary: chunk size equals list length', () {
+      final list = [1, 2, 3];
+      final result = list.chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('boundary: chunk size exceeds list length', () {
+      final list = [1, 2, 3];
+      final result = list.chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('empty list returns empty list', () {
+      final list = <int>[];
+      final result = list.chunked(3);
+      expect(result, <List<int>>[]);
+    });
+
+    test('single element list', () {
+      final list = [1];
+      final result = list.chunked(1);
+      expect(result, [[1]]);
+    });
+
+    test('throws ArgumentError when size is 0', () {
+      final list = [1, 2, 3];
+      expect(() => list.chunked(0), throwsA(isA<ArgumentError>()));
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      final list = [1, 2, 3];
+      expect(() => list.chunked(-1), throwsA(isA<ArgumentError>()));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #193

## What changed

- Created `lib/core/utils/list_extensions.dart` adding `extension ChunkedList<T> on List<T>` with a `chunked(int size)` method.
- Created `test/core/utils/list_extensions_test.dart` containing 8 test cases covering happy path, boundary conditions, empty lists, and error handling.

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```

Output:
All tests passed! (8 tests)

## Acceptance criteria coverage

- AC 1: Implementation of `chunked` in `lib/core/utils/list_extensions.dart` matches all behavioral requirements including `ArgumentError` for size < 1 and independent returned chunks.
- AC 2: All named tests in `test/core/utils/list_extensions_test.dart` passed via `flutter test`.
- AC 3: No new dependencies added; uses standard Dart/Flutter test framework.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated.
- Do NOT add third-party dependencies: not violated.
- Do NOT refactor unrelated code: not violated.

## Notes

None.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/list_extensions.dart`
- All named tests pass the verification command: ✓ addressed in `test/core/utils/list_extensions_test.dart`
- No dependencies added unless absolutely required: ✓ addressed in `pubspec.yaml` (no changes)