### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,88 @@
+/// Compares two semantic version strings.
+///
+/// Returns a comparator-style integer:
+/// - Negative if `a < b`
+/// - Zero if `a == b`
+/// - Positive if `a > b`
+///
+/// Accepts versions of the form `MAJOR.MINOR.PATCH` (e.g. `1.2.3`) and compares
+/// major → minor → patch NUMERICALLY (not lexicographically), so `1.10.0 > 1.2.0`.
+///
+/// A short version (e.g. `1.2`) is treated as `1.2.0` — missing components default to zero.
+///
+/// A version with extra trailing components (e.g. `1.2.3.4`) is treated as `1.2.3`.
+/// Components beyond patch are ignored.
+///
+/// Malformed input throws [FormatException]. "Malformed" means any of:
+/// - Non-numeric component
+/// - Empty string
+/// - Purely whitespace string
+///
+/// The [FormatException] message includes the offending input string verbatim.
+///
+/// Examples:
+/// - `compareSemVer('1.2.3', '1.2.3')` → `0`
+/// - `compareSemVer('1.2.3', '1.2.4')` → negative
+/// - `compareSemVer('1.10.0', '1.2.0')` → positive (numeric, not lexicographic)
+/// - `compareSemVer('2.0.0', '1.99.99')` → positive
+/// - `compareSemVer('1.2', '1.2.0')` → `0` (short form pads with zero)
+/// - `compareSemVer('1.2.3.4', '1.2.3')` → `0` (extra components ignored)
+/// - `compareSemVer('1.2.a', '1.2.3')` → throws [FormatException] whose message contains `'1.2.a'`
+int compareSemVer(String a, String b) {
+  final normalizedA = _normalizeVersion(a);
+  final normalizedB = _normalizeVersion(b);
+
+  for (int i = 0; i < 3; i++) {
+    final result = normalizedA[i].compareTo(normalizedB[i]);
+    if (result != 0) {
+      return result;
+    }
+  }
+
+  return 0;
+}
+
+/// Normalizes a version string into a list of exactly three numeric components.
+///
+/// Validates the input string and throws [FormatException] if it's invalid.
+/// Validates that every dot-separated component is non-empty and parseable as an integer.
+/// After validation, splits on `.`, takes the first three components, and pads with 0.
+List<int> _normalizeVersion(String version) {
+  final trimmed = version.trim();
+
+  // Validate input is not empty or whitespace-only
+  if (trimmed.isEmpty) {
+    throw FormatException('Invalid semver for "$version"');
+  }
+
+  // Split into components
+  final components = trimmed.split('.');
+
+  // Validate each component is non-empty and numeric
+  for (int i = 0; i < components.length; i++) {
+    final component = components[i];
+    if (component.isEmpty) {
+      throw FormatException(
+          'Invalid semver "$version": empty component at position $i');
+    }
+    // Try to parse as integer; if it fails, it's non-numeric
+    if (int.tryParse(component) == null) {
+      throw FormatException(
+          'Invalid semver "$version": non-numeric component "$component"');
+    }
+  }
+
+  // Parse components to integers
+  final parsedComponents = <int>[];
+  for (int i = 0; i < components.length; i++) {
+    parsedComponents.add(int.parse(components[i]));
+  }
+
+  // Take only first three components, pad with zeros if needed
+  final result = <int>[0, 0, 0];
+  for (int i = 0; i < 3 && i < parsedComponents.length; i++) {
+    result[i] = parsedComponents[i];
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns 0 for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+      expect(compareSemVer('0.0.0', '0.0.0'), equals(0));
+      expect(compareSemVer('10.20.30', '10.20.30'), equals(0));
+    });
+
+    test('returns positive when major version is greater', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+    });
+
+    test('returns negative when major version is smaller', () {
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('returns positive when minor version is greater', () {
+      expect(compareSemVer('1.2.0', '1.1.0'), isPositive);
+    });
+
+    test('returns negative when minor version is smaller', () {
+      expect(compareSemVer('1.1.0', '1.2.0'), isNegative);
+    });
+
+    test('returns positive when patch version is greater', () {
+      expect(compareSemVer('1.2.3', '1.2.2'), isPositive);
+    });
+
+    test('returns negative when patch version is smaller', () {
+      expect(compareSemVer('1.2.2', '1.2.3'), isNegative);
+    });
+
+    test('compares numeric components numerically instead of lexicographically',
+        () {
+      // 1.10.0 should be greater than 1.2.0 (numeric comparison)
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      // 1.2.0 should be less than 1.10.0
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('treats short versions as zero-padded', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('1.2', '1.2.1'), isNegative);
+    });
+
+    test('ignores extra trailing components after patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3.4.5', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for non-numeric input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '1.2.a'),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('includes non-numeric offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          predicate((e) => e is FormatException && e.message.contains('1.2.a')),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty input', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes empty offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(
+          predicate((e) => e is FormatException && e.message.contains('')),
+        ),
+      );
+    });
+
+    test('throws FormatException for whitespace-only input', () {
+      expect(
+          () => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes whitespace-only offending input in FormatException message',
+        () {
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(
+          predicate((e) => e is FormatException && e.message.contains('   ')),
+        ),
+      );
+    });
+
+    test('throws FormatException for version with empty component', () {
+      expect(() => compareSemVer('1..3', '1.2.3'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.', '1.2.3'),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('handles negative comparison correctly', () {
+      expect(compareSemVer('1.2.3', '2.0.0'), isNegative);
+    });
+
+    test('handles large version numbers', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('999.999.999', '1.1.1'), isPositive);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #208

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` helper function
- Compares versions numerically (major → minor → patch), not lexicographically
- Returns comparator-style integer: negative if `a < b`, zero if equal, positive if `a > b`
- Validates input and throws `FormatException` for malformed versions (empty, whitespace-only, non-numeric components, empty components)
- Includes offending input verbatim in exception message
- Supports short versions (e.g., `1.2` treated as `1.2.0`) and ignores extra trailing components
- Created `test/core/utils/semver_test.dart` with 19 comprehensive test cases covering all acceptance criteria

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/semver.dart test/core/utils/semver_test.dart
flutter test test/core/utils/semver_test.dart
flutter test
```

- Format check passed with no changes
- `flutter test test/core/utils/semver_test.dart` → 19 tests passed
- `flutter test` → 34 tests passed (including existing tests)

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ Covered by implementation in semver.dart and tests in semver_test.dart
- AC 2 (All named tests pass verification command): ✓ All 19 new tests pass, 34 total tests pass
- AC 3 (No dependencies added unless absolutely required): ✓ Only uses Dart core library APIs

## Non-goals acknowledged

- Do NOT modify files beyond expected set: ✓ Only semver.dart and semver_test.dart changed
- Do NOT add third-party dependencies: ✓ None added
- Do NOT refactor unrelated code: ✓ No refactors, only new files added

## Notes

### Coverage

- AC 1: ✓ Addressed in semver.dart implementation and semver_test.dart test cases
- AC 2: ✓ Addressed - all tests pass verification commands
- AC 3: ✓ Addressed - only Dart core library used

### Test coverage details
- `returns 0 for equal versions` - 3 tests
- `positive/negative when major/minor/patch differs` - 6 tests  
- `compares numeric components numerically` - 1 test
- `treats short versions as zero-padded` - 1 test
- `ignores extra trailing components after patch` - 1 test
- `throws FormatException for malformed input` - 4 tests
- `includes offending input in exception message` - 3 tests
- `handles negative comparison` - 1 test
- `handles large version numbers` - 1 test