### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,46 @@
+/// Compares two semantic-version strings numerically.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b],
+/// or a positive integer if [a] > [b] — mirroring [Comparable.compareTo].
+///
+/// Short versions are padded with zeros (e.g. `"1.2"` → `1.2.0`).
+/// Components beyond patch are ignored (e.g. `"1.2.3.4"` → `1.2.3`).
+///
+/// Throws [FormatException] if either input is malformed (empty,
+/// whitespace-only, contains non-numeric or empty components).
+/// The exception message includes the offending input verbatim.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+  for (var i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) return cmp;
+  }
+  return 0;
+}
+
+/// Parses a semantic-version string into exactly three integer components.
+///
+/// Validates every component in the original input (not just the first three).
+/// Pads missing minor/patch with 0; truncates components beyond patch only
+/// after validation succeeds.
+///
+/// Throws [FormatException] with the original input included verbatim
+/// in the message if validation fails.
+List<int> _parseSemVer(String version) {
+  if (version.isEmpty || version.trim().isEmpty) {
+    throw FormatException('Invalid semantic version: "$version"');
+  }
+  final parts = version.split('.');
+  // Validate every component — empty segments or non-numeric are malformed.
+  for (final part in parts) {
+    if (part.isEmpty || int.tryParse(part) == null) {
+      throw FormatException('Invalid semantic version: "$version"');
+    }
+  }
+  return [
+    int.parse(parts[0]),
+    parts.length > 1 ? int.parse(parts[1]) : 0,
+    parts.length > 2 ? int.parse(parts[2]) : 0,
+  ];
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions return zero', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('major difference returns positive when a > b', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+    });
+
+    test('minor difference returns negative when a < b', () {
+      expect(compareSemVer('1.2.3', '1.3.0'), isNegative);
+    });
+
+    test('patch difference returns negative when a < b', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('numeric ordering: 1.10.0 > 1.2.0', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('short form pads with zero: 1.2 equals 1.2.0', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('extra components truncated: 1.2.3.4 equals 1.2.3', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('malformed input throws FormatException', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message contains offending input verbatim', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #262

## What changed

- Added `lib/core/utils/semver.dart` — new file with `int compareSemVer(String a, String b)` that compares semantic-version strings numerically (major → minor → patch), pads short versions with zero, ignores extra trailing components, and throws `FormatException` with the offending input verbatim in the message for malformed inputs.
- Added `test/core/utils/semver_test.dart` — 9 test cases covering equality, per-component sign ordering, numeric ordering regression (`1.10.0` vs `1.2.0`), short-form padding, extra-component truncation, `FormatException` type assertion, and `FormatException` message-content assertion.

## How verified

```
$ flutter test test/core/utils/semver_test.dart
00:00 +9: All tests passed!

$ dart analyze lib/core/utils/semver.dart
No issues found!

$ dart analyze test/core/utils/semver_test.dart
No issues found!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body → ✓ addressed in `lib/core/utils/semver.dart` (`compareSemVer` + `_parseSemVer`)
- AC 2: All named tests pass the verification command → ✓ addressed in `test/core/utils/semver_test.dart` (9/9 tests pass)
- AC 3: No dependencies added unless absolutely required → ✓ only uses core Dart `String`/`int`/`FormatException`; no package changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `semver.dart` and `semver_test.dart` changed
- Do NOT add third-party dependencies: not violated — no pubspec changes
- Do NOT refactor unrelated code: not violated — no existing files touched

## Notes

- The `_parseSemVer` private helper validates ALL dot-separated components in the original string before normalizing to three integer parts, so `1.2.3.a` is rejected (not silently accepted) while `1.2.3.4` normalizes to `1.2.3`.
- `pubspec.lock` was temporarily modified by `flutter pub get` during test execution but was reverted before commit.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/semver.dart` (`compareSemVer`, `_parseSemVer`)
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/semver_test.dart` (9/9 passing)
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — zero dependency file changes