### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,34 @@
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Returns a list of lists where each inner list contains up to [size] elements
+  /// from the original list in the same order. The last chunk may be smaller
+  /// than [size] if the list length is not evenly divisible by [size].
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Examples:
+  /// ```dart
+  /// [1, 2, 3, 4, 5].chunked(2) // [[1, 2], [3, 4], [5]]
+  /// [1, 2, 3].chunked(10)      // [[1, 2, 3]]
+  /// [].chunked(3)              // []
+  /// [1].chunked(1)             // [[1]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'Must be greater than 0');
+    }
+
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final List<List<T>> chunks = <List<T>>[];
+    for (int i = 0; i < length; i += size) {
+      final int end = (i + size < length) ? i + size : length;
+      chunks.add(sublist(i, end));
+    }
+
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      final List<int> list = [1, 2, 3, 4, 5];
+      final List<List<int>> result = list.chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      final List<int> list = [1, 2, 3];
+      final List<List<int>> result = list.chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      final List<int> list = [1, 2, 3];
+      final List<List<int>> result = list.chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      final List<int> list = [];
+      final List<List<int>> result = list.chunked(3);
+      expect(result, []);
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      final List<int> list = [42];
+      final List<List<int>> result = list.chunked(1);
+      expect(result, [[42]]);
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      final List<int> list = [1, 2, 3];
+      expect(() => list.chunked(0), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunks (mutating a chunk does not affect original list)', () {
+      final List<int> list = [1, 2, 3, 4, 5];
+      final List<List<int>> chunks = list.chunked(2);
+      
+      // Mutate the first chunk
+      chunks[0][0] = 999;
+      
+      // Original list should remain unchanged
+      expect(list, [1, 2, 3, 4, 5]);
+      
+      // The chunk should reflect the mutation
+      expect(chunks[0], [999, 2]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #270

## What changed

- Created `lib/core/utils/list_extensions.dart` with `ChunkedList<T>` extension on `List<T>`
- Implements `List<List<T>> chunked(int size)` method that splits list into consecutive chunks
- Added proper argument validation (size must be >= 1)
- Returns independent chunks so mutating a chunk doesn't affect the original list
- Created `test/core/utils/list_extensions_test.dart` with comprehensive test coverage

## How verified

```bash
cd ~/workspace/infiquetra/mimir && flutter test test/core/utils/list_extensions_test.dart
```
Output: All 7 tests passed including happy path, boundary cases, empty list, single element, ArgumentError on size=0, and independence test.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body ✓ addressed in lib/core/utils/list_extensions.dart (chunked method implementation) and test/core/utils/list_extensions_test.dart (all test cases)
- AC 2: All named tests pass the verification command ✓ addressed by running flutter test test/core/utils/list_extensions_test.dart which exits with code 0
- AC 3: No dependencies added unless absolutely required ✓ addressed by verifying pubspec.lock unchanged and no new packages added

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated (only modified lib/core/utils/list_extensions.dart and test/core/utils/list_extensions_test.dart)
- Do NOT add third-party dependencies unless required by the task body: not violated (no dependencies added)
- Do NOT refactor unrelated code in the touched files: not violated (only added the required extension method and tests)

## Notes

- Used Dart's built-in sublist method to ensure returned chunks are independent
- Followed the exact specification from the issue including all examples and edge cases
- Implemented proper error handling with ArgumentError for invalid size values
- All tests pass and dart analyzer shows no new errors

### Coverage

- AC 1 (verbatim): ✓ addressed in lib/core/utils/list_extensions.dart and test/core/utils/list_extensions_test.dart
- AC 2 (verbatim): ✓ addressed in test/core/utils/list_extensions_test.dart
- AC 3 (verbatim): ✓ addressed in pubspec.lock (unchanged) and no new dependencies added