### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,38 @@
+library;
+
+/// Utility extension methods for List operations.
+
+/// Extension on List<T> providing chunked operations.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The last chunk may be smaller than [size] if the list length is not
+  /// evenly divisible by [size].
+  ///
+  /// If [size] is less than 1, throws [ArgumentError].
+  ///
+  /// Examples:
+  /// - `[1,2,3,4,5].chunked(2)` → `[[1,2],[3,4],[5]]`
+  /// - `[1,2,3].chunked(10)` → `[[1,2,3]]`
+  /// - `[].chunked(3)` → `[]`
+  /// - `[1].chunked(1)` → `[[1]]`
+  List<List<T>> chunked(int size) {
+    // Validate input
+    if (size < 1) {
+      throw ArgumentError('size must be >= 1, got $size');
+    }
+
+    // Empty list returns empty list
+    if (isEmpty) {
+      return [];
+    }
+
+    // Generate chunks using sublist - each sublist is a new list instance
+    final chunks = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      final end = (i + size).clamp(0, length);
+      chunks.add(sublist(i, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList.chunked', () {
+    test('chunks list into multiple chunks of given size', () {
+      // Happy path: [1,2,3,4,5] with size 2
+      final result = [1, 2, 3, 4, 5].chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('handles boundary where chunk size equals list length', () {
+      // Size equals list length - single chunk containing all elements
+      final result = [1, 2, 3].chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('handles boundary where chunk size is greater than list length', () {
+      // Size larger than list - single chunk with all elements
+      final result = [1, 2, 3].chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('returns empty list for empty input', () {
+      final result = <int>[].chunked(3);
+      expect(result, []);
+    });
+
+    test('handles single element list with size 1', () {
+      final result = [1].chunked(1);
+      expect(result, [[1]]);
+    });
+
+    test('throws ArgumentError when size is 0', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('proves returned chunks are independent copies', () {
+      // Chunk the list, modify a returned chunk, verify original is unchanged
+      final original = [1, 2, 3, 4, 5];
+      final chunks = original.chunked(2);
+      
+      // Modify the first chunk
+      chunks[0][0] = 999;
+      
+      // Original list should be unchanged
+      expect(original[0], 1);
+      expect(original[1], 2);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #213

## What changed

- Created  with  extension
- Implemented  method that splits list into consecutive sublists
- Added validation: throws  if size < 1
- Handles empty lists correctly (returns empty list)
- Last chunk may be smaller than requested size
- Returns independent copies, not views of original list

- Created  with comprehensive tests:
  - Happy path: chunking into multiple chunks
  - Boundary: chunk size equals list length
  - Boundary: chunk size greater than list length
  - Empty list returns empty list
  - Single element list with size 1
  - ArgumentError thrown when size is 0
  - Test proving returned chunks are independent copies

## How verified

00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: ChunkedList.chunked chunks list into multiple chunks of given size
00:00 +1: ChunkedList.chunked handles boundary where chunk size equals list length
00:00 +2: ChunkedList.chunked handles boundary where chunk size is greater than list length
00:00 +3: ChunkedList.chunked returns empty list for empty input
00:00 +4: ChunkedList.chunked handles single element list with size 1
00:00 +5: ChunkedList.chunked throws ArgumentError when size is 0
00:00 +6: ChunkedList.chunked proves returned chunks are independent copies
00:00 +7: All tests passed!

Test output:


dart analyze output:


## Acceptance criteria coverage

- AC: Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in  -  implementation with input validation, empty list handling, and sublist creation
- AC: All named tests pass the verification command: ✓ addressed in  - all 7 named tests pass with 00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/widget_test.dart
00:00 +0: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +1: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +2: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +3: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +4: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +5: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +6: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +7: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +8: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList.chunked chunks list into multiple chunks of given size
00:01 +9: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList.chunked handles boundary where chunk size equals list length
00:01 +10: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList.chunked handles boundary where chunk size is greater than list length
00:01 +11: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList.chunked returns empty list for empty input
00:01 +12: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList.chunked handles single element list with size 1
00:01 +13: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList.chunked throws ArgumentError when size is 0
00:01 +14: /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart: ChunkedList.chunked proves returned chunks are independent copies
00:01 +15: All tests passed!
- AC: No dependencies added unless absolutely required: ✓ not violated - uses only Dart core library (, , etc.)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only modified the 2 expected files
- Do NOT add third-party dependencies unless required by the task body: not violated - no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - new files created, no refactoring performed

## Notes

- Analyzing mimir...

   info - lib/core/utils/formatters.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments

1 issue found. reports 0 issues on the new files
- The test file follows the existing pattern in  (group/test structure)
- The source file follows the existing pattern in  and  (library directive, doc comments)
