### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,19 @@
+extension ChunkedList<T> on List<T> {
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('chunk size must be >= 1, but was $size');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final result = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = (start + size).clamp(0, length);
+      result.add(sublist(start, end));
+    }
+
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList.chunked', () {
+    test('splits a list into consecutive chunks of the requested size', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [
+        [1, 2],
+        [3, 4],
+        [5]
+      ]);
+    });
+
+    test('returns one chunk when chunk size equals the list length', () {
+      expect([1, 2, 3].chunked(3), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('returns one chunk when chunk size exceeds the list length', () {
+      expect([1, 2, 3].chunked(10), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('returns an empty list for an empty source list', () {
+      expect([].chunked(3), []);
+    });
+
+    test('returns a single-element chunk for a single-element list', () {
+      expect([1].chunked(1), [
+        [1]
+      ]);
+    });
+
+    test('throws ArgumentError when size is 0', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+    });
+
+    test('returns independent chunk lists', () {
+      final original = [1, 2, 3, 4];
+      final chunks = original.chunked(2);
+      // Mutate a chunk
+      chunks[0][0] = 99;
+      // Original should remain unchanged
+      expect(original, [1, 2, 3, 4]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #255

## What changed

- Added `extension ChunkedList<T> on List<T>` with method `List<List<T>> chunked(int size)` in `lib/core/utils/list_extensions.dart`.
- Added comprehensive test suite in `test/core/utils/list_extensions_test.dart` covering all required behaviors.

## How verified

Exact commands run (from the card's `verification` field) and their output digest:

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```

Output:
```
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: ChunkedList.chunked splits a list into consecutive chunks of the requested size
00:00 +1: ChunkedList.chunked returns one chunk when chunk size equals the list length
00:00 +2: ChunkedList.chunked returns one chunk when chunk size exceeds the list length
00:00 +3: ChunkedList.chunked returns an empty list for an empty source list
00:00 +4: ChunkedList.chunked returns a single-element chunk for a single-element list
00:00 +5: ChunkedList.chunked throws ArgumentError when size is 0
00:00 +6: ChunkedList.chunked throws ArgumentError when size is negative
00:00 +7: ChunkedList.chunked returns independent chunk lists
00:00 +8: All tests passed!
```

Static analysis: `dart analyze lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart` reports "No issues found!".

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes)
  ✓ Implemented `ChunkedList<T>.chunked(int size)` with required signature, argument validation (`size >= 1`), empty list handling, last-chunk smaller than size, and independent chunk lists via `sublist`.
  ✓ All example behaviors verified by tests: `[1,2,3,4,5].chunked(2) → [[1,2],[3,4],[5]]`, size > length, empty list, single-element.

- AC 2: All named tests pass the verification command
  ✓ Test file includes 8 tests covering happy path, boundary cases (size = length, size > length), empty list, single element, ArgumentError on size=0, and chunk independence.
  ✓ `flutter test test/core/utils/list_extensions_test.dart` passes all tests (8/8).

- AC 3: No dependencies added unless absolutely required
  ✓ No changes to `pubspec.yaml`, lockfiles, or any dependency declarations. Implementation uses core Dart list operations only.

## Non-goals acknowledged

Each non-goal from the linked card, confirmed not violated:

- Do NOT modify files beyond the expected set below: only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` were created (git diff confirms).
- Do NOT add third-party dependencies unless required by the task body: no dependencies added (no pubspec changes).
- Do NOT refactor unrelated code in the touched files: no refactoring of existing code; only new extension and test file.

## Notes

- Added extra test case for negative size (size < 1) as reasonable extension of `size >= 1` requirement.
- Test for chunk independence ensures mutation of a chunk does not affect original list.
-