### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,51 @@
+import 'dart:core';
+
+/// Compares two semantic version strings numerically.
+/// 
+/// Returns:
+/// - A negative integer if [a] < [b]
+/// - Zero if [a] == [b]
+/// - A positive integer if [a] > [b]
+/// 
+/// Throws [FormatException] if either input is malformed (empty, whitespace-only,
+/// or contains non-numeric components in the first three segments).
+int compareSemVer(String a, String b) {
+  final List<int> versionA = _parseVersion(a);
+  final List<int> versionB = _parseVersion(b);
+
+  for (int i = 0; i < 3; i++) {
+    final int diff = versionA[i].compareTo(versionB[i]);
+    if (diff != 0) {
+      return diff;
+    }
+  }
+
+  return 0;
+}
+
+List<int> _parseVersion(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed version string: "$input"');
+  }
+
+  final parts = input.split('.');
+  final List<int> components = [];
+
+  for (int i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final part = parts[i];
+      if (part.isEmpty) {
+        throw FormatException('Malformed version string: "$input"');
+      }
+      final parsed = int.tryParse(part);
+      if (parsed == null) {
+        throw FormatException('Malformed version string: "$input"');
+      }
+      components.add(parsed);
+    } else {
+      components.add(0);
+    }
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions return 0', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('major difference return sign', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('minor difference return sign', () {
+      expect(compareSemVer('1.1.0', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '1.1.0'), isNegative);
+    });
+
+    test('patch difference return sign', () {
+      expect(compareSemVer('1.0.1', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '1.0.1'), isNegative);
+    });
+
+    test('numeric ordering (1.10.0 > 1.2.0)', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('short-form padding (1.2 == 1.2.0)', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('extra-component truncation (1.2.3.4 == 1.2.3)', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('malformed input throws FormatException', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('  ', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1..3', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message contains offending input verbatim', () {
+      final badInput = '1.2.a';
+      expect(
+        () => compareSemVer(badInput, '1.2.3'),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains(badInput))),
+      );
+
+      final badInput2 = '  ';
+      expect(
+        () => compareSemVer('1.2.3', badInput2),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains(badInput2))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #194

## What changed

- Created `lib/core/utils/semver.dart` implementing `int compareSemVer(String a, String b)`.
- Implemented numeric comparison of MAJOR.MINOR.PATCH components.
- Added logic to pad missing components with zero (e.g., '1.2' -> '1.2.0').
- Added logic to truncate components beyond patch (e.g., '1.2.3.4' -> '1.2.3').
- Added input validation that throws `FormatException` containing the offending string for empty, whitespace, or non-numeric inputs.
- Created `test/core/utils/semver_test.dart` covering all requirements including sign-only assertions and exception message verification.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
\`\`\`
Output: 9 tests passed.

## Acceptance criteria coverage

- AC 1: Signature `int compareSemVer(String a, String b)` is implemented in `lib/core/utils/semver.dart`.
- AC 2: Numeric comparison verified by `1.10.0 > 1.2.0` test case.
- AC 3: Short-form padding verified by `1.2 == 1.2.0` test case.
- AC 4: Extra-component truncation verified by `1.2.3.4 == 1.2.3` test case.
- AC 5: Sign-only contract followed using `isPositive`/`isNegative`/`equals(0)` in tests.
- AC 6: `FormatException` thrown on malformed input verified in tests.
- AC 7: `FormatException` message includes offending input verified using `.having()` in tests.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated. Only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were touched.
- Do NOT add third-party dependencies: not violated.
- Do NOT refactor unrelated code: not violated.

## Notes

No deviations from the approved plan.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/semver.dart`.
- All named tests pass the verification command: ✓ addressed in `test/core/utils/semver_test.dart`.
- No dependencies added unless absolutely required: ✓ addressed (no changes to `pubspec.yaml`).