### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,24 @@
+// Extension methods on List for common collection operations.
+
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The last chunk may be smaller than [size] if the list length is not
+  /// evenly divisible. Returned chunks are independent copies — mutating
+  /// a chunk will not affect the original list.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'must be >= 1');
+    }
+    if (isEmpty) return [];
+
+    final result = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = (start + size).clamp(0, length);
+      result.add(sublist(start, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('splits a list into consecutive chunks of at most size elements', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [
+        [1, 2],
+        [3, 4],
+        [5],
+      ]);
+    });
+
+    test('returns a single chunk when size equals list length', () {
+      expect([1, 2, 3].chunked(3), [
+        [1, 2, 3],
+      ]);
+    });
+
+    test('returns a single chunk when size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), [
+        [1, 2, 3],
+      ]);
+    });
+
+    test('returns an empty list for an empty source list', () {
+      expect(<int>[].chunked(3), []);
+    });
+
+    test('returns a single-element chunk for a one-item list', () {
+      expect([1].chunked(1), [
+        [1],
+      ]);
+    });
+
+    test('throws ArgumentError when size is 0', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('returns independent chunk lists', () {
+      final original = [1, 2, 3, 4];
+      final chunks = original.chunked(2);
+      chunks[0][0] = 99;
+      expect(original[0], equals(1));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #277

## What changed

- Added `lib/core/utils/list_extensions.dart` with `extension ChunkedList<T> on List<T>` providing `List<List<T>> chunked(int size)`
- Added `test/core/utils/list_extensions_test.dart` with 7 test cases in `group('ChunkedList', ...)`

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
dart analyze lib/core/utils/list_extensions.dart
```

Output: 7/7 tests passed, 0 analyzer issues.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ Addressed in `lib/core/utils/list_extensions.dart` — the `chunked()` method handles size validation (ArgumentError for size < 1), empty-list fast-return, consecutive slicing with last-chunk-shorter-than-size, and independent chunk lists via `sublist()`.
- AC 2 (All named tests pass the verification command): ✓ All 7 test cases in `test/core/utils/list_extensions_test.dart` pass via `flutter test test/core/utils/list_extensions_test.dart`.
- AC 3 (No dependencies added unless absolutely required): ✓ No new dependencies. Implementation uses only Dart core `List<T>` operations.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` in the diff.
- Do NOT add third-party dependencies unless required by the task body: not violated — zero new package imports.
- Do NOT refactor unrelated code in the touched files: not violated — both files are newly created with no adjacent code to refactor.

## Notes

No deviations from the approved plan.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/list_extensions.dart` / `ChunkedList.chunked()`
- All named tests pass the verification command: ✓ addressed in `test/core/utils/list_extensions_test.dart` — 7/7 passing
- No dependencies added unless absolutely required: ✓ confirmed — no pubspec changes, no new imports beyond `flutter_test` and the package import