### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,49 @@
+/// Compares two semantic version strings and returns a comparator-style integer.
+///
+/// Returns negative if [a] < [b], zero if [a] == [b], positive if [a] > [b].
+///
+/// Versions are compared numerically (not lexicographically), so
+/// `1.10.0 > 1.2.0`. Missing components default to zero (e.g. `1.2` is
+/// treated as `1.2.0`). Extra trailing components beyond patch are ignored
+/// (e.g. `1.2.3.4` is treated as `1.2.3`).
+///
+/// Throws [FormatException] if either version is empty, whitespace-only, or
+/// contains non-numeric components.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+
+  for (int i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) return cmp;
+  }
+  return 0;
+}
+
+/// Parses a semver string into a list of three integers: [major, minor, patch].
+///
+/// Normalizes short versions by padding missing components with zero.
+/// Ignores components beyond the third (patch). Throws [FormatException] on
+/// malformed input.
+List<int> _parseSemVer(String version) {
+  if (version.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $version');
+  }
+
+  final parts = version.split('.');
+  final result = <int>[];
+
+  for (int i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final parsed = int.tryParse(parts[i]);
+      if (parsed == null) {
+        throw FormatException('Malformed semantic version: $version');
+      }
+      result.add(parsed);
+    } else {
+      result.add(0);
+    }
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major component numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor component numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch component numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders numeric components instead of lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores extra trailing components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty string', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException for whitespace-only string', () {
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #308

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` and a private `_parseSemVer` helper
- Created `test/core/utils/semver_test.dart` with 11 unit tests covering equality, numeric ordering, short-form padding, extra-component truncation, and malformed input (FormatException type + message)

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

Output: 00:00 +11: All tests passed!

```
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

Output: No issues found!

## Acceptance criteria coverage

- AC 1: Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`: ✓ addressed in `lib/core/utils/semver.dart` — function signature matches exactly
- AC 2: Accepts versions of the form MAJOR.MINOR.PATCH and compares major → minor → patch NUMERICALLY (not lexicographically), so 1.10.0 > 1.2.0: ✓ addressed in `_parseSemVer` using `int.tryParse` + numeric `compareTo` in `compareSemVer`; test confirms `compareSemVer('1.10.0', '1.2.0')` is `isPositive`
- AC 3: A short version (e.g. 1.2) is treated as 1.2.0 — missing components default to zero: ✓ addressed in `_parseSemVer` — when `i >= parts.length` adds `0`; test confirms `compareSemVer('1.2', '1.2.0')` equals `0`
- AC 4: A version with extra trailing components (e.g. 1.2.3.4) is treated as 1.2.3 — components beyond patch are ignored: ✓ addressed in `_parseSemVer` — loops only indexes 0..2; test confirms `compareSemVer('1.2.3.4', '1.2.3')` equals `0`
- AC 5: Return value contract mirrors Comparable.compareTo — tests MUST assert isNegative/isPositive/equals(0), not specific integers: ✓ all sign-based tests use `isPositive`, `isNegative`, `equals(0)`; no tests assert specific non-zero integers
- AC 6: Malformed input throws FormatException ("malformed" = non-numeric component, empty string, or purely whitespace string): ✓ addressed in `_parseSemVer` — throws `FormatException` when `version.trim().isEmpty` or when `int.tryParse` returns null; tests cover all three malformed cases
- AC 7: FormatException message MUST include the offending input string verbatim: ✓ addressed in `_parseSemVer` — throws `FormatException('Malformed semantic version: $version')`; test uses `throwsA(isA<FormatException>().having((e) => e.message, 'message', contains('1.2.a')))` to prove message contains `'1.2.a'`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only the two named files were created
- Do NOT add third-party dependencies unless required by the task body: not violated — Dart core only + existing `flutter_test`
- Do NOT refactor unrelated code in the touched files: not violated — both files are new and contain only the semver helper and its tests

## Notes

No deviations from the approved plan. All implementation matches the described behaviors.

### Coverage

- AC 1 (verbatim): ✓ addressed in `lib/core/utils/semver.dart` — exact function signature
- AC 2 (verbatim): ✓ addressed in `_parseSemVer` + `compareSemVer` numeric comparison; verified by test
- AC 3 (verbatim): ✓ addressed in `_parseSemVer` zero-padding; verified by test
- AC 4 (verbatim): ✓ addressed in `_parseSemVer` 3-component loop; verified by test
- AC 5 (verbatim): ✓ all tests use `isPositive`/`isNegative`/`equals(0)` — no specific integers
- AC 6 (verbatim): ✓ `_parseSemVer` throws `FormatException` for non-numeric, empty, whitespace
- AC 7 (verbatim): ✓ `_parseSemVer` includes `$version` in message; test proves `contains('1.2.a')`