### PR TITLE
feat(semver): add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,48 @@
+// Utility functions for semantic versioning.
+
+/// Compares two semantic-version strings and returns a comparator-style integer.
+///
+/// Returns a negative integer if `a < b`, zero if `a == b`, and a positive
+/// integer if `a > b`.
+///
+/// Accepts versions of the form `MAJOR.MINOR.PATCH` (e.g., `1.2.3`) and compares
+/// components numerically. Missing components default to zero (e.g., `1.2` is
+/// treated as `1.2.0`). Components beyond patch (e.g., `1.2.3.4`) are ignored.
+///
+/// Throws a [FormatException] if either input is empty, purely whitespace, or
+/// contains a non-numeric component that impacts the comparison. The exception
+/// message will contain the offending input string.
+int compareSemVer(String a, String b) {
+  final versionA = _parseSemVer(a);
+  final versionB = _parseSemVer(b);
+
+  for (var i = 0; i < 3; i++) {
+    final cmp = versionA[i].compareTo(versionB[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+/// Parses a version string into its [major, minor, patch] components.
+List<int> _parseSemVer(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Version string cannot be empty or whitespace: "$input"');
+  }
+
+  final components = input.split('.');
+  final result = <int>[0, 0, 0];
+
+  for (var i = 0; i < 3 && i < components.length; i++) {
+    final component = components[i];
+    final value = int.tryParse(component);
+
+    if (value == null) {
+      throw FormatException('Invalid numeric component "$component" in version string: "$input"');
+    }
+
+    result[i] = value;
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns 0 for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major differences', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('compares minor differences', () {
+      expect(compareSemVer('1.2.0', '1.1.0'), isPositive);
+      expect(compareSemVer('1.1.0', '1.2.0'), isNegative);
+    });
+
+    test('compares patch differences', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares versions numerically', () {
+      // 1.10.0 > 1.2.0
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('treats short-form versions as padded with zeros', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('1.2.0', '1.2'), equals(0));
+    });
+
+    test('ignores extra components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.99'), equals(0));
+    });
+
+    test('throws FormatException for non-numeric components', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+    });
+
+    test('throws FormatException for empty or whitespace strings', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer(' ', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(
+        () => compareSemVer('1.2.3', ''),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains(''))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #239

## What changed

- Created lib/core/utils/semver.dart with compareSemVer() helper function.
- Created test/core/utils/semver_test.dart with comprehensive coverage for version comparison and error handling.

## How verified

```bash
flutter test test/core/utils/semver_test.dart
flutter test
flutter analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

Verification results:
- flutter test test/core/utils/semver_test.dart: 9 tests passed
- flutter test: All tests passed (17 tests total)
- flutter analyze: No issues found

## Acceptance criteria coverage

- AC 1: Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`. -> ✓ addressed in lib/core/utils/semver.dart
- AC 2: Accepts versions of the form `MAJOR.MINOR.PATCH` and compares major → minor → patch NUMERICALLY. -> ✓ addressed in lib/core/utils/semver.dart
- AC 3: A short version (e.g. `1.2`) is treated as `1.2.0`. -> ✓ addressed in _parseSemVer helper
- AC 4: A version with extra trailing components is treated as `1.2.3`. -> ✓ addressed in _parseSemVer loop limit
- AC 5: Return value contract mirrors `Comparable.compareTo`: the SIGN is what matters. -> ✓ addressed in compareSemVer
- AC 6: Malformed input throws `FormatException`. -> ✓ addressed in _parseSemVer
- AC 7: The `FormatException` message MUST include the offending input string verbatim. -> ✓ addressed in _parseSemVer

## Non-goals acknowledged

- Do NOT modify files beyond expected set: ✓ not violated
- Do NOT add third-party dependencies: ✓ not violated
- Do NOT refactor unrelated code: ✓ not violated

## Notes

- Used `//` instead of `///` for the library-level descriptive comment to avoid the `dangling_library_doc_comments` lint issue observed in the repo.

### Coverage

- Signature is exactly int compareSemVer(String a, String b) and lives in lib/core/utils/semver.dart: ✓ addressed in lib/core/utils/semver.dart
- Accepts versions of the form MAJOR.MINOR.PATCH (e.g. 1.2.3) and compares major → minor → patch NUMERICALLY (not lexicographically), so 1.10.0 > 1.2.0: ✓ addressed in lib/core/utils/semver.dart
- A short version (e.g. 1.2) is treated as 1.2.0 — missing components default to zero: ✓ addressed in _parseSemVer
- A version with extra trailing components (e.g. 1.2.3.4) is treated as 1.2.3 — components beyond patch are ignored: ✓ addressed in _parseSemVer
- Return value contract mirrors Comparable.compareTo: the SIGN is what matters (not magnitude). Tests MUST assert isNegative/isPositive/equals(0), not specific integers: ✓ addressed in compareSemVer and semver_test.dart
- Malformed input throws FormatException. "Malformed" means any of: non-numeric component, empty string, or a purely whitespace string: ✓ addressed in _parseSemVer
- The FormatException message MUST include the offending input string verbatim so callers can diagnose which argument was bad. Example: for compareSemVer('1.2.a', '1.2.3') the thrown FormatException.message must contain the substring '1.2.a': ✓ addressed in _parseSemVer
