### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,34 @@
+/// Extension methods on [List<T>] for collection operations.
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Returns a new list containing independent chunk lists. Mutating a
+  /// returned chunk does not affect the original list or other chunks.
+  ///
+  /// ## Examples
+  /// ```dart
+  /// [1, 2, 3, 4, 5].chunked(2) // [[1, 2], [3, 4], [5]]
+  /// [1, 2, 3].chunked(10)      // [[1, 2, 3]]
+  /// [].chunked(3)              // []
+  /// [1].chunked(1)             // [[1]]
+  /// ```
+  ///
+  /// ## Throws
+  /// [ArgumentError] if [size] is less than 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError('size must be >= 1, got $size');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final chunks = <List<T>>[];
+    for (var i = 0; i < length; i += size) {
+      final end = i + size < length ? i + size : length;
+      chunks.add(sublist(i, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('chunked', () {
+    test('returns consecutive chunks for a normal list', () {
+      final result = [1, 2, 3, 4, 5].chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('returns one chunk when size equals list length', () {
+      final result = [1, 2, 3].chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('returns one chunk when size exceeds list length', () {
+      final result = [1, 2, 3].chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('returns empty list for empty input', () {
+      final result = <int>[].chunked(3);
+      expect(result, []);
+    });
+
+    test('returns single-item chunk for single-element list', () {
+      final result = [1].chunked(1);
+      expect(result, [[1]]);
+    });
+
+    test('throws ArgumentError when size is 0', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('returned chunks are independent from original list', () {
+      final original = [1, 2, 3, 4, 5];
+      final chunks = original.chunked(2);
+      
+      // Mutate the first chunk
+      chunks[0].add(99);
+      
+      // Original list should be unchanged
+      expect(original, [1, 2, 3, 4, 5]);
+      
+      // Other chunks should be unchanged
+      expect(chunks[1], [3, 4]);
+      expect(chunks[2], [5]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #263

## What changed

- Created `lib/core/utils/list_extensions.dart` with `ChunkedList<T>` extension on `List<T>`
- Added `chunked(int size)` method that splits list into consecutive sub-lists of at most `size` elements
- Created `test/core/utils/list_extensions_test.dart` with comprehensive test coverage

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```

Output: All 7 tests passed (happy path, boundary cases, empty list, single element, ArgumentError on size=0, chunk independence)

```bash
flutter test
```

Output: All 15 tests passed (full suite including new tests)

```bash
dart analyze lib/core/utils/list_extensions.dart
```

Output: No issues found

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body ✓ addressed in `lib/core/utils/list_extensions.dart` (chunked method with size validation, empty handling, independent chunks)
- AC 2: All named tests pass the verification command ✓ addressed in `test/core/utils/list_extensions_test.dart` (7 tests covering all named cases)
- AC 3: No dependencies added unless absolutely required ✓ addressed - uses only core Dart list operations, no pubspec.yaml changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated - only touched the two expected files
- Do NOT add third-party dependencies unless required by the task body: not violated - no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - new files only, no refactoring

## Notes

None - implementation followed the approved plan exactly.

### Coverage

- AC 1: Implementation matches all behaviors described in the task body: ✓ addressed in lib/core/utils/list_extensions.dart
- AC 2: All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- AC 3: No dependencies added unless absolutely required: ✓ addressed - no pubspec.yaml changes