### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,32 @@
+/// Extension methods for Lists.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The last chunk may be smaller than [size].
+  ///
+  /// Throws an [ArgumentError] if [size] is less than 1.
+  ///
+  /// Examples:
+  /// ```dart
+  /// [1,2,3,4,5].chunked(2) // [[1,2], [3,4], [5]]
+  /// [1,2,3].chunked(10)    // [[1,2,3]]
+  /// [].chunked(3)          // []
+  /// [1].chunked(1)         // [[1]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'Must be greater than or equal to 1');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final chunks = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      final end = i + size < length ? i + size : length;
+      chunks.add(sublist(i, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('chunked', () {
+    test('splits a list into consecutive chunks', () {
+      expect([1, 2, 3, 4, 5].chunked(2), equals([
+        [1, 2],
+        [3, 4],
+        [5]
+      ]));
+    });
+
+    test('returns a single chunk when chunk size matches list length', () {
+      expect([1, 2, 3].chunked(3), equals([
+        [1, 2, 3]
+      ]));
+    });
+
+    test('returns a single chunk when chunk size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), equals([
+        [1, 2, 3]
+      ]));
+    });
+
+    test('returns an empty list for empty input', () {
+      expect(<int>[].chunked(3), equals([]));
+    });
+
+    test('returns a single-element chunk for a single-item list', () {
+      expect([1].chunked(1), equals([
+        [1]
+      ]));
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+    });
+
+    test('returns independent chunk lists', () {
+      final originalList = [1, 2, 3, 4];
+      final chunks = originalList.chunked(2);
+      final firstChunk = chunks[0];
+
+      // Mutate the chunk
+      firstChunk[0] = 999;
+
+      // Original list should be unchanged
+      expect(originalList, equals([1, 2, 3, 4]));
+      // The chunk should reflect the mutation
+      expect(firstChunk, equals([999, 2]));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #232

## What changed

- Added `lib/core/utils/list_extensions.dart` with `ChunkedList` extension providing a `chunked(int size)` method
- Added `test/core/utils/list_extensions_test.dart` with comprehensive tests covering all requirements

## How verified

```bash
cd ~/workspace/infiquetra/mimir && flutter test test/core/utils/list_extensions_test.dart
00:00 +8: All tests passed!

cd ~/workspace/infiquetra/mimir && flutter test
00:00 +16: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body - ✓ addressed in `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart`
- AC 2: All named tests pass the verification command - ✓ verified with `flutter test` and `flutter test test/core/utils/list_extensions_test.dart`
- AC 3: No dependencies added unless absolutely required - ✓ no new dependencies added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only created the two specified files
- Do NOT add third-party dependencies unless required by the task body: not violated - no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - only added new functionality

## Notes

Implementation follows Dart/Flutter best practices and mimir's coding standards:
- Uses extension methods for enhanced functionality
- Proper error handling with ArgumentError for invalid size parameter
- Comprehensive documentation with examples
- Independent chunk creation using sublist to prevent mutations from affecting the original list
- Thorough test coverage including edge cases and mutation independence verification

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- [ ] All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- [ ] No dependencies added unless absolutely required: ✓ addressed (no dependencies added)