### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,40 @@
+/// Compares two semantic version strings numerically.
+///
+/// Returns a negative integer if [a] < [b], zero if equal, a positive
+/// integer if [a] > [b]. Missing components default to `0` (e.g. `1.2`
+/// is treated as `1.2.0`). Components beyond the patch field are ignored.
+///
+/// Throws [FormatException] if either input is empty, whitespace-only, or
+/// contains non-numeric components. The exception message includes the
+/// offending input verbatim.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+
+  for (int i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+List<int> _parseSemVer(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+  final result = <int>[];
+
+  for (int i = 0; i < 3; i++) {
+    final component = i < parts.length ? parts[i] : '0';
+    final value = int.tryParse(component);
+    if (value == null) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+    result.add(value);
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares differing major components by sign', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares differing minor components by sign', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares differing patch components by sign', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares components numerically instead of lexicographically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores extra trailing components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty or whitespace input', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #312

## What changed

- `lib/core/utils/semver.dart` (new): Added `int compareSemVer(String a, String b)` with private `_parseSemVer` helper. Compares semantic versions numerically (major → minor → patch). Handles short-form padding (`1.2` → `1.2.0`), extra trailing components ignored (`1.2.3.4` → `1.2.3`), and throws `FormatException` on malformed input with the offending string in the message.

- `test/core/utils/semver_test.dart` (new): 10 test cases covering equal versions, major/minor/patch sign assertions, numeric ordering, short-form padding, extra-component truncation, FormatException type assertion, FormatException message-content assertion, and empty/whitespace input.

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

```
00:00 +10: All tests passed!
```

```bash
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

```
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/semver.dart` — `compareSemVer` follows numeric comparison, short-form padding, extra-component truncation, and malformed-input FormatException behavior.
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/semver_test.dart` — all 10 named test cases pass `flutter test test/core/utils/semver_test.dart`.
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — uses only Dart core APIs and existing `flutter_test`.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were created.
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new additions.

## Notes

No deviations from plan. The implementation follows the exact signature and behavior specified.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/semver.dart`
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/semver_test.dart`
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — no new dependencies