### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,53 @@
+/// Compares two semantic-version strings numerically.
+///
+/// Returns a comparator-style integer: negative if [a] < [b], zero if
+/// [a] == [b], positive if [a] > [b].
+///
+/// Short versions (e.g. `"1.2"`) are treated as `"1.2.0"` — missing
+/// components default to zero. Extra trailing components (e.g.
+/// `"1.2.3.4"`) beyond patch are ignored.
+///
+/// Throws [FormatException] if either input is empty, whitespace-only,
+/// or contains a non-numeric component in the first three positions.
+int compareSemVer(String a, String b) {
+  final partsA = _parseSemVerComponents(a);
+  final partsB = _parseSemVerComponents(b);
+
+  for (int i = 0; i < 3; i++) {
+    final cmp = partsA[i].compareTo(partsB[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+/// Parses a version string into exactly three integer components.
+///
+/// Missing components are padded with zero. Input must not be empty,
+/// whitespace-only, or contain non-numeric components in the first
+/// three positions.
+List<int> _parseSemVerComponents(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final components = input.split('.');
+
+  final result = <int>[];
+  final limit = components.length < 3 ? components.length : 3;
+
+  for (int i = 0; i < limit; i++) {
+    final value = int.tryParse(components[i]);
+    if (value == null) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+    result.add(value);
+  }
+
+  // Pad with zeros until we have exactly 3 components.
+  while (result.length < 3) {
+    result.add(0);
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares differing major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares differing minor components numerically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('compares differing patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('pads short versions with zero patch components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #294

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` and a private `_parseSemVerComponents` helper.
- Created `test/core/utils/semver_test.dart` with 8 named tests covering all acceptance criteria.

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test
```

All 16 tests pass (8 existing widget tests + 8 new semver tests). Output:

```
00:02 +16: All tests passed!
```

```
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

No issues found.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `_parseSemVerComponents` (empty/whitespace check, numeric validation, padding, truncation) and `compareSemVer` (component-by-component compareTo with early return on first difference).
- AC 2 (All named tests pass the verification command): ✓ verified by `flutter test test/core/utils/semver_test.dart` — all 8/8 tests pass.
- AC 3 (No dependencies added unless absolutely required): ✓ no dependencies added — only Dart core APIs used (String.split, int.tryParse, compareTo, FormatException).

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were created.
- Do NOT add third-party dependencies unless required by the task body: not violated — no pubspec.yaml or lockfile changes.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new additions with no refactoring.

## Notes

Plan deviations: none. The plan's approach was followed as written.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `_parseSemVerComponents` and `compareSemVer` in `lib/core/utils/semver.dart`
- AC 2 (All named tests pass the verification command): ✓ verified by `flutter test` exit 0 with all tests passing
- AC 3 (No dependencies added unless absolutely required): ✓ no pubspec.yaml or dependency files modified