### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,84 @@
+/// Parses a semantic version string into [major, minor, patch] components.
+///
+/// Short versions (e.g. '1.2') are padded with zeros.
+/// Extra components (e.g. '1.2.3.4') are truncated to 3 components.
+/// Throws [FormatException] for malformed input.
+List<int> _parseSemVerComponents(String input) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = trimmed.split('.');
+
+  // Parse major (always required)
+  int major;
+  try {
+    major = int.parse(parts[0]);
+  } on FormatException {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  // Parse minor (default to 0 if missing)
+  int minor = 0;
+  if (parts.length > 1) {
+    try {
+      minor = int.parse(parts[1]);
+    } on FormatException {
+      throw FormatException('Malformed semantic version: $input');
+    }
+  }
+
+  // Parse patch (default to 0 if missing)
+  int patch = 0;
+  if (parts.length > 2) {
+    try {
+      patch = int.parse(parts[2]);
+    } on FormatException {
+      throw FormatException('Malformed semantic version: $input');
+    }
+  }
+
+  return [major, minor, patch];
+}
+
+/// Compares two semantic version strings.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b], or a positive
+/// integer if [a] > [b]. The magnitude of the return value is not specified;
+/// only the sign matters.
+///
+/// Versions are compared numerically by major, then minor, then patch.
+/// Short versions (e.g. '1.2') are treated as '1.2.0'.
+/// Extra trailing components (e.g. '1.2.3.4') are ignored.
+///
+/// Throws [FormatException] if either input is malformed (empty, whitespace-only,
+/// or contains non-numeric components).
+///
+/// Example:
+/// ```dart
+/// compareSemVer('1.2.3', '1.2.4'); // negative
+/// compareSemVer('1.10.0', '1.2.0'); // positive (numeric comparison)
+/// compareSemVer('1.2', '1.2.0');     // zero (short form padding)
+/// ```
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  // Compare major
+  if (aComponents[0] != bComponents[0]) {
+    return aComponents[0].compareTo(bComponents[0]);
+  }
+
+  // Compare minor
+  if (aComponents[1] != bComponents[1]) {
+    return aComponents[1].compareTo(bComponents[1]);
+  }
+
+  // Compare patch
+  if (aComponents[2] != bComponents[2]) {
+    return aComponents[2].compareTo(bComponents[2]);
+  }
+
+  return 0;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('uses numeric ordering instead of lexicographic ordering', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores extra trailing components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>().having((error) => error.message, 'message', contains('1.2.a'))),
+      );
+    });
+
+    test('throws FormatException for empty and whitespace-only input', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>().having((error) => error.message, 'message', contains('   '))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #316

## What changed

- Added new utility file `lib/core/utils/semver.dart` with:
  - `_parseSemVerComponents(String)` private helper that parses version strings into [major, minor, patch] components
  - `int compareSemVer(String a, String b)` public function for comparing semantic versions
- Added comprehensive test suite in `test/core/utils/semver_test.dart` with 10 test cases covering all acceptance criteria

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

Output:
```
Resolving dependencies...
Got dependencies!
00:00 +0: loading .../semver_test.dart
00:00 +0: compareSemVer returns zero for equal versions
00:00 +1: compareSemVer compares major components numerically
00:00 +2: compareSemVer compares minor components numerically
00:00 +3: compareSemVer compares patch components numerically
00:00 +4: compareSemVer uses numeric ordering instead of lexicographic ordering
00:00 +5: compareSemVer pads short versions with zero components
00:00 +6: compareSemVer ignores extra trailing components beyond patch
00:00 +7: compareSemVer throws FormatException for malformed input
00:00 +8: compareSemVer includes offending input in FormatException message
00:00 +9: compareSemVer throws FormatException for empty and whitespace-only input
00:00 +10: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Signature is exactly `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`
- AC 2: Compares major, minor, patch numerically (not lexicographically) - verified by test "uses numeric ordering instead of lexicographic ordering"
- AC 3: Short versions like "1.2" treated as "1.2.0" - verified by test "pads short versions with zero components"
- AC 4: Extra components beyond patch are ignored - verified by test "ignores extra trailing components beyond patch"
- AC 5: Return value uses sign convention from `Comparable.compareTo` - tests use `isNegative`/`isPositive`/`equals(0)` assertions
- AC 6: Malformed input throws `FormatException` - verified by test "throws FormatException for malformed input"
- AC 7: `FormatException` message includes offending input - verified by test "includes offending input in FormatException message" and "throws FormatException for empty and whitespace-only input"

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only modified `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart`
- Do NOT add third-party dependencies: no dependencies added, only uses Dart core APIs
- Do NOT refactor unrelated code: no unrelated files modified

## Notes

No deviations from plan. Implementation follows all acceptance criteria exactly.

### Coverage

- AC 1 (verbatim): ✓ addressed in lib/core/utils/semver.dart, function compareSemVer
- AC 2 (verbatim): ✓ addressed in compareSemVer function with numeric comparison, tests verify 1.10.0 > 1.2.0
- AC 3 (verbatim): ✓ addressed in _parseSemVerComponents with default-to-zero logic, tests verify 1.2 == 1.2.0
- AC 4 (verbatim): ✓ addressed in _parseSemVerComponents by only parsing first 3 components, tests verify 1.2.3.4 == 1.2.3
- AC 5 (verbatim): ✓ addressed - tests use isNegative/isPositive/equals(0) assertions, never specific magnitudes
- AC 6 (verbatim): ✓ addressed in _parseSemVerComponents with empty/whitespace and int.parse error handling
- AC 7 (verbatim): ✓ addressed - FormatException message includes full input string as shown in tests