### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,51 @@
+/// Compares two semantic version strings numerically.
+///
+/// Accepts versions of the form `MAJOR.MINOR.PATCH`. Missing components
+/// are treated as zero. Components beyond patch are ignored.
+/// Comparison is numeric (not lexicographic) at each level.
+///
+/// Returns a value whose sign indicates the ordering:
+///   - negative if [a] < [b]
+///   - zero if [a] == [b]
+///   - positive if [a] > [b]
+///
+/// Throws [FormatException] if either input is empty, whitespace-only,
+/// or contains a non-numeric component.
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  for (int i = 0; i < 3; i++) {
+    final cmp = aComponents[i].compareTo(bComponents[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+/// Parses a semver string into `[major, minor, patch]`.
+///
+/// Missing components become 0. Components beyond patch are ignored.
+/// Throws [FormatException] for empty/whitespace/non-numeric input.
+List<int> _parseSemVerComponents(String version) {
+  if (version.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $version');
+  }
+
+  final parts = version.split('.');
+  final components = <int>[];
+
+  for (int i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final value = int.tryParse(parts[i]);
+      if (value == null) {
+        throw FormatException('Malformed semantic version: $version');
+      }
+      components.add(value);
+    } else {
+      components.add(0);
+    }
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major version numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor version numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch version numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares components numerically instead of lexicographically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads missing components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #298

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` and a private parser `_parseSemVerComponents`
- Created `test/core/utils/semver_test.dart` with 9 tests covering equality, component ordering, numeric comparison, short-form padding, extra-component truncation, and malformed input

## How verified

Exact commands run and their output digest:

```
$ cd ~/workspace/infiquetra/mimir && flutter test test/core/utils/semver_test.dart
00:00 +9: All tests passed!

$ cd ~/workspace/infiquetra/mimir && flutter test
00:00 +17: All tests passed!

$ cd ~/workspace/infiquetra/mimir && dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
Analyzing semver.dart, semver_test.dart...
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): addressed in lib/core/utils/semver.dart -- all documented behaviors implemented (numeric comparison, short-form padding, extra-component truncation, malformed input handling with message containment)
- AC 2 (All named tests pass the verification command): addressed -- flutter test test/core/utils/semver_test.dart exits 0 with all 9 tests passing
- AC 3 (No dependencies added unless absolutely required): addressed -- no changes to pubspec.yaml; uses only Dart core APIs and existing flutter_test

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated -- only lib/core/utils/semver.dart and test/core/utils/semver_test.dart are in the diff
- Do NOT add third-party dependencies unless required by the task body: not violated -- no new dependencies
- Do NOT refactor unrelated code in the touched files: not violated -- both files are new and contain only the semver helper and its tests

## Notes

- The pubspec.lock was modified by flutter pub get during dependency resolution but reverted before commit -- not part of the diff
- .hermes/ directory from plan review is untracked and not committed

### Coverage

- AC 1 (verbatim): Implementation matches all behaviors described in the task body (see Notes): addressed in lib/core/utils/semver.dart -- compareSemVer and _parseSemVerComponents implement all documented behaviors
- AC 2 (verbatim): All named tests pass the verification command: addressed -- flutter test test/core/utils/semver_test.dart passes all 9 tests
- AC 3 (verbatim): No dependencies added unless absolutely required: addressed -- no pubspec.yaml changes, no new dependencies
