### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,53 @@
+/// Compares two semantic version strings and returns a comparator-style integer.
+///
+/// Returns a negative value when [a] < [b], zero when [a] == [b], and a
+/// positive value when [a] > [b].
+///
+/// Versions are compared numerically component by component (major → minor →
+/// patch), so `1.10.0` is greater than `1.2.0`.
+///
+/// Short versions (e.g. `1.2`) are treated as if the missing components are
+/// zero (`1.2.0`). Extra trailing components beyond patch (e.g. `1.2.3.4`)
+/// are ignored.
+///
+/// Throws [FormatException] if [a] or [b] is empty, whitespace-only, or
+/// contains a non-numeric component in the first three positions.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+
+  for (int i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into a list of three integers.
+///
+/// Missing components are padded with zero. Components beyond the first three
+/// are ignored. Throws [FormatException] for empty, whitespace-only, or
+/// non-numeric input.
+List<int> _parseSemVer(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+  final result = <int>[];
+
+  for (int i = 0; i < 3; i++) {
+    if (i >= parts.length) {
+      result.add(0);
+    } else {
+      final parsed = int.tryParse(parts[i]);
+      if (parsed == null) {
+        throw FormatException('Malformed semantic version: $input');
+      }
+      result.add(parsed);
+    }
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major versions numerically', () {
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+      expect(compareSemVer('2.0.0', '1.0.0'), isPositive);
+    });
+
+    test('compares minor versions numerically', () {
+      expect(compareSemVer('1.1.0', '1.2.0'), isNegative);
+      expect(compareSemVer('1.3.0', '1.2.0'), isPositive);
+    });
+
+    test('compares patch versions numerically', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+      expect(compareSemVer('1.2.5', '1.2.4'), isPositive);
+    });
+
+    test('compares numeric components instead of lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('pads missing components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('1.2', '1.2.1'), isNegative);
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3.999', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      // Non-numeric component
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      // Empty string
+      expect(
+        () => compareSemVer('', '1.0.0'),
+        throwsA(isA<FormatException>()),
+      );
+      // Whitespace-only string
+      expect(
+        () => compareSemVer('   ', '1.0.0'),
+        throwsA(isA<FormatException>()),
+      );
+      // Malformed in second argument
+      expect(
+        () => compareSemVer('1.0.0', 'abc'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #289

## What changed

- Created `lib/core/utils/semver.dart` with a top-level `int compareSemVer(String a, String b)` function and a private `_parseSemVer(String input)` helper
- Created `test/core/utils/semver_test.dart` with 9 named tests covering equality, numeric ordering, short-form padding, extra-component truncation, and FormatException type/message assertions

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

All 9 tests passed. Full suite (17 tests) also green -- no regressions.

```
00:00 +9: All tests passed!
```

```
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
Analyzing semver.dart, semver_test.dart...
No issues found!
```

## Acceptance criteria coverage

- AC 1: Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`: -- file created at that path with that exact signature
- AC 2: Compares major/minor/patch NUMERICALLY (1.10.0 > 1.2.0): -- `_parseSemVer` uses int.parse, test covers numeric ordering
- AC 3: Short versions (1.2) treated as 1.2.0: -- `_parseSemVer` pads missing components with zero, test covers `compareSemVer('1.2', '1.2.0')`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: -- only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` changed
- Do NOT add third-party dependencies: -- uses Dart core library only, no pubspec.yaml changes
- Do NOT refactor unrelated code: -- no existing files touched

## Notes

The `pubspec.lock` changed during `flutter test` dependency resolution (16 dependencies bumped) but was reverted to `origin/main` before committing -- it's not part of this PR's diff.

### Coverage

- Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`: addressed in `lib/core/utils/semver.dart` (top-level function)
- All named tests pass the verification command: addressed in `test/core/utils/semver_test.dart` (9 tests, all pass)
- No dependencies added unless absolutely required: addressed -- zero new dependencies, pubspec.yaml untouched
