### PR TITLE
feat(semver): add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,52 @@
+/// Compares two semantic version strings numerically.
+///
+/// Returns a negative integer if [a] < [b], zero if equal, positive if [a] > [b].
+/// Missing minor/patch components default to zero. Components beyond patch are
+/// ignored. Throws [FormatException] for malformed input (empty, whitespace-only,
+/// or non-numeric components in the first three positions).
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+  for (var i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) return cmp;
+  }
+  return 0;
+}
+
+/// Parses the first three dot-separated components of [input] as integers.
+///
+/// Missing components (indices 0..2) default to zero. Components beyond index 2
+/// are ignored. Throws [FormatException] if [input] is empty, whitespace-only,
+/// or contains non-numeric content in the first three positions.
+List<int> _parseSemVer(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException("Malformed semantic version: '$input'", input);
+  }
+
+  final parts = input.split('.');
+  final result = <int>[0, 0, 0];
+
+  final limit = parts.length < 3 ? parts.length : 3;
+  for (var i = 0; i < limit; i++) {
+    final component = parts[i];
+    if (!_isNumeric(component)) {
+      throw FormatException(
+        "Malformed semantic version '$input': component '$component' is not numeric",
+        input,
+      );
+    }
+    result[i] = int.parse(component);
+  }
+
+  return result;
+}
+
+/// Returns true if [s] is a non-empty string of digits only.
+bool _isNumeric(String s) {
+  if (s.isEmpty) return false;
+  for (var i = 0; i < s.length; i++) {
+    if (s.codeUnitAt(i) < 0x30 || s.codeUnitAt(i) > 0x39) return false;
+  }
+  return true;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('orders by major component', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('orders by minor component', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('orders by patch component', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders numeric components instead of lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads missing minor or patch components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    group('malformed input', () {
+      test('throws FormatException for malformed input', () {
+        expect(
+          () => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()),
+        );
+        expect(
+          () => compareSemVer('', '1.2.3'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('includes offending input in FormatException message', () {
+        expect(
+          () => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('1.2.a'),
+            ),
+          ),
+        );
+        expect(
+          () => compareSemVer('   ', '1.2.3'),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('   '),
+            ),
+          ),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #302

## What changed

- Added `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` and a private `_parseSemVer()` parser
- Added `test/core/utils/semver_test.dart` with 9 named tests covering equality, component ordering, numeric comparison, short-form padding, extra-component truncation, and malformed input

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/semver.dart test/core/utils/semver_test.dart
flutter test test/core/utils/semver_test.dart
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

All 9 tests passed. Formatter made no changes. Analyzer reported no issues.

```
00:00 +9: All tests passed!
```

## Acceptance criteria coverage

- AC 1 — exact signature and location: `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`
- AC 2 — numeric major/minor/patch comparison: `_parseSemVer` converts components with `int.parse`, comparison uses `int.compareTo`, verified by test `orders numeric components instead of lexicographic strings`
- AC 3 — short version pads missing components with zero: `_parseSemVer` appends 0 for absent indices 0..2, verified by test `pads missing minor or patch components with zero`
- AC 4 — extra trailing components ignored: `_parseSemVer` only parses indices 0..2, verified by test `ignores components beyond patch`
- AC 5 — comparator-style sign contract: non-equal tests use only `isPositive`/`isNegative`, equal tests use `equals(0)`
- AC 6 — malformed input throws FormatException: verified by test `throws FormatException for malformed input` using `throwsA(isA<FormatException>())`
- AC 7 — FormatException.message includes offending input verbatim: verified by test `includes offending input in FormatException message` using `throwsA(isA<FormatException>().having(...))` proving `'1.2.a'` and `'   '` appear in the message

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were changed
- Do NOT add third-party dependencies: only Dart core string APIs and existing `flutter_test` used
- Do NOT refactor unrelated code: both files are new; no existing files were touched

## Notes

No deviations from the approved plan. Implementation follows the plan's approach exactly.

### Coverage

- [x] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/semver.dart`
- [x] All named tests pass the verification command: ✓ verified — 9/9 tests pass
- [x] No dependencies added unless absolutely required: ✓ no pubspec.yaml changes, no new deps