### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,54 @@
+/// Compares two semantic-version strings.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b],
+/// and a positive integer if [a] > [b].
+///
+/// Supports `MAJOR.MINOR.PATCH` format with numeric comparison.
+/// Missing components are treated as zero (e.g., `1.2` == `1.2.0`).
+/// Components beyond patch are ignored (e.g., `1.2.3.4` == `1.2.3`).
+///
+/// Throws [FormatException] for malformed input (empty, whitespace-only,
+/// or non-numeric components).
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  for (int i = 0; i < 3; i++) {
+    final comparison = aComponents[i].compareTo(bComponents[i]);
+    if (comparison != 0) return comparison;
+  }
+
+  return 0;
+}
+
+/// Parses a version string into a list of three integer components.
+///
+/// Returns `[major, minor, patch]`. Missing components default to 0.
+/// Extra components (index 3+) are ignored.
+///
+/// Throws [FormatException] if the input is empty, whitespace-only, or
+/// contains a non-numeric component.
+List<int> _parseSemVerComponents(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException(
+      'Malformed semantic version: "$input"',
+      input,
+    );
+  }
+
+  final parts = input.split('.');
+  final components = <int>[0, 0, 0];
+
+  for (int i = 0; i < 3 && i < parts.length; i++) {
+    final component = parts[i];
+    if (!RegExp(r'^\d+$').hasMatch(component)) {
+      throw FormatException(
+        'Malformed semantic version: "$input"',
+        input,
+      );
+    }
+    components[i] = int.parse(component);
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('pads missing components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores components after patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #296

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` — comparator-style semantic version comparison
- Created private helper `List<int> _parseSemVerComponents(String input)` — splits and validates version components, pads missing with zero, throws `FormatException` on malformed input
- Created `test/core/utils/semver_test.dart` with 8 tests covering equality, numeric comparison (major/minor/patch), short-form padding, extra-component truncation, and FormatException type + message-content assertions

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

Output:
```
00:00 +8: All tests passed!
```

Full project suite also passes:
```
flutter test
00:00 +16: All tests passed!
```

Zero analyzer issues:
```
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed — `compareSemVer` in `lib/core/utils/semver.dart` implements all required behaviors (numeric component comparison, short-version zero-padding, extra-component truncation, comparator sign contract, FormatException with offending input in message)
- AC 2 (All named tests pass the verification command): ✓ addressed — `flutter test test/core/utils/semver_test.dart` passes 8/8 tests covering all named cases
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — implementation uses only Dart core library; tests use existing `flutter_test` dependency

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were created/modified
- Do NOT add third-party dependencies unless required by the task body: not violated — no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — both touched files are new and no existing code was refactored

### Coverage

- AC: Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/semver.dart` (compareSemVer + _parseSemVerComponents)
- AC: All named tests pass the verification command: ✓ addressed in `test/core/utils/semver_test.dart` (8 tests, all pass)
- AC: No dependencies added unless absolutely required: ✓ addressed — no third-party deps added; implementation uses Dart core only

## Notes

No deviations from the plan. The implementation follows the approved design exactly.