### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,28 @@
+/// Extension for chunking a list into consecutive sub-lists.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Each chunk is a fresh list independent of the original.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Examples:
+  /// - `[1,2,3,4,5].chunked(2)` → `[[1,2],[3,4],[5]]`
+  /// - `[1,2,3].chunked(10)` → `[[1,2,3]]`
+  /// - `[].chunked(3)` → `[]`
+  /// - `[1].chunked(1)` → `[[1]]`
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('size must be at least 1', 'size');
+    }
+    if (isEmpty) {
+      return [];
+    }
+    final result = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = start + size < length ? start + size : length;
+      result.add(sublist(start, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      expect([1, 2, 3, 4, 5].chunked(2), equals([[1, 2], [3, 4], [5]]));
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      expect([1, 2, 3].chunked(3), equals([[1, 2, 3]]));
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), equals([[1, 2, 3]]));
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      expect(<int>[].chunked(3), equals([]));
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      expect([1].chunked(1), equals([[1]]));
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(
+        () => [1, 2, 3].chunked(0),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final original = [1, 2, 3, 4];
+      final chunks = original.chunked(2);
+      chunks[0][0] = 99;
+      expect(original, equals([1, 2, 3, 4]));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #246

## What changed

- Added `extension ChunkedList<T> on List<T>` in `lib/core/utils/list_extensions.dart` with `chunked(int size)` method that splits a list into consecutive sub-lists of at most `size` elements.
- Added 7 tests in `test/core/utils/list_extensions_test.dart` covering happy path, boundary cases (size equals/exceeds list length), empty list, single element, ArgumentError on size=0, and independent chunk verification.

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```

```
00:00 +7: All tests passed!
flutter analyze lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): Verified via `chunked()` implementation covering: ArgumentError on size<1, empty-list returns [], bounded chunk-end calculation for smaller last chunk, and `sublist()` for independent chunk lists. Mutation test proves independence.
- AC 2 (All named tests pass the verification command): Verified via `flutter test test/core/utils/list_extensions_test.dart` — all 7 tests pass.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` were touched.
- Do NOT add third-party dependencies unless required by the task body: not violated — no new dependencies added.
- Do NOT refactor unrelated code in the touched files: not violated — only `ChunkedList.chunked(int size)` was added/modified.

## Notes

- The implementation uses a simple index-loop with `sublist(start, end)` to produce fresh independent chunk lists.
- `pubspec.lock` was reverted after `flutter pub get` updated it during test runs — not included in the commit.