### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,66 @@
+/// Semantic version comparison utilities.
+library;
+
+/// Compares two semantic version strings.
+///
+/// Returns a comparator-style integer:
+/// - Negative if [a] < [b]
+/// - Zero if [a] == [b]
+/// - Positive if [a] > [b]
+///
+/// Examples:
+/// - `compareSemVer('1.2.3', '1.2.3')` → `0`
+/// - `compareSemVer('1.2.3', '1.2.4')` → negative
+/// - `compareSemVer('1.10.0', '1.2.0')` → positive (numeric, not lexicographic)
+/// - `compareSemVer('2.0.0', '1.99.99')` → positive
+/// - `compareSemVer('1.2', '1.2.0')` → `0` (short form pads with zero)
+/// - `compareSemVer('1.2.3.4', '1.2.3')` → `0` (extra components ignored)
+///
+/// Throws [FormatException] if either version string is malformed:
+/// - Empty or whitespace-only
+/// - Contains non-numeric components
+int compareSemVer(String a, String b) {
+  final aComponents = _parseVersion(a);
+  final bComponents = _parseVersion(b);
+
+  for (int i = 0; i < 3; i++) {
+    final diff = aComponents[i] - bComponents[i];
+    if (diff != 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/// Parses a version string into its numeric components.
+///
+/// Returns a list of exactly 3 integers [major, minor, patch].
+/// Throws [FormatException] if the input is malformed.
+List<int> _parseVersion(String version) {
+  if (version.isEmpty || version.trim().isEmpty) {
+    throw FormatException('Invalid version: "$version"', version, 0);
+  }
+
+  final parts = version.split('.');
+  if (parts.length < 3) {
+    // Pad with zeros
+    while (parts.length < 3) {
+      parts.add('0');
+    }
+  } else if (parts.length > 3) {
+    // Truncate to first 3 components
+    parts.removeRange(3, parts.length);
+  }
+
+  final components = <int>[];
+  for (int i = 0; i < 3; i++) {
+    final part = parts[i];
+    final parsed = int.tryParse(part);
+    if (parsed == null) {
+      throw FormatException('Invalid version: "$version"', version, 0);
+    }
+    components.add(parsed);
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions return 0', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('different major versions', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('different minor versions', () {
+      expect(compareSemVer('1.3.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.3.0'), isNegative);
+    });
+
+    test('different patch versions', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('numeric ordering (1.10.0 > 1.2.0)', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('short form padding (1.2 vs 1.2.0)', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('extra components ignored (1.2.3.4 vs 1.2.3)', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException on empty string', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException on whitespace-only string', () {
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException on non-numeric component', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message contains offending input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a')),
+        ),
+      );
+    });
+
+    test('throws FormatException on version with missing component', () {
+      expect(() => compareSemVer('1..3', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #190

## What changed

- Add `compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`
- Implement numeric comparison of major.minor.patch components with normalization
- Pad short versions with zeros, truncate extra components
- Throw `FormatException` for malformed input with original string in message
- Add comprehensive tests in `test/core/utils/semver_test.dart`

## How verified

```
cd ~/workspace/infiquetra/mimir && flutter test test/core/utils/semver_test.dart
```
Results:
```
00:00 +12: All tests passed!
```

```
cd ~/workspace/infiquetra/mimir && flutter test
```
Results: All 20 tests pass.

```
cd ~/workspace/infiquetra/mimir && dart analyze lib/core/utils/semver.dart
```
Results: No issues found.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors): ✓ addressed in compareSemVer() implementation with normalization, numeric comparison, and error handling
- AC 2 (All named tests pass): ✓ verified with flutter test - all 12 semver tests and 20 total tests pass
- AC 3 (No dependencies added): ✓ no changes to pubspec.yaml or pubspec.lock beyond flutter pub get

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only semver.dart and semver_test.dart added
- Do NOT add third-party dependencies: not violated - uses only Dart standard library
- Do NOT refactor unrelated code: not violated - no modifications to existing utility files

## Notes

- First implementation attempt had a bug (`int.tryParse(part).hasValue`) which was fixed by checking for null with `parsed == null`
- The `library;` directive was added after the header comment to satisfy Dart analyzer's `dangling_library_doc_comments` warning
- Implementation follows existing pattern from `formatters.dart` - small top-level utility functions under `lib/core/utils`
- Tests use the `group()/test()` pattern and `flutter_test` import as seen in existing tests
- AC 7 (FormatException message contains offending input): Verified with matcher `having((e) => e.message, 'message', contains(<offending input>))` in test
- AC 2 (numeric ordering): `1.10.0 > 1.2.0` explicitly tested to prove numeric, not lexicographic, comparison

### Coverage

- AC 1 (verbatim): ✓ addressed in `compareSemVer(String a, String b)` in lib/core/utils/semver.dart
- AC 2 (verbatim): ✓ addressed in test/core/utils/semver_test.dart - all tests pass
- AC 3 (verbatim): ✓ addressed - no pubspec.yaml changes
- Task-body AC 1 (signature): ✓ addressed in semver.dart
- Task-body AC 2 (numeric comparison): ✓ addressed with int.parse comparison
- Task-body AC 3 (short-form padding): ✓ addressed in _parseVersion() pad logic
- Task-body AC 4 (extra components ignored): ✓ addressed in _parseVersion() truncate logic
- Task-body AC 5 (sign-only return): ✓ addressed with isPositive/isNegative/equals(0) tests
- Task-body AC 6 (FormatException): ✓ addressed in _parseVersion() with throwsA(isA<FormatException>())
- Task-body AC 7 (message contains input): ✓ addressed with having((e) => e.message, 'message', contains(<input>)) test