### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,37 @@
+/// Utility functions for string manipulation.
+
+/// Truncates [input] to [maxLength] by replacing the middle with [ellipsis],
+/// keeping the start and end visible.
+///
+/// The odd-budget rule: when `(maxLength - ellipsis.length)` is odd, the
+/// extra character is given to the start portion.
+///
+/// - Returns [input] unchanged if `input.length <= maxLength`.
+/// - Returns `ellipsis.substring(0, maxLength)` if `maxLength <= ellipsis.length`.
+/// - Throws [ArgumentError] if [maxLength] is negative.
+/// - Returns `''` if [maxLength] is zero.
+String truncateMiddle(
+  String input,
+  int maxLength, {
+  String ellipsis = '…',
+}) {
+  if (maxLength < 0) {
+    throw ArgumentError('maxLength must not be negative', 'maxLength');
+  }
+  if (maxLength == 0) {
+    return '';
+  }
+  if (input.length <= maxLength) {
+    return input;
+  }
+  if (maxLength <= ellipsis.length) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  final visibleCount = maxLength - ellipsis.length;
+  // Odd budget goes to the start: (n+1)/2 for start, n/2 for end
+  final startCount = (visibleCount + 1) ~/ 2;
+  final endCount = visibleCount ~/ 2;
+
+  return '${input.substring(0, startCount)}$ellipsis${input.substring(input.length - endCount)}';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when shorter than maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+    });
+
+    test('returns input unchanged when length equals maxLength', () {
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('returns single-character input unchanged when within maxLength', () {
+      expect(truncateMiddle('x', 1), 'x');
+      expect(truncateMiddle('x', 5), 'x');
+    });
+
+    test('replaces the middle while keeping start and end visible', () {
+      // maxLength=8, ellipsis=1 → visible=7 → start=4, end=3 (odd to start)
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abcd…lmn');
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns truncated ellipsis when maxLength is shorter than ellipsis',
+        () {
+      expect(truncateMiddle('hello', 1, ellipsis: '……'), '…');
+      expect(truncateMiddle('hello', 2, ellipsis: '……'), '……'.substring(0, 2));
+    });
+
+    test('counts custom ellipsis length toward maxLength', () {
+      // 3-char ellipsis + 1 start + 1 end = 5 total ≤ maxLength=5
+      expect(truncateMiddle('abcdefgh', 5, ellipsis: '...'), 'a...h');
+      // maxLength=6: visible=6-3=3 → start=2, end=1 → 'ab...i' (6 chars)
+      expect(truncateMiddle('abcdefghij', 6, ellipsis: '...'), 'ab...j');
+    });
+
+    test('gives the odd extra visible character to the start consistently', () {
+      // maxLength=7, ellipsis=1 → visible=6 → start=3, end=3 → 'abc…hij' (7)
+      expect(truncateMiddle('abcdefghij', 7), 'abc…hij');
+      // maxLength=8, ellipsis=1 → visible=7 → start=4, end=3 → 'abcd…hij' (8)
+      expect(truncateMiddle('abcdefghij', 8), 'abcd…hij');
+    });
+
+    test('throws ArgumentError when maxLength is negative', () {
+      expect(() => truncateMiddle('hello', -1), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #271

## What changed

- Added `truncateMiddle(String input, int maxLength, {String ellipsis = '…'})` to `lib/core/utils/string_utils.dart`
- Added 9 focused test cases in `test/core/utils/string_utils_test.dart`
- Follows the existing top-level utility function convention in `formatters.dart`

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
# Result: 00:00 +9 All tests passed!

flutter test
# Result: 00:00 +17 All tests passed! (9 new + 8 existing)
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — addressed in `lib/core/utils/string_utils.dart` with guards for negative/zero maxLength, unchanged-return for short strings, explicit ellipsis accounting, and the odd-to-start budget rule via `startCount = (visibleCount + 1) ~/ 2`
- AC 2: All named tests pass the verification command — addressed in `test/core/utils/string_utils_test.dart`; 9 named tests covering all specified cases; `flutter test` and `flutter test test/core/utils/string_utils_test.dart` both exit 0
- AC 3: No dependencies added unless absolutely required — addressed; `truncateMiddle` uses only core Dart `String` operations; no changes to `pubspec.yaml` or any dependency file

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart` modified
- Do NOT add third-party dependencies unless required by the task body: not violated — no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — only the new helper and its test group were added

## Notes

- The issue body example `truncateMiddle('abcdefghijklmn', 8) → 'abc…lmn'` shows 3+1+3=7 chars, while the plan's odd-to-start formula produces `abcd…lmn` (4+1+3=8 chars). Both are valid per the "<= maxLength" constraint. This PR follows the plan's approved formula (odd budget to start) and documents the discrepancy.
- The existing `formatters.dart` has the same `dangling_library_doc_comments` lint info that appears in `string_utils.dart`; no new lint issues introduced.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/string_utils.dart` — guards for negative/zero maxLength, early return for unchanged input, ellipsis-length accounting, odd-to-start budget rule
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/string_utils_test.dart` — 9 named tests cover all required cases; `flutter test` and `flutter test test/core/utils/string_utils_test.dart` both exit 0
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — no new dependencies, `truncateMiddle` uses only core Dart `String` APIs