### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,52 @@
+/// Compares two semantic-version strings [a] and [b] and returns a
+/// comparator-style integer: negative if [a] < [b], zero if [a] == [b],
+/// positive if [a] > [b].
+///
+/// Versions are of the form `MAJOR.MINOR.PATCH` or shorter forms like
+/// `MAJOR.MINOR` (where the missing component defaults to zero).
+/// Components beyond PATCH are ignored (e.g. `1.2.3.4` is treated as
+/// `1.2.3`). All components are compared numerically, not
+/// lexicographically, so `1.10.0 > 1.2.0`.
+///
+/// Throws [FormatException] if any of the first three components is
+/// non-numeric, or if the input is empty or whitespace-only.
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  for (int i = 0; i < 3; i++) {
+    final comparison = aComponents[i].compareTo(bComponents[i]);
+    if (comparison != 0) return comparison;
+  }
+
+  return 0;
+}
+
+/// Parses the first three dot-separated components of [version].
+///
+/// Missing components (e.g. `"1.2"` has no patch) default to zero.
+/// Components beyond index 2 are ignored. Throws [FormatException] if
+/// any of the first three components is non-numeric or if [version] is
+/// empty or whitespace-only.
+List<int> _parseSemVerComponents(String version) {
+  if (version.isEmpty || version.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $version');
+  }
+
+  final parts = version.split('.');
+  final components = <int>[];
+
+  for (int i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final parsed = int.tryParse(parts[i]);
+      if (parsed == null) {
+        throw FormatException('Malformed semantic version: $version');
+      }
+      components.add(parsed);
+    } else {
+      components.add(0);
+    }
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders components numerically instead of lexicographically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads missing patch components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores components after patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input type', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty and whitespace input', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains(''),
+          ),
+        ),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('   '),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #291

## What changed

- Created `lib/core/utils/semver.dart` with public function `int compareSemVer(String a, String b)` and private parser helper `_parseSemVerComponents(String version)`
- Created `test/core/utils/semver_test.dart` with 10 test cases covering equality, component ordering, numeric (not lexicographic) comparison, short-form padding, extra-component truncation, and FormatException type + message assertions

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
# 10/10 tests passed

flutter test
# Full suite: 18/18 tests passed (no regressions)

dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
# No issues found
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): covered by `lib/core/utils/semver.dart` — `compareSemVer` compares major/minor/patch numerically, pads missing components with zero, ignores extra components, and throws `FormatException` with the offending input verbatim
- AC 2 (All named tests pass the verification command): verified — `flutter test` and `dart analyze` both exit 0
- AC 3 (No dependencies added unless absolutely required): confirmed — no `pubspec.yaml` or `pubspec.lock` changes; uses only Dart core + existing `flutter_test`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were changed
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — both files are new

## Notes

No deviations from the plan.

### Coverage

- AC 1 (verbatim): Implementation matches all behaviors described in the task body (see Notes) ✓ addressed in `lib/core/utils/semver.dart`
- AC 2 (verbatim): All named tests pass the verification command ✓ addressed in `test/core/utils/semver_test.dart`
- AC 3 (verbatim): No dependencies added unless absolutely required ✓ no pubspec changes