### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,50 @@
+/// Compares two semantic version strings numerically.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b],
+/// and a positive integer if [a] > [b].
+///
+/// Accepts versions of the form `MAJOR.MINOR.PATCH` (e.g., `1.2.3`).
+/// A short version (e.g., `1.2`) is treated as `1.2.0`.
+/// Extra trailing components (e.g., `1.2.3.4`) are ignored.
+///
+/// Throws [FormatException] if either input is empty, purely whitespace,
+/// or contains a non-numeric component in the first three positions.
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  for (var i = 0; i < 3; i++) {
+    final cmp = aComponents[i].compareTo(bComponents[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into [major, minor, patch] integers.
+///
+/// Throws [FormatException] if [version] is empty, purely whitespace,
+/// or contains a non-numeric component in the first three positions.
+/// The exception message includes the original [version] string verbatim.
+List<int> _parseSemVerComponents(String version) {
+  if (version.isEmpty || version.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: "$version"');
+  }
+
+  final parts = version.split('.').take(3).toList();
+  final components = <int>[];
+
+  for (final part in parts) {
+    final parsed = int.tryParse(part);
+    if (parsed == null) {
+      throw FormatException('Malformed semantic version: "$version"');
+    }
+    components.add(parsed);
+  }
+
+  while (components.length < 3) {
+    components.add(0);
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major versions numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor versions numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+    });
+
+    test('compares patch versions numerically', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders numeric components instead of lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('pads missing components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes malformed input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Add `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart` — a comparator-style version comparison helper that compares semantic versions numerically.

## Related Issue

Closes #314

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

All 9 tests passed. Analyzer (`dart analyze`) reports zero issues.

## Acceptance criteria coverage

- AC 1 (Signature is exactly `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`): ✓ addressed — `lib/core/utils/semver.dart` line 12 defines `int compareSemVer(String a, String b)`.
- AC 2 (Numeric, not lexicographic comparison): ✓ addressed — `_parseSemVerComponents` returns `[major, minor, patch]` ints, `compareSemVer` compares with `int.compareTo`, tested by `orders numeric components` test.
- AC 3 (Missing components default to zero): ✓ addressed — `_parseSemVerComponents` appends zeroes until length=3, tested by `pads missing components with zero` test.
- AC 4 (Extra trailing components ignored): ✓ addressed — `_parseSemVerComponents` uses `.take(3)` on the split, tested by `ignores components beyond patch` test.
- AC 5 (Return value mirrors Comparable.compareTo — sign matters, not magnitude): ✓ addressed — tests use `isPositive`/`isNegative`/`equals(0)`, no exact integer assertions.
- AC 6 (Malformed input throws FormatException): ✓ addressed — `_parseSemVerComponents` throws for empty/whitespace/non-numeric input, tested by `throws FormatException for malformed input` test with empty, whitespace, and non-numeric cases.
- AC 7 (FormatException message includes offending input): ✓ addressed — exception message contains the original version string, tested by `includes malformed input in FormatException message` test using `.having((e) => e.message, 'message', contains('1.2.a'))`.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: ✓ not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` modified.
- Do NOT add third-party dependencies: ✓ not violated — no `pubspec.yaml` changes, no package imports in implementation.
- Do NOT refactor unrelated code in touched files: ✓ not violated — both files are new.

## Notes

The default branch for this repo is `develop`, not `main`. The branch was created from `origin/develop`. The PR base is set to `develop` accordingly.

### Coverage

- Implementation matches all behaviors described in the task body: ✓ addressed in `lib/core/utils/semver.dart` (compareSemVer + _parseSemVerComponents).
- All named tests pass the verification command: ✓ addressed — `flutter test test/core/utils/semver_test.dart` passes all 9 tests.
- No dependencies added unless absolutely required: ✓ addressed — no `pubspec.yaml` changes, zero new dependencies.