### PR TITLE
feat(collections): add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 InfiquiTra. All rights reserved.
+// This file is part of the mimir project.
+
+import 'dart:math';
+
+/// Extension on [List] to provide chunking capabilities.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive chunks of at most [size] items.
+  ///
+  /// Throws an [ArgumentError] if [size] < 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('Chunk size must be at least 1. Provided: $size');
+    }
+
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final List<List<T>> chunks = [];
+    for (var i = 0; i < length; i += size) {
+      chunks.add(sublist(i, min(i + size, length)));
+    }
+
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList.chunked', () {
+    test('happy path: splits into consecutive chunks', () {
+      final input = [1, 2, 3, 4, 5];
+      final result = input.chunked(2);
+      expect(result, equals([[1, 2], [3, 4], [5]]));
+    });
+
+    test('boundary: chunk size equals list length', () {
+      final input = [1, 2, 3];
+      final result = input.chunked(3);
+      expect(result, equals([[1, 2, 3]]));
+    });
+
+    test('boundary: chunk size exceeds list length', () {
+      final input = [1, 2, 3];
+      final result = input.chunked(10);
+      expect(result, equals([[1, 2, 3]]));
+    });
+
+    test('empty list: returns empty list', () {
+      final input = <int>[];
+      final result = input.chunked(3);
+      expect(result, equals(<List<int>>[]));
+    });
+
+    test('single element: returns a single chunk with one element', () {
+      final input = [1];
+      final result = input.chunked(1);
+      expect(result, equals([[1]]));
+    });
+
+    test('throws ArgumentError when size is 0', () {
+      final input = [1, 2, 3];
+      expect(() => input.chunked(0), throwsArgumentError);
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      final input = [1, 2, 3];
+      expect(() => input.chunked(-1), throwsArgumentError);
+    });
+
+    test('returned chunks are independent from the original list', () {
+      final input = [1, 2, 3, 4];
+      final chunks = input.chunked(2);
+      
+      // Mutate the first chunk
+      chunks[0][0] = 99;
+      
+      expect(input[0], equals(1), reason: 'Original list should not be affected by mutating the chunk');
+      expect(chunks[0][0], equals(99), reason: 'Chunk should be mutated independently');
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #207

## What changed

- Added `ChunkedList` extension on `List<T>` in `lib/core/utils/list_extensions.dart` with `chunked(int size)` method.
- Implemented `chunked` to split lists into sub-lists of at most `size` elements, throwing `ArgumentError` for `size < 1`.
- Added comprehensive unit tests in `test/core/utils/list_extensions_test.dart` covering happy path, boundaries, empty lists, and chunk independence.

## How verified

```bash
flutter test test/core/utils/list_extensions_test.dart
```
Output:
8 tests passed!

```bash
flutter test
```
(Verified that new tests pass; existing failures in `string_utils_test.dart` are pre-existing and unrelated to this change).

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors (size guard, empty list handling, independent chunks) ✓ addressed in `lib/core/utils/list_extensions.dart`
- AC 2: All named tests pass verification ✓ addressed in `test/core/utils/list_extensions_test.dart`
- AC 3: No dependencies added ✓ addressed by using only Dart core API

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated.
- Do NOT add third-party dependencies: not violated.
- Do NOT refactor unrelated code: not violated.

## Notes

The `flutter test` command reported a failure in `test/core/utils/string_utils_test.dart`. I verified this is a pre-existing issue in `main` and not caused by the `chunked` implementation.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/list_extensions.dart`
- All named tests pass the verification command: ✓ addressed in `test/core/utils/list_extensions_test.dart`
- No dependencies added unless absolutely required: ✓ addressed in `lib/core/utils/list_extensions.dart`