### PR TITLE
feat(strings): add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,41 @@
+/// Utility functions for string manipulation.
+
+/// Truncates the middle of a string with an ellipsis, preserving the start and end.
+///
+/// If [input] length is less than or equal to [maxLength], returns [input] unchanged.
+/// Otherwise, replaces the middle of the string with [ellipsis], keeping the start
+/// and end visible such that the total length is less than or equal to [maxLength].
+///
+/// The [maxLength] parameter includes the length of the ellipsis.
+/// If [maxLength] is shorter than [ellipsis], returns [ellipsis] truncated to [maxLength].
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abcd…lmn'`
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'*
+library string_utils;
+
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // Return unchanged if input already fits within maxLength
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  // Calculate available characters for visible content (excluding ellipsis)
+  final availableVisibleChars = maxLength - ellipsis.length;
+  
+  // If maxLength is shorter than ellipsis, return truncated ellipsis
+  if (availableVisibleChars <= 0) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  // Distribute visible characters: start gets the extra character if odd
+  final prefixLength = (availableVisibleChars + 1) ~/ 2;
+  final suffixLength = availableVisibleChars ~/ 2;
+  
+  // Construct and return the truncated string
+  return input.substring(0, prefixLength) +
+      ellipsis +
+      input.substring(input.length - suffixLength);
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when it already fits maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('a', 1), 'a');
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('truncates the middle with the extra odd-budget character kept at the start', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abcd…lmn');
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+
+    test('returns empty string for empty input', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns truncated ellipsis alone when maxLength is shorter than ellipsis', () {
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+      expect(truncateMiddle('abcdef', 1, ellipsis: '...'), '.');
+    });
+
+    test('counts the full ellipsis length toward maxLength', () {
+      expect(truncateMiddle('abcdefghi', 5, ellipsis: '...'), 'a...i');
+      // Verify length constraint is respected
+      final result = truncateMiddle('abcdefghi', 5, ellipsis: '...');
+      expect(result.length, lessThanOrEqualTo(5));
+    });
+
+    test('handles single character input', () {
+      expect(truncateMiddle('a', 1), 'a');
+      expect(truncateMiddle('ab', 1), '…');
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #252

## What changed

- Created `lib/core/utils/string_utils.dart` with the `truncateMiddle()` function
- Created `test/core/utils/string_utils_test.dart` with comprehensive test coverage

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
```
Output: All 6 tests passed

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body ✓ addressed in lib/core/utils/string_utils.dart
- AC 2: All named tests pass the verification command ✓ addressed in test/core/utils/string_utils_test.dart
- AC 3: No dependencies added unless absolutely required ✓ addressed (no dependencies added)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

- Implementation follows the exact truncation policy specified: when visible character budget is odd, the extra character goes to the start
- All edge cases handled: empty string, single character, maxLength shorter than ellipsis
- No modifications made to existing files, only added the two requested files

### Coverage

- AC 1 (verbatim): ✓ addressed in lib/core/utils/string_utils.dart
- AC 2 (verbatim): ✓ addressed in test/core/utils/string_utils_test.dart
- AC 3 (verbatim): ✓ addressed (no dependencies added)