### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,56 @@
+/// Utility for comparing semantic version strings.
+///
+/// Compares versions of the form MAJOR.MINOR.PATCH numerically.
+/// Short versions (e.g., `1.2`) treat missing components as zero.
+/// Extra components beyond patch (e.g., `1.2.3.4`) are ignored.
+library;
+
+/// Compares two semantic version strings and returns a comparator-style
+/// integer: negative if [a] < [b], zero if [a] == [b], positive if [a] > [b].
+///
+/// Comparison is numeric, not lexicographic: `1.10.0 > 1.2.0`.
+///
+/// Throws [FormatException] if either input is empty, whitespace-only,
+/// or contains a non-numeric component.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+
+  for (var i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into a list of exactly three integers
+/// ([major, minor, patch]).
+///
+/// - Missing components are padded with zero (e.g., `"1.2"` → `[1, 2, 0]`).
+/// - Extra components beyond patch are ignored (e.g., `"1.2.3.4"` → `[1, 2, 3]`).
+/// - Throws [FormatException] if [input] is empty, whitespace-only, or
+///   contains a non-numeric component.
+List<int> _parseSemVer(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: "$input"');
+  }
+
+  final components = input.split('.');
+  final parts = <int>[];
+
+  for (final component in components) {
+    final value = int.tryParse(component);
+    if (value == null) {
+      throw FormatException('Malformed semantic version: "$input"');
+    }
+    parts.add(value);
+  }
+
+  // Pad missing components with zero, truncate to major.minor.patch.
+  while (parts.length < 3) {
+    parts.add(0);
+  }
+
+  return parts.sublist(0, 3);
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('returns positive when major version is greater', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+    });
+
+    test('returns positive when minor version is greater numerically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('returns negative when patch version is lower', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('pads missing components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores extra trailing components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty and whitespace-only input', () {
+      // Empty string
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains(''),
+          ),
+        ),
+      );
+
+      // Whitespace-only — verify original input is preserved verbatim
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('   '),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #306

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` and a private `_parseSemVer(String input)` helper.
- Created `test/core/utils/semver_test.dart` with 9 named tests covering equal versions, major/minor/patch differences, numeric ordering, short-form padding, extra-component truncation, and malformed input.

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

All 9 tests passed. Full `flutter test` also passed (17 total, including 8 existing tests). `dart analyze` reported zero issues on both files.

```
00:00 +9: All tests passed!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): Covered by steps 1–7 of the plan — the `compareSemVer` function in `lib/core/utils/semver.dart` handles numeric comparison, short-form padding, extra-component truncation, and malformed input as specified, and the test file covers every named case.
- AC 2 (All named tests pass the verification command): Verified — `flutter test test/core/utils/semver_test.dart` exits 0 with all 9 tests passing.
- AC 3 (No dependencies added unless absolutely required): Confirmed — `semver.dart` uses only Dart core APIs. No changes to `pubspec.yaml` or `pubspec.lock`.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were created.
- Do NOT add third-party dependencies: not violated — no dependency changes.
- Do NOT refactor unrelated code in the touched files: not violated — no pre-existing files were modified.

## Notes

No deviations from the plan. The implementation follows the exact signature and behavior specified.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/semver.dart` (compareSemVer + _parseSemVer) and `test/core/utils/semver_test.dart`
- All named tests pass the verification command: ✓ addressed in `test/core/utils/semver_test.dart` — 9 tests, all pass
- No dependencies added unless absolutely required: ✓ addressed — core Dart APIs only, no pubspec changes