### PR TITLE
[BENCH t01 qwen3.5-c] feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,68 @@
+// Utility functions for semantic version comparison.
+
+/// Compares two semantic version strings and returns a comparator-style integer.
+///
+/// Returns negative if [a] < [b], zero if [a] == [b], positive if [a] > [b].
+///
+/// Accepts versions of the form MAJOR.MINOR.PATCH (e.g., '1.2.3').
+/// Short versions like '1.2' are treated as '1.2.0' (missing components default to zero).
+/// Extra trailing components beyond patch are ignored (e.g., '1.2.3.4' is treated as '1.2.3').
+///
+/// Throws [FormatException] if either input is malformed (empty, whitespace-only,
+/// or contains non-numeric components). The exception message includes the
+/// offending input string verbatim.
+///
+/// Examples:
+/// - `compareSemVer('1.2.3', '1.2.3')` → `0`
+/// - `compareSemVer('1.2.3', '1.2.4')` → negative
+/// - `compareSemVer('1.10.0', '1.2.0')` → positive (numeric comparison)
+/// - `compareSemVer('1.2', '1.2.0')` → `0` (short form pads with zero)
+/// - `compareSemVer('1.2.3.4', '1.2.3')` → `0` (extra components ignored)
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVer(a);
+  final bComponents = _parseSemVer(b);
+
+  // Compare major, then minor, then patch
+  for (int i = 0; i < 3; i++) {
+    final comparison = aComponents[i].compareTo(bComponents[i]);
+    if (comparison != 0) {
+      return comparison;
+    }
+  }
+  return 0;
+}
+
+/// Parses a semantic version string into exactly three numeric components.
+///
+/// Returns a list of three integers: [major, minor, patch].
+/// Short versions are padded with zeros (e.g., '1.2' → [1, 2, 0]).
+/// Extra trailing components are ignored (e.g., '1.2.3.4' → [1, 2, 3]).
+///
+/// Throws [FormatException] if the input is empty, whitespace-only,
+/// or contains non-numeric components. The exception message includes
+/// the original input string.
+List<int> _parseSemVer(String input) {
+  // Reject empty or whitespace-only input
+  if (input.trim().isEmpty) {
+    throw FormatException('Invalid semantic version: $input');
+  }
+
+  final parts = input.split('.');
+
+  // Parse exactly three components (major, minor, patch)
+  final components = <int>[];
+  for (int i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final parsed = int.tryParse(parts[i]);
+      if (parsed == null) {
+        throw FormatException('Invalid semantic version: $input');
+      }
+      components.add(parsed);
+    } else {
+      // Pad missing components with 0
+      components.add(0);
+    }
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions returns zero', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('major difference returns correct sign', () {
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('minor difference returns correct sign', () {
+      expect(compareSemVer('1.3.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.3.0'), isNegative);
+    });
+
+    test('patch difference returns correct sign', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('numeric ordering works correctly', () {
+      // 1.10.0 > 1.2.0 (numeric, not lexicographic)
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('short form pads missing components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('1.2', '1.2.3'), isNegative);
+    });
+
+    test('extra trailing components are ignored', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3.4.5', '1.2.3'), equals(0));
+    });
+
+    test('malformed input throws FormatException', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('FormatException message contains the offending input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('empty or whitespace-only input throws FormatException', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #249

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` function
- Created `test/core/utils/semver_test.dart` with 10 test cases covering all acceptance criteria
- Implementation handles short forms (1.2 → 1.2.0), extra components (1.2.3.4 → 1.2.3), and numeric comparison
- Malformed input throws FormatException with the offending input in the message

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
flutter test
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

Output digest:
- `flutter test test/core/utils/semver_test.dart`: 10 tests passed
- `flutter test`: 18 tests passed (full suite including new tests)
- `dart analyze`: No issues found

## Acceptance criteria coverage

- AC 1 (signature is exactly `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`): ✓ addressed in `lib/core/utils/semver.dart` line 18
- AC 2 (numeric major/minor/patch comparison): ✓ addressed in `lib/core/utils/semver.dart` lines 20-27
- AC 3 (short version defaults missing components to zero): ✓ addressed in `_parseSemVer` helper, tested in "short form pads missing components with zero"
- AC 4 (extra trailing components are ignored): ✓ addressed in `_parseSemVer` helper (only reads first 3 components), tested in "extra trailing components are ignored"
- AC 5 (tests assert sign only, not exact nonzero magnitude): ✓ addressed in `test/core/utils/semver_test.dart` using `isPositive`/`isNegative`/`equals(0)`
- AC 6 (malformed input throws FormatException): ✓ addressed in `_parseSemVer` helper, tested in "malformed input throws FormatException" and "empty or whitespace-only input throws FormatException"
- AC 7 (FormatException.message includes the offending input verbatim): ✓ addressed in exception message construction, tested in "FormatException message contains the offending input"
- AC: Implementation matches all behaviors described in the task body: ✓ addressed in full implementation
- AC: All named tests pass the verification command: ✓ verified with `flutter test`
- AC: No dependencies added unless absolutely required: ✓ no dependencies added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` modified
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — new files only

## Notes

None — implementation follows the approved plan exactly.

### Coverage

- AC 1 (signature is exactly `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`): ✓ addressed in lib/core/utils/semver.dart
- AC 2 (numeric major/minor/patch comparison): ✓ addressed in lib/core/utils/semver.dart
- AC 3 (short version defaults missing components to zero): ✓ addressed in lib/core/utils/semver.dart
- AC 4 (extra trailing components are ignored): ✓ addressed in lib/core/utils/semver.dart
- AC 5 (tests assert sign only, not exact nonzero magnitude): ✓ addressed in test/core/utils/semver_test.dart
- AC 6 (malformed input throws FormatException): ✓ addressed in lib/core/utils/semver.dart
- AC 7 (FormatException.message includes the offending input verbatim): ✓ addressed in lib/core/utils/semver.dart
- AC: Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/semver.dart
- AC: All named tests pass the verification command: ✓ addressed in test/core/utils/semver_test.dart
- AC: No dependencies added unless absolutely required: ✓ no dependencies added