### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,31 @@
+/// Extension methods for List operations.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws an [ArgumentError] if [size] is less than 1.
+  ///
+  /// Examples:
+  /// ```dart
+  /// [1,2,3,4,5].chunked(2) // [[1,2],[3,4],[5]]
+  /// [1,2,3].chunked(10)    // [[1,2,3]]
+  /// [].chunked(3)          // []
+  /// [1].chunked(1)         // [[1]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'must be greater than or equal to 1');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final result = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      final end = i + size < length ? i + size : length;
+      // Create a new list to ensure independence of chunks
+      result.add(sublist(i, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('chunked', () {
+    test('splits a list into consecutive chunks', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [
+        [1, 2],
+        [3, 4],
+        [5]
+      ]);
+    });
+
+    test('returns a single chunk when size equals list length', () {
+      expect([1, 2, 3].chunked(3), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('returns a single chunk when size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('returns an empty list for an empty source list', () {
+      expect(<int>[].chunked(3), []);
+    });
+
+    test('returns a single-element chunk for a one-item list', () {
+      expect([1].chunked(1), [
+        [1]
+      ]);
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+    });
+
+    test('returns independent chunk lists', () {
+      final originalList = [1, 2, 3, 4, 5];
+      final chunks = originalList.chunked(2);
+      
+      // Mutate the first chunk
+      if (chunks.isNotEmpty) {
+        chunks[0].add(99);
+      }
+      
+      // Original list should be unchanged
+      expect(originalList, [1, 2, 3, 4, 5]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #230

## What changed

- Added a new `ChunkedList` extension on `List<T>` with a `chunked(int size)` method in `lib/core/utils/list_extensions.dart`
- Created comprehensive tests in `test/core/utils/list_extensions_test.dart` covering:
  - Happy path chunking behavior
  - Boundary cases (chunk size equals or exceeds list length)
  - Empty list handling
  - Single element list handling
  - Error cases (invalid size values)
  - Independence of returned chunks

## How verified

```bash
$ cd ~/workspace/infiquetra/mimir
$ flutter test test/core/utils/list_extensions_test.dart
00:00 +8: All tests passed!
$ flutter test
00:02 +22: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) - ✓ addressed in lib/core/utils/list_extensions.dart
- AC 2: All named tests pass the verification command - ✓ addressed in test/core/utils/list_extensions_test.dart
- AC 3: No dependencies added unless absolutely required - ✓ no dependencies added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

The implementation follows Dart best practices:
- Uses proper null safety with generic type `<T>`
- Validates input parameters with appropriate error handling
- Ensures chunk independence by creating new sublists
- Comprehensive test coverage including edge cases

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- [ ] All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- [ ] No dependencies added unless absolutely required: ✓ addressed - no dependencies added