### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,48 @@
+import 'dart:core';
+
+/// Compares two semantic version strings.
+///
+/// Returns a negative value if [a] < [b], zero if [a] == [b], and a positive value if [a] > [b].
+///
+/// Supports versions in the form MAJOR.MINOR.PATCH.
+/// - Short versions (e.g., '1.2') are padded with zeros (e.g., '1.2.0').
+/// - Extra components beyond the patch (e.g., '1.2.3.4') are ignored.
+/// - Throws [FormatException] if the input is malformed (empty, whitespace, or non-numeric components).
+int compareSemVer(String a, String b) {
+  final partsA = _parseVersion(a);
+  final partsB = _parseVersion(b);
+
+  for (int i = 0; i < 3; i++) {
+    final diff = partsA[i].compareTo(partsB[i]);
+    if (diff != 0) return diff;
+  }
+
+  return 0;
+}
+
+List<int> _parseVersion(String version) {
+  if (version.trim().isEmpty) {
+    throw FormatException('Malformed version string: "$version"');
+  }
+
+  final segments = version.split('.');
+  final parsed = <int>[];
+
+  for (int i = 0; i < 3; i++) {
+    if (i < segments.length) {
+      final segment = segments[i];
+      if (segment.isEmpty) {
+        throw FormatException('Malformed version string: "$version"');
+      }
+      final val = int.tryParse(segment);
+      if (val == null) {
+        throw FormatException('Malformed version string: "$version"');
+      }
+      parsed.add(val);
+    } else {
+      parsed.add(0);
+    }
+  }
+
+  return parsed;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('Equal versions should return 0', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('Major version difference should return correct sign', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('Minor version difference should return correct sign', () {
+      expect(compareSemVer('1.2.0', '1.1.0'), isPositive);
+      expect(compareSemVer('1.1.0', '1.2.0'), isNegative);
+    });
+
+    test('Patch version difference should return correct sign', () {
+      expect(compareSemVer('1.2.1', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.2.1'), isNegative);
+    });
+
+    test('Numeric ordering (1.10.0 > 1.2.0)', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('Short-form padding (1.2 == 1.2.0)', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('Extra-component truncation (1.2.3.4 == 1.2.3)', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('Malformed input should throw FormatException', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer(' ', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1..2', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message should contain offending input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+      expect(
+        () => compareSemVer('1.2.3', 'b.2.3'),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('b.2.3'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #194

## What changed

- Created \`lib/core/utils/semver.dart\` containing \`compareSemVer(String a, String b)\`.
- Created \`test/core/utils/semver_test.dart\` with comprehensive test coverage for comparison logic, padding, truncation, and malformed input handling.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
\`\`\`
Output: All tests passed! (9 tests)

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) - Verified by unit tests covering all edge cases.
- AC 2: All named tests pass the verification command - Passed \`flutter test\`.
- AC 3: No dependencies added unless absolutely required - No new dependencies added.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated.
- Do NOT add third-party dependencies unless required by the task body: not violated.
- Do NOT refactor unrelated code in the touched files: not violated.

## Notes

None.

### Coverage

- Signature is exactly \`int compareSemVer(String a, String b)\` and lives in \`lib/core/utils/semver.dart\`: ✓ addressed in \`lib/core/utils/semver.dart\`
- Accepts versions of the form \`MAJOR.MINOR.PATCH\` and compares major → minor → patch NUMERICALLY: ✓ addressed in \`lib/core/utils/semver.dart\` / \`test/core/utils/semver_test.dart\`
- A short version (e.g. \`1.2\`) is treated as \`1.2.0\`: ✓ addressed in \`lib/core/utils/semver.dart\` / \`test/core/utils/semver_test.dart\`
- A version with extra trailing components (e.g. \`1.2.3.4\`) is treated as \`1.2.3\`: ✓ addressed in \`lib/core/utils/semver.dart\` / \`test/core/utils/semver_test.dart\`
- Return value contract mirrors \`Comparable.compareTo\`: ✓ addressed in \`test/core/utils/semver_test.dart\`
- Malformed input throws \`FormatException\`: ✓ addressed in \`lib/core/utils/semver.dart\` / \`test/core/utils/semver_test.dart\`
- The \`FormatException\` message MUST include the offending input string verbatim: ✓ addressed in \`lib/core/utils/semver.dart\` / \`test/core/utils/semver_test.dart\`