### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,66 @@
+library;
+
+/// Utility functions for semantic version comparison.
+///
+/// Compares two semantic version strings.
+///
+/// Returns a comparator-style integer:
+/// - Negative if [a] < [b]
+/// - Zero if [a] == [b]
+/// - Positive if [a] > [b]
+///
+/// Versions are expected in the form `MAJOR.MINOR.PATCH` (e.g., `1.2.3`).
+/// Missing components default to zero (e.g., `1.2` becomes `1.2.0`).
+/// Extra components beyond PATCH are ignored (e.g., `1.2.3.4` becomes `1.2.3`).
+///
+/// Comparison is NUMERIC, not lexicographic, so `1.10.0 > 1.2.0`.
+///
+/// Throws [FormatException] if the version string is empty, whitespace-only,
+/// or contains non-numeric components.
+int compareSemVer(String a, String b) {
+  final tupleA = _parseVersion(a);
+  final tupleB = _parseVersion(b);
+
+  // Compare major, then minor, then patch
+  final majorDiff = tupleA[0].compareTo(tupleB[0]);
+  if (majorDiff != 0) return majorDiff;
+
+  final minorDiff = tupleA[1].compareTo(tupleB[1]);
+  if (minorDiff != 0) return minorDiff;
+
+  final patchDiff = tupleA[2].compareTo(tupleB[2]);
+  return patchDiff;
+}
+
+/// Parses a version string into a three-element numeric tuple [major, minor, patch].
+/// Returns [FormatException] if the string is empty, whitespace-only, or has non-numeric components.
+List<int> _parseVersion(String input) {
+  // Check for empty or whitespace-only input
+  if (input.isEmpty || input.trim().isEmpty) {
+    throw FormatException('Version string is empty or whitespace: "$input"', input);
+  }
+
+  final components = input.trim().split('.');
+  final result = <int>[];
+
+  for (int i = 0; i < 3; i++) {
+    if (i < components.length) {
+      final component = components[i];
+      // Check if component is empty (e.g., "1..3" or "1.2.")
+      if (component.isEmpty) {
+        throw FormatException('Version component is empty at position $i: "$input"', input);
+      }
+      // Try to parse as integer
+      final value = int.tryParse(component);
+      if (value == null) {
+        throw FormatException('Version component "$component" is not a valid integer: "$input"', input);
+      }
+      result.add(value);
+    } else {
+      // Pad missing components with zero
+      result.add(0);
+    }
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('major difference returns negative', () {
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('major difference returns positive', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+    });
+
+    test('minor difference returns negative', () {
+      expect(compareSemVer('1.1.0', '1.2.0'), isNegative);
+    });
+
+    test('minor difference returns positive', () {
+      expect(compareSemVer('1.2.0', '1.1.0'), isPositive);
+    });
+
+    test('patch difference returns negative', () {
+      expect(compareSemVer('1.2.1', '1.2.2'), isNegative);
+    });
+
+    test('patch difference returns positive', () {
+      expect(compareSemVer('1.2.2', '1.2.1'), isPositive);
+    });
+
+    test('numeric ordering: 1.10.0 > 1.2.0', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('short-form padding: 1.2 equals 1.2.0', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('extra-component truncation: 1.2.3.4 equals 1.2.3', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message contains the offending input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a')),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty string', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException for whitespace-only string', () {
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #205

## What changed

- Added `lib/core/utils/semver.dart` with `compareSemVer(String a, String b)` function
- Added `test/core/utils/semver_test.dart` with 14 comprehensive tests

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

Output digest:
- 14 tests passed
- `dart analyze` reports no issues on new files

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors — covered by semver.dart implementation with _parseVersion parser and compareSemVer comparator; tests verify equality, ordering (major/minor/patch), numeric ordering (1.10.0 > 1.2.0), short-form padding, extra-component truncation, and FormatException handling with message content

- AC 2: All named tests pass — 14 tests in test/core/utils/semver_test.dart all pass with flutter test

- AC 3: No dependencies added — implementation uses only Dart core libraries (String, int, FormatException) and flutter_test matchers

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated (only semver.dart and semver_test.dart created)
- Do NOT add third-party dependencies unless required by the task body: not violated (no pubspec changes)
- Do NOT refactor unrelated code in the touched files: not violated (clean new files added)

## Notes

- Implementation follows the existing formatters.dart pattern with library directive and doc comments
- FormatException messages include the offending input string verbatim as required by AC 7
- Tests use sign assertions (isNegative, isPositive, equals(0)) not exact numeric values per AC 5
