### PR TITLE
feat(strings): Add truncateMiddle() helper

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,42 @@
+// Utility functions for String manipulation.
+
+/// Truncates a string by replacing the middle portion with an ellipsis
+/// if its length exceeds [maxLength].
+///
+/// The [maxLength] includes the length of the [ellipsis].
+/// If the input length is less than or equal to [maxLength], it is returned unchanged.
+///
+/// If [maxLength] is less than the length of [ellipsis], the ellipsis
+/// itself is truncated to [maxLength].
+///
+/// When the remaining budget for visible characters ([maxLength] - [ellipsis].length)
+/// is odd, the extra character is assigned to the prefix.
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abcd…lmn'`
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'`
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  if (maxLength < ellipsis.length) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  final availableVisibleChars = maxLength - ellipsis.length;
+  // If availableVisibleChars is odd, distribute the extra char to the prefix.
+  final prefixCount = (availableVisibleChars + 1) ~/ 2;
+  final suffixCount = availableVisibleChars - prefixCount;
+
+  final prefix = input.substring(0, prefixCount);
+  final suffix = input.substring(input.length - suffixCount);
+
+  return '$prefix$ellipsis$suffix';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('replaces the middle while preserving prefix and suffix', () {
+      // Input length 14, maxLength 8, ellipsis '…' (len 1)
+      // availableVisibleChars = 7. Prefix 4, Suffix 3.
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abcd…lmn');
+    });
+
+    test('returns empty string for empty input', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns truncated ellipsis when maxLength is shorter than ellipsis', () {
+      // ellipsis is '...', length 3. maxLength is 2.
+      expect(truncateMiddle('some long string', 2, ellipsis: '...'), '..');
+      expect(truncateMiddle('some long string', 1, ellipsis: '...'), '.');
+      expect(truncateMiddle('some long string', 0, ellipsis: '...'), '');
+    });
+
+    test('counts custom ellipsis length against maxLength', () {
+      // Input 'abcdefghij' (10), maxLength 7, ellipsis '...' (3)
+      // availableVisibleChars = 4. Prefix 2, Suffix 2.
+      expect(truncateMiddle('abcdefghij', 7, ellipsis: '...'), 'ab...ij');
+    });
+
+    test('assigns the odd leftover visible character to the prefix consistently', () {
+      // Input length 10, maxLength 6, ellipsis '…' (1)
+      // availableVisibleChars = 5. Prefix 3, Suffix 2.
+      expect(truncateMiddle('abcdefghij', 6), 'abc…ij');
+      
+      // Input length 10, maxLength 4, ellipsis '…' (1)
+      // availableVisibleChars = 3. Prefix 2, Suffix 1.
+      expect(truncateMiddle('abcdefghij', 4), 'ab…j');
+    });
+
+    test('handles maxLength exactly equal to ellipsis length', () {
+      expect(truncateMiddle('abcdef', 1, ellipsis: '…'), '…');
+      expect(truncateMiddle('abcdef', 3, ellipsis: '...'), '...');
+    });
+    
+    test('documented design choice for small maxLength', () {
+      // truncateMiddle('abcdef', 3) -> 'a…f'
+      // availableVisibleChars = 2. Prefix 1, Suffix 1.
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+  });
+}


### PR DESCRIPTION
## Linked card\n\nCloses #240\n\n## What changed\n\n- Added lib/core/utils/string_utils.dart with truncateMiddle() utility.\n- Added test/core/utils/string_utils_test.dart with comprehensive unit tests.\n\n## How verified\n\n```bash\nflutter test test/core/utils/string_utils_test.dart\n# 00:00 +8: All tests passed!\nflutter test\n# 00:00 +16: All tests passed!\ndart analyze lib/core/utils/string_utils.dart test/core/utils/string_utils_test.dart\n# No issues found!\n```\n\n## Acceptance criteria coverage\n\n- AC 1: Implementation matches all behaviors described in the task body (see Notes)\n  - ✓ addressed in lib/core/utils/string_utils.dart\n- AC 2: All named tests pass the verification command\n  - ✓ addressed in test/core/utils/string_utils_test.dart\n- AC 3: No dependencies added unless absolutely required\n  - ✓ addressed: no changes to pubspec.yaml\n\n## Non-goals acknowledged\n\n- Do NOT modify files beyond the expected set below: not violated\n- Do NOT add third-party dependencies unless required by the task body: not violated\n- Do NOT refactor unrelated code in the touched files: not violated\n\n## Notes\n\n- Documented design choice: For truncateMiddle('abcdef', 3), the result is 'a…f'. This maximizes visible characters by using the full maxLength budget (1 prefix + 1 ellipsis + 1 suffix).\n- Leftover distribution: When (maxLength - ellipsis.length) is odd, the extra character is assigned to the prefix.\n- Handling of short maxLength: If maxLength is less than ellipsis length, the ellipsis is truncated (e.g., truncateMiddle(..., 2, ellipsis: '...') returns '..').\n\n### Coverage\n\n- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/string_utils.dart\n- All named tests pass the verification command: ✓ addressed in test/core/utils/string_utils_test.dart\n- No dependencies added unless absolutely required: ✓ addressed in pubspec.yaml