### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,59 @@
+// Semantic version comparison utility.
+
+/// Compares two semantic version strings and returns a comparator-style integer.
+///
+/// Parses versions of the form MAJOR.MINOR.PATCH and compares them numerically.
+/// - Returns negative if [a] < [b], zero if [a] == [b], positive if [a] > [b].
+/// - Short versions like "1.2" are treated as "1.2.0" (missing components default to 0).
+/// - Extra components like "1.2.3.4" are truncated to "1.2.3" (components beyond patch are ignored).
+/// - Non-numeric components, empty strings, or whitespace-only strings throw [FormatException].
+///
+/// Throws [FormatException] with message containing the offending input string if parsing fails.
+int compareSemVer(String a, String b) {
+  final versionA = _parseVersion(a);
+  final versionB = _parseVersion(b);
+
+  final majorCompare = versionA.major.compareTo(versionB.major);
+  if (majorCompare != 0) return majorCompare;
+
+  final minorCompare = versionA.minor.compareTo(versionB.minor);
+  if (minorCompare != 0) return minorCompare;
+
+  return versionA.patch.compareTo(versionB.patch);
+}
+
+/// Holds the parsed version components.
+class _Version {
+  final int major;
+  final int minor;
+  final int patch;
+
+  const _Version(this.major, this.minor, this.patch);
+}
+
+/// Parses a version string into major, minor, patch components.
+///
+/// - Splits on '.' and takes only the first three components.
+/// - Missing components default to 0.
+/// - Extra components are ignored.
+/// - Throws [FormatException] if the input is empty/whitespace or any consumed component is non-numeric.
+_Version _parseVersion(String version) {
+  if (version.trim().isEmpty) {
+    throw FormatException('Invalid version: "$version"');
+  }
+
+  final parts = version.split('.');
+  final components = <int>[];
+
+  // Parse only the first 3 components (major, minor, patch)
+  for (var i = 0; i < 3; i++) {
+    final part = i < parts.length ? parts[i] : '0';
+    final parsed = int.tryParse(part);
+    if (parsed == null) {
+      throw FormatException('Invalid version: "$version"');
+    }
+    components.add(parsed);
+  }
+
+  return _Version(components[0], components[1], components[2]);
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions returns equals(0)', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('major difference returns sign-only assertion', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('minor difference returns sign-only assertion', () {
+      expect(compareSemVer('1.2.0', '1.1.99'), isPositive);
+      expect(compareSemVer('1.1.99', '1.2.0'), isNegative);
+    });
+
+    test('patch difference returns sign-only assertion', () {
+      expect(compareSemVer('1.2.3', '1.2.2'), isPositive);
+      expect(compareSemVer('1.2.2', '1.2.3'), isNegative);
+    });
+
+    test('numeric ordering uses sign-only assertion', () {
+      // 1.10.0 > 1.2.0 because 10 > 2 (numeric comparison, not lexicographic)
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('short-form padding (1.2 vs 1.2.0) returns equals(0)', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1.2.0', '1.2'), equals(0));
+    });
+
+    test('short-form with only major', () {
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('2', '1.99.99'), isPositive);
+    });
+
+    test('extra-component truncation (1.2.3.4 vs 1.2.3) returns equals(0)', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.4'), equals(0));
+    });
+
+    test('extra components beyond patch are ignored in comparison', () {
+      // 1.2.3.5 vs 1.2.3.4 - the 4th component should be ignored
+      expect(compareSemVer('1.2.3.5', '1.2.3.4'), equals(0));
+    });
+
+    test('malformed input throws FormatException', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', 'bad'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', ''), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '   '), throwsA(isA<FormatException>()));
+    });
+
+    test('malformed input error message contains offending substring', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+      expect(
+        () => compareSemVer('1.2.3', 'bad'),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('bad'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #234

## What changed

- Added `lib/core/utils/semver.dart` with top-level function `int compareSemVer(String a, String b)`
- Added `test/core/utils/semver_test.dart` with comprehensive test coverage

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

Output:
```
00:00 +11: All tests passed!
```

```bash
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

Output:
```
Analyzing semver.dart, semver_test.dart...
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Signature is exactly int compareSemVer(String a, String b) and lives in lib/core/utils/semver.dart): ✓ addressed in lib/core/utils/semver.dart line 12
- AC 2 (Accepts versions of the form MAJOR.MINOR.PATCH and compares major → minor → patch NUMERICALLY): ✓ addressed in lib/core/utils/semver.dart lines 14-21, tests at lines 24-35
- AC 3 (A short version is treated as MAJOR.MINOR.0 — missing components default to zero): ✓ addressed in lib/core/utils/semver.dart lines 58-61, tests at lines 31-37
- AC 4 (A version with extra trailing components is treated as MAJOR.MINOR.PATCH — components beyond patch are ignored): ✓ addressed in lib/core/utils/semver.dart line 56, tests at lines 38-44
- AC 5 (Return value contract mirrors Comparable.compareTo: the SIGN is what matters): ✓ addressed in lib/core/utils/semver.dart lines 14-21, tests use isPositive/isNegative/equals(0)
- AC 6 (Malformed input throws FormatException): ✓ addressed in lib/core/utils/semver.dart lines 49-53, tests at lines 45-51
- AC 7 (The FormatException message MUST include the offending input string verbatim): ✓ addressed in lib/core/utils/semver.dart lines 49-53, tests at lines 52-57

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ Only lib/core/utils/semver.dart and test/core/utils/semver_test.dart modified
- Do NOT add third-party dependencies unless required by the task body: ✓ No dependencies added
- Do NOT refactor unrelated code in the touched files: ✓ No refactoring, only new code

## Notes

- Followed existing test patterns from formatters_test.dart
- Implementation uses int.tryParse for robust numeric validation
- All edge cases covered including empty strings, whitespace-only strings, and non-numeric components