### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,60 @@
+/// Utility functions for string manipulation.
+
+/// Truncates a string in the middle with an ellipsis.
+///
+/// If the [input] length is less than or equal to [maxLength], returns
+/// [input] unchanged. Otherwise, replaces the middle of the string with
+/// [ellipsis], keeping both the start and end portions visible.
+///
+/// The total length of the returned string will be at most [maxLength],
+/// including the length of the ellipsis.
+///
+/// If [maxLength] is less than the [ellipsis] length, the ellipsis itself
+/// is truncated to [maxLength] and returned alone.
+///
+/// When the available space for visible characters (after subtracting the
+/// ellipsis length) is odd, the extra character is **dropped** so that both
+/// prefix and suffix have equal length. This yields a total length less than
+/// maxLength in those cases, which matches the example given in the issue.
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'`
+/// - `truncateMiddle('xyz', 2)` → `'…'` (ellipsis truncated to 1 char)
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // If input already fits, return unchanged.
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  // Ensure non‑negative maxLength.
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  // Ellipsis cannot exceed maxLength.
+  final effectiveEllipsis =
+      ellipsis.length <= maxLength ? ellipsis : ellipsis.substring(0, maxLength);
+
+  // If the whole budget is consumed by the ellipsis, return it alone.
+  if (maxLength <= effectiveEllipsis.length) {
+    return effectiveEllipsis;
+  }
+
+  // Budget for visible prefix/suffix characters.
+  final visibleBudget = maxLength - effectiveEllipsis.length;
+  assert(visibleBudget > 0);
+
+  // Split visible budget equally between prefix and suffix.
+  // If visibleBudget is odd, the extra character is dropped (not shown),
+  // because the example in the issue uses equal prefix/suffix lengths.
+  final prefixCount = visibleBudget ~/ 2;
+  final suffixCount = visibleBudget ~/ 2;
+
+  // Both counts are safe because input.length > maxLength >= effectiveEllipsis.length + visibleBudget.
+  return input.substring(0, prefixCount) +
+         effectiveEllipsis +
+         input.substring(input.length - suffixCount);
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when input.length <= maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('abc', 3), 'abc');
+      expect(truncateMiddle('xy', 5), 'xy');
+    });
+
+    test('returns empty string unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('truncates middle while preserving both ends', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+      // prefixCount = (maxLength - ellipsis.length + 1) ~/ 2 = (8 - 1 + 1) ~/ 2 = 8~/2? Wait, compute.
+      // visibleBudget = 8 - 1 = 7, prefixCount = (7+1)~/2 = 4, suffixCount = 7~/2 = 3. Actually prefix=4? That would be "abcd…lmn" length 4+1+3 = 8.
+      // Let's compute: 'abcdefghijklmn' length 14. prefix 4 => 'abcd', suffix 3 => 'lmn', ellipsis '…' => 'abcd…lmn'. That's correct. Good.
+    });
+
+    test('returns truncated ellipsis alone when maxLength < ellipsis.length', () {
+      expect(truncateMiddle('xyz', 2), '…'); // ellipsis length 1 <= 2, not this case. Need maxLength < ellipsis length.
+      // Use custom ellipsis longer than maxLength.
+      expect(truncateMiddle('anything', 3, ellipsis: '----'), '---');
+      expect(truncateMiddle('anything', 1, ellipsis: '....'), '.');
+    });
+
+    test('counts custom ellipsis length toward maxLength', () {
+      // maxLength = 10, ellipsis length = 4, visibleBudget = 6, split: prefix = 6~/2 = 3, suffix = 3.
+      // Input length 20 > 10.
+      expect(truncateMiddle('abcdefghijklmnopqrst', 10, ellipsis: '!!!!'), 'abc!!!!rst');
+      // Verify length = 3 + 4 + 3 = 10.
+    });
+
+    test('even visible budget yields equal prefix/suffix and total length equals maxLength', () {
+      // Example from issue: truncateMiddle('abcdef', 3) -> 'a…f'
+      // maxLength = 3, ellipsis length = 1, visibleBudget = 2 (even).
+      // prefixCount = 2~/2 = 1, suffixCount = 1, total length = 1+1+1 = 3.
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+
+    test('odd visible budget yields equal prefix/suffix and total length less than maxLength', () {
+      // maxLength = 6, ellipsis length = 1, visibleBudget = 5 (odd).
+      // prefixCount = 5~/2 = 2, suffixCount = 2, total length = 2+1+2 = 5 < maxLength.
+      expect(truncateMiddle('123456789', 6), '12…89');
+      // Validate length.
+      final result = truncateMiddle('123456789', 6);
+      expect(result.length, 5);
+    });
+
+    test('handles maxLength zero or negative', () {
+      expect(truncateMiddle('hello', 0), '');
+      expect(truncateMiddle('hello', -5), '');
+    });
+
+    test('ellipsis truncated to maxLength when ellipsis longer', () {
+      expect(truncateMiddle('abc', 1), '…');
+      // Actually ellipsis default '…' length 1, maxLength 1, returns '…'.
+      // Let's use custom ellipsis '>>>', maxLength 2 -> '>>'.
+      expect(truncateMiddle('something', 2, ellipsis: '>>>'), '>>');
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #238

## What changed

- Added `truncateMiddle()` utility to `lib/core/utils/string_utils.dart`
. Implementation follows the issue specification:
  - Returns input unchanged when `input.length <= maxLength`
  - Handles empty string, zero/negative maxLength
  - Ellipsis length counted toward maxLength; ellipsis truncated if longer
  - Splits visible budget equally between prefix and suffix; odd extra character dropped (so total length may be less than maxLength)
- Added comprehensive test coverage in `test/core/utils/string_utils_test.dart`:
  - Short strings unchanged
  - Middle truncation preserving both ends
  - Edge cases: empty string, maxLength shorter than ellipsis, custom ellipsis length accounted
  - Even/odd visible budget behavior documented

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
```
Output: All 9 tests passed.

```bash
dart analyze lib/core/utils/string_utils.dart
```
Output: One info-level lint about dangling library doc comment (same as existing `formatters.dart`). No new errors introduced.

## Acceptance criteria coverage

-Q AC 1: Implementation matches all behaviors described in the task body — `truncateMiddle` handles all specified cases: short strings unchanged, middle truncation, empty input, maxLength shorter than ellipsis, ellipsis length counted.
-Q AC 2: All named tests pass the verification command — `flutter test test/core/utils/string_utils_test.dart` passes 9/9.
-Q AC 3: No dependencies added unless absolutely required — no changes to `pubspec.yaml`; only standard library used.

## Non-goals acknowledged

/ Do NOT modify files beyond the expected set below — only `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart` were created.
- Do NOT add third-party dependencies unless required by the task body — no dependencies added.
/ Do NOT refactor unrelated code in the touched files — no refactoring.

## Notes

- The existing `formatters.dart` utility file also has a dangling library doc comment lint (same as new file). This is a pre‑existing analyzer warning, not introduced by this change.
- The implementation chooses to drop the extra character when the visible budget (maxLength - ellipsis.length) is odd, giving equal prefix and suffix lengths. This yields a total length less than maxLength in those cases. This matches the example in the issue where `truncateMiddle('abcdef', 3)` returns `'a…f'` (visible budget = 2, even) and `truncateMiddle('abcdefghijklmn', 8)` returns `'abc…lmn'` (visible budget = 7, odd, length = 7). The design choice is documented in the function's doc comment and test.

### Coverage

-S AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `truncateMiddle` function with early‑return guards, ellipsis truncation, and equal prefix/suffix split.
-S AC 2 (All named tests pass the verification command): ✓ covered by 9 unit tests in `string_utils_test.dart`; `flutter test` passes.
-S AC 3 (No dependencies added unless absolutely required): ✓ no changes to `pubspec.yaml` or `pubspec.lock` (lockfile reverted to match main).