### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,18 @@
+extension ChunkedList<T> on List<T> {
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('size must be >= 1, got $size');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final result = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      final end = i + size > length ? length : i + size;
+      result.add(sublist(i, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('chunked', () {
+    test('splits a list into consecutive chunks of the requested size', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [[1, 2], [3, 4], [5]]);
+    });
+
+    test('returns one chunk when chunk size equals list length', () {
+      expect([1, 2, 3].chunked(3), [[1, 2, 3]]);
+    });
+
+    test('returns one chunk when chunk size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), [[1, 2, 3]]);
+    });
+
+    test('returns an empty list for an empty source list', () {
+      expect([].chunked(3), []);
+    });
+
+    test('returns a single-element chunk for a single-element list', () {
+      expect([1].chunked(1), [[1]]);
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('returned chunks are independent of the source list', () {
+      final source = [1, 2, 3, 4, 5];
+      final chunks = source.chunked(2);
+      chunks[0][0] = 999;
+      expect(source, [1, 2, 3, 4, 5]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #183

## What changed

- Created `lib/core/utils/list_extensions.dart` with `extension ChunkedList<T> on List<T>` and `List<List<T>> chunked(int size)` method
- Created `test/core/utils/list_extensions_test.dart` with tests covering:
  - happy path: `[1,2,3,4,5].chunked(2)` → `[[1,2],[3,4],[5]]`
  - boundary: chunk size = list length
  - boundary: chunk size > list length  
  - empty list returning `[]`
  - single-element list with size `1`
  - `ArgumentError` on `size=0`
  - chunk independence after mutation

## How verified

```bash
cd ~/workspace/infiquetra/mimir && flutter test test/core/utils/list_extensions_test.dart
```

Output:
```
00:00 +7: All tests passed!
```

```bash
cd ~/workspace/infiquetra/mimir && flutter test
```

Output:
```
00:01 +15: All tests passed!
```

```bash
cd ~/workspace/infiquetra/mimir && dart analyze lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart
```

Output:
```
Analyzing list_extensions.dart, list_extensions_test.dart...
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ addressed in `lib/core/utils/list_extensions.dart` - the `chunked()` method validates size, handles empty list, calculates consecutive sublists, and returns independent copies
- AC 2 (All named tests pass): ✓ addressed in `test/core/utils/list_extensions_test.dart` - 7 tests verify all required behaviors
- AC 3 (No dependencies added): ✓ verified - only core Dart/Flutter facilities used

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated - only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` changed
- Do NOT add third-party dependencies: not violated - no new dependencies introduced
- Do NOT refactor unrelated code: not violated - no unrelated files modified

## Notes

- Implementation follows the existing utility pattern in `formatters.dart`
- Tests follow the `group()/test()` structure from existing test files
- No dependencies required for this small utility (<50 lines as specified)