### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,46 @@
+/// Compares two semantic version strings numerically.
+///
+/// Returns a negative integer if `a < b`, zero if `a == b`, and a positive integer if `a > b`.
+///
+/// Each string is expected to be in the form `MAJOR.MINOR.PATCH` (e.g., '1.2.3').
+/// Extra components (e.g., '1.2.3.4') are ignored. Short versions (e.g., '1.2')
+/// are padded with zeros (e.g., '1.2.0').
+///
+/// Throws a [FormatException] if either input is empty, purely whitespace,
+/// or contains a non-numeric component.
+int compareSemVer(String a, String b) {
+  final aParts = _parseVersion(a);
+  final bParts = _parseVersion(b);
+
+  for (var i = 0; i < 3; i++) {
+    final comparison = aParts[i].compareTo(bParts[i]);
+    if (comparison != 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+List<int> _parseVersion(String version) {
+  if (version.trim().isEmpty) {
+    throw FormatException('Invalid version string: "$version"', version);
+  }
+
+  final parts = version.split('.');
+  final result = <int>[0, 0, 0];
+
+  for (var i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final part = parts[i];
+      final parsed = int.tryParse(part);
+
+      if (parsed == null) {
+        throw FormatException('Invalid non-numeric component in version: "$version"', version);
+      }
+      result[i] = parsed;
+    }
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('major difference', () {
+      expect(compareSemVer('2.0.0', '1.9.9'), isPositive);
+      expect(compareSemVer('1.9.9', '2.0.0'), isNegative);
+    });
+
+    test('minor difference', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('patch difference', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('numeric ordering', () {
+      // Proves it's not lexicographical
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('short-form padding', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('1.2.1', '1.2'), isPositive);
+    });
+
+    test('extra-component truncation', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.4'), equals(0));
+    });
+
+    test('FormatException type assertion', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('FormatException message-content assertion', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+      expect(
+        () => compareSemVer('1.2.3', ''),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains(''))),
+      );
+      expect(
+        () => compareSemVer('1.2.3', '   '),
+        throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('   '))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card\n\nCloses #264\n\n## What changed\n\n- Created `lib/core/utils/semver.dart` with `compareSemVer(a, b)` utility.\n- Implemented numeric semantic version comparison (major -> minor -> patch).\n- Added support for short-form versions (padding with zero) and extra components (truncation).\n- Added `FormatException` handling for malformed input with verbatim offending string in message.\n- Created `test/core/utils/semver_test.dart` with full coverage of required behaviors.\n\n## How verified\n\n```bash\nflutter test test/core/utils/semver_test.dart\n```\nOutput digest:\n```\n00:00 +0: compareSemVer equal versions\n00:00 +1: compareSemVer major difference\n00:00 +2: compareSemVer minor difference\n00:00 +3: compareSemVer patch difference\n00:00 +4: compareSemVer numeric ordering\n00:00 +5: compareSemVer short-form padding\n00:00 +6: compareSemVer extra-component truncation\n00:00 +7: compareSemVer FormatException type assertion\n00:00 +8: compareSemVer FormatException message-content assertion\n00:00 +9: All tests passed!\n```\n\n## Acceptance criteria coverage\n\n- Implementation matches all behaviors described in the task body: ✓ Addressed in `lib/core/utils/semver.dart`\n- All named tests pass the verification command: ✓ Verified with `flutter test`\n- No dependencies added unless absolutely required: ✓ No changes to `pubspec.yaml`\n\n## Non-goals acknowledged\n\n- Do NOT modify files beyond the expected set below: Not violated\n- Do NOT add third-party dependencies unless required by the task body: Not violated\n- Do NOT refactor unrelated code in the touched files: Not violated\n\n## Notes\n\nNone.\n\n### Coverage\n\n- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/semver.dart\n- All named tests pass the verification command: ✓ addressed in test/core/utils/semver_test.dart\n- No dependencies added unless absolutely required: ✓ addressed (no pubspec.yaml changes)\n