### PR TITLE
feat(semver): add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,51 @@
+/// Utility functions for semantic version comparison.
+
+/// Compares two semantic version strings and returns:
+/// - a negative integer if `a < b`,
+/// - zero if `a == b`,
+/// - a positive integer if `a > b`.
+///
+/// Versions are parsed as `MAJOR.MINOR.PATCH`. Missing components default to
+/// zero, and components beyond patch are ignored. Comparison is numeric, not
+/// lexicographic, so `1.10.0 > 1.2.0`.
+///
+/// Throws [FormatException] if either input is empty, whitespace-only, or
+/// contains a non-numeric component.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+
+  for (int i = 0; i < 3; i++) {
+    if (aParts[i] != bParts[i]) {
+      return aParts[i].compareTo(bParts[i]);
+    }
+  }
+
+  return 0;
+}
+
+List<int> _parseSemVer(String input) {
+  if (input.isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+  final result = <int>[];
+
+  for (final component in parts.take(3)) {
+    final value = int.tryParse(component);
+    if (value == null) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+    result.add(value);
+  }
+
+  while (result.length < 3) {
+    result.add(0);
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major versions numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor versions numerically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('compares patch versions numerically', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+    });
+
+    test('pads short versions with zero patch component', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('   ', '1.2.3'),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #310

## What changed

- Added `lib/core/utils/semver.dart`: new file with public `int compareSemVer(String a, String b)` function and private `_parseSemVer(String input)` parser
- Added `test/core/utils/semver_test.dart`: comprehensive test suite covering equality, component-order numeric comparison, short-form padding, extra-component truncation, and malformed-input diagnostics

## How verified

```bash
cd ~/workspace/infiquetra/mimir

# Focused test
flutter test test/core/utils/semver_test.dart
# → 00:00 +8: All tests passed!

# Full suite (no regressions)
flutter test
# → 00:01 +16: All tests passed!

# Static analysis (matches existing repo convention — same info-level lint as formatters.dart)
dart analyze lib/core/utils/semver.dart
# → 1 info issue (dangling_library_doc_comments — same as existing formatters.dart)
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart`
- AC 2 (All named tests pass the verification command): ✓ confirmed — 8/8 tests pass
- AC 3 (No dependencies added unless absolutely required): ✓ confirmed — no `pubspec.yaml` or dependency changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` changed
- Do NOT add third-party dependencies unless required by the task body: not violated — uses only Dart core APIs and existing `flutter_test`
- Do NOT refactor unrelated code in the touched files: not violated — both files are new

## Notes

No deviations from plan. The `dangling_library_doc_comments` info-level linter warning is pre-existing in the repo (same warning on `formatters.dart`) and is not treated as an error by CI.