### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,79 @@
+/// Utility functions for semantic version comparison.
+///
+/// Provides a [compareSemVer] function that compares two semantic version
+/// strings and returns a comparator-style integer: negative if a < b,
+/// zero if a == b, positive if a > b.
+
+library semver;
+
+/// Compares two semantic version strings.
+///
+/// Accepts versions of the form MAJOR.MINOR.PATCH (e.g. "1.2.3") and compares
+/// major → minor → patch NUMERICALLY (not lexicographically), so "1.10.0 > 1.2.0".
+///
+/// A short version (e.g. "1.2") is treated as "1.2.0" — missing components
+/// default to zero.
+///
+/// A version with extra trailing components (e.g. "1.2.3.4") is treated as
+/// "1.2.3" — components beyond patch are ignored.
+///
+/// Returns:
+/// - Negative integer if [a] < [b]
+/// - Zero if [a] == [b]
+/// - Positive integer if [a] > [b]
+///
+/// Throws [FormatException] if either version string is malformed:
+/// - Empty or whitespace-only
+/// - Contains non-numeric components (e.g. "1.2.a")
+/// - Contains signed components (e.g. "-1.2.3" or "+1.2.3")
+int compareSemVer(String a, String b) {
+  final aParts = _parseVersion(a);
+  final bParts = _parseVersion(b);
+
+  // Compare major, minor, patch in order
+  final majorDiff = aParts[0].compareTo(bParts[0]);
+  if (majorDiff != 0) return majorDiff;
+
+  final minorDiff = aParts[1].compareTo(bParts[1]);
+  if (minorDiff != 0) return minorDiff;
+
+  final patchDiff = aParts[2].compareTo(bParts[2]);
+  return patchDiff;
+}
+
+/// Parses a semantic version string and returns a normalized 3-element list.
+///
+/// Throws [FormatException] if the input is malformed (empty, whitespace-only,
+/// or contains non-numeric components).
+List<int> _parseVersion(String input) {
+  // Reject empty or whitespace-only input
+  if (input.isEmpty || input.trim().isEmpty) {
+    throw FormatException(
+        'Invalid version string: expected semantic version (e.g. "1.2.3"), got "$input"');
+  }
+
+  final trimmed = input.trim();
+  final parts = trimmed.split('.');
+
+  // Only inspect first three components (major, minor, patch)
+  // Pad missing positions with 0
+  final normalized = List<int>.filled(3, 0);
+
+  for (int i = 0; i < 3; i++) {
+    if (i >= parts.length) {
+      break;
+    }
+
+    final component = parts[i];
+
+    // Require decimal digits only - reject signed values, empty strings, etc.
+    if (component.isEmpty || !RegExp(r'^\d+$').hasMatch(component)) {
+      throw FormatException(
+          'Invalid version string: component "$component" in "$input" is not a valid non-negative integer');
+    }
+
+    normalized[i] = int.parse(component);
+  }
+
+  return normalized;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    // Equal versions
+    test('returns 0 for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+      expect(compareSemVer('0.0.0', '0.0.0'), equals(0));
+      expect(compareSemVer('10.20.30', '10.20.30'), equals(0));
+    });
+
+    // Major difference
+    test('returns negative when a has smaller major version', () {
+      expect(compareSemVer('1.2.3', '2.0.0'), isNegative);
+    });
+
+    test('returns positive when a has larger major version', () {
+      expect(compareSemVer('2.0.0', '1.2.3'), isPositive);
+    });
+
+    // Minor difference
+    test('returns negative when a has smaller minor version', () {
+      expect(compareSemVer('1.1.3', '1.2.0'), isNegative);
+    });
+
+    test('returns positive when a has larger minor version', () {
+      expect(compareSemVer('1.2.0', '1.1.3'), isPositive);
+    });
+
+    // Patch difference
+    test('returns negative when a has smaller patch version', () {
+      expect(compareSemVer('1.2.2', '1.2.3'), isNegative);
+    });
+
+    test('returns positive when a has larger patch version', () {
+      expect(compareSemVer('1.2.3', '1.2.2'), isPositive);
+    });
+
+    // Numeric ordering (not lexicographic)
+    test('compares 1.10.0 > 1.2.0 numerically', () {
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('compares 1.99.99 < 2.0.0 numerically', () {
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+    });
+
+    // Short-form padding
+    test('treats 1.2 as 1.2.0', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('treats 1.2 < 1.2.1 when padded', () {
+      expect(compareSemVer('1.2', '1.2.1'), isNegative);
+      expect(compareSemVer('1.2.1', '1.2'), isPositive);
+    });
+
+    // Extra-component truncation
+    test('ignores extra components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3.999', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3.4.5', '1.2.3'), equals(0));
+    });
+
+    // Malformed input: non-numeric component
+    test('throws FormatException for non-numeric component', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message contains offending input for non-numeric', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a'))));
+    });
+
+    test('throws FormatException for letters in component', () {
+      expect(() => compareSemVer('abc', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException for mixed alphanumeric', () {
+      expect(() => compareSemVer('1.2a.3', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    // Malformed input: empty string
+    test('throws FormatException for empty string', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message contains empty string', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('got ""'))));
+    });
+
+    // Malformed input: whitespace-only string
+    test('throws FormatException for whitespace-only string', () {
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message contains whitespace string', () {
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('   '))));
+    });
+
+    // Signed components (should be rejected)
+    test('throws FormatException for signed negative component', () {
+      expect(() => compareSemVer('-1.2.3', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException for signed positive component', () {
+      expect(() => compareSemVer('+1.2.3', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    // Edge cases
+    test('handles zero components correctly', () {
+      expect(compareSemVer('0.0.0', '0.0.0'), equals(0));
+      expect(compareSemVer('0.0.0', '0.0.1'), isNegative);
+    });
+
+    test('handles large version numbers', () {
+      expect(compareSemVer('999.999.999', '999.999.999'), equals(0));
+      expect(compareSemVer('999.999.999', '1000.0.0'), isNegative);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #200

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)`
  - Parses semantic version strings like '1.2.3'
  - Compares versions numerically (major -> minor -> patch)
  - Returns negative/zero/positive for a < b / a == b / a > b
  - Handles short forms (e.g. '1.2' == '1.2.0') and extra components (e.g. '1.2.3.4' == '1.2.3')
  - Throws FormatException for malformed input (empty, whitespace, non-numeric components)

- Created `test/core/utils/semver_test.dart` with 24 test cases covering all behaviors

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
# Output: 24 tests passed
flutter test
# Output: All tests passed (39 total)
flutter analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
# Output: No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ addressed - all parsing, comparison, and error handling behaviors from the card body are implemented and tested in `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart`

- AC 2 (All named tests pass): ✓ addressed - all 24 tests pass with `flutter test test/core/utils/semver_test.dart`

- AC 3 (No dependencies added): ✓ addressed - implementation uses only Dart core library (RegExp, FormatException)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were modified

- Do NOT add third-party dependencies unless required: not violated - no new dependencies added

- Do NOT refactor unrelated code: not violated - only added new files with the helper and its tests

## Notes

- No deviations from the approved plan; implementation follows the exact specification

- No unexpected findings; the task completed as planned

- Follow-on suggestions: None for this task

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart`

- AC 2 (All named tests pass the verification command): ✓ addressed - 24 tests pass with `flutter test test/core/utils/semver_test.dart`

- AC 3 (No dependencies added unless absolutely required): ✓ addressed - only Dart core library used, no new dependencies