### PR TITLE
feat(semver): add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,57 @@
+// Utility functions for comparing semantic version strings.
+//
+// Functions in this file support comparator-style comparison of
+// [semver](https://semver.org/) strings with relaxed parsing
+// (no prerelease/suffix support, missing components default to zero,
+// extra trailing components are ignored).
+
+/// Compares two semantic version strings [a] and [b] and returns:
+///
+/// - a negative integer if `a < b`,
+/// - zero if `a == b`,
+/// - a positive integer if `a > b`.
+///
+/// Comparison is numeric (not lexicographic), so `1.10.0 > 1.2.0`.
+///
+/// Missing components default to zero (e.g., `1.2` is treated as `1.2.0`).
+/// Extra trailing components beyond patch are ignored (e.g., `1.2.3.4`
+/// is treated as `1.2.3`).
+///
+/// Throws a [FormatException] if either input is empty, whitespace-only,
+/// or contains a non-numeric component.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+
+  for (int i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into a 3-element list of integers
+/// (`[major, minor, patch]`).
+///
+/// Missing components default to `0`. Extra components beyond patch are
+/// silently ignored. Throws [FormatException] for empty, whitespace-only,
+/// or non-numeric input.
+List<int> _parseSemVer(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+  final result = <int>[0, 0, 0];
+
+  for (int i = 0; i < 3 && i < parts.length; i++) {
+    final value = int.tryParse(parts[i]);
+    if (value == null) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+    result[i] = value;
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major versions numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor versions numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch versions numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders numeric components instead of lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores extra trailing components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty and whitespace-only input', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #300

## What changed

- Added `lib/core/utils/semver.dart` with `compareSemVer(String a, String b)` — a comparator-style semver comparison function
- Added `test/core/utils/semver_test.dart` with 10 focused unit tests covering equality, numeric comparison, short-form padding, extra-component truncation, and FormatException for malformed inputs

## How verified

Commands run and results:

```bash
$ cd ~/workspace/infiquetra/mimir
$ flutter test test/core/utils/semver_test.dart
00:00 +10: All tests passed!

$ flutter test
00:01 +18: All tests passed!   (10 new + 8 existing)

$ dart analyze lib/core/utils/semver.dart
No issues found!

$ dart analyze test/core/utils/semver_test.dart
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/semver.dart` (compareSemVer) and `test/core/utils/semver_test.dart` (10 tests matching all named cases)
- AC 2 (All named tests pass the verification command): ✓ addressed — `flutter test test/core/utils/semver_test.dart` exits 0 with all 10 tests passing
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — no third-party imports; uses only Dart core libraries and existing `flutter_test`

### Coverage

- AC 1 (Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`): ✓ addressed in `lib/core/utils/semver.dart` line 25
- AC 2 (Accepts versions of the form MAJOR.MINOR.PATCH and compares numerically): ✓ addressed in `compareSemVer` body (uses int.compareTo on parsed components)
- AC 3 (Short version missing components default to zero): ✓ addressed in `_parseSemVer` — result initialized as `[0, 0, 0]`, only populated for present indices
- AC 4 (Extra trailing components beyond patch are ignored): ✓ addressed in `_parseSemVer` — loop bound is `min(3, parts.length)`
- AC 5 (Return value contract: sign is what matters): ✓ addressed — tests use `isPositive`/`isNegative`/`equals(0)`, never specific integers
- AC 6 (Malformed input throws FormatException): ✓ addressed in `_parseSemVer` — two throw paths (empty/whitespace, non-numeric component); tested with type assertion
- AC 7 (FormatException message includes offending input verbatim): ✓ addressed — both throw paths use `'Malformed semantic version: $input'`; tested with `.having()` message-content assertion

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were created
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — both files are new and contain only the focused helper and its tests

## Notes

No deviations from the approved plan. The implementation follows the exact approach described: a `_parseSemVer` private helper called by `compareSemVer`, with three-component default-zero logic, numeric comparison, and FormatException on malformed input.