### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,53 @@
+/// Compares two semantic version strings.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b],
+/// and a positive integer if [a] > [b].
+///
+/// Versions are compared numerically (not lexicographically) by
+/// major, then minor, then patch components.
+///
+/// - Short versions like "1.2" are treated as "1.2.0"
+/// - Extra components beyond patch (e.g., "1.2.3.4") are ignored
+/// - Malformed versions throw [FormatException] with the offending input in the message
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVerParts(a);
+  final bParts = _parseSemVerParts(b);
+
+  for (var i = 0; i < 3; i++) {
+    final comparison = aParts[i].compareTo(bParts[i]);
+    if (comparison != 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into major, minor, and patch components.
+///
+/// - Empty or whitespace-only strings throw [FormatException]
+/// - Each component must be parseable as an integer
+/// - Missing minor or patch components default to 0
+/// - Components beyond the third are ignored
+List<int> _parseSemVerParts(String version) {
+  if (version.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $version');
+  }
+
+  final parts = version.split('.');
+  final result = <int>[];
+
+  for (var i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final parsed = int.tryParse(parts[i]);
+      if (parsed == null) {
+        throw FormatException('Malformed semantic version: $version');
+      }
+      result.add(parsed);
+    } else {
+      result.add(0);
+    }
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares components numerically instead of lexicographically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads missing minor or patch components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1.2.0', '1.2'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('1.0.0', '1'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.4'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '1.2.a'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(
+          () => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((error) => error.message, 'message', contains('1.2.a'))),
+      );
+      expect(
+        () => compareSemVer('1.2.3', '1.2.a'),
+        throwsA(isA<FormatException>()
+            .having((error) => error.message, 'message', contains('1.2.a'))),
+      );
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((error) => error.message, 'message', contains(''))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #325

## What changed

- Created  with  function
- Implemented private  helper for parsing and validation
- Created  with comprehensive test coverage

## How verified

Formatted 2 files (0 changed) in 0.02 seconds.
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/semver_test.dart
00:00 +0: compareSemVer returns zero for equal versions
00:00 +1: compareSemVer compares major components numerically
00:00 +2: compareSemVer compares minor components numerically
00:00 +3: compareSemVer compares patch components numerically
00:00 +4: compareSemVer compares components numerically instead of lexicographically
00:00 +5: compareSemVer pads missing minor or patch components with zero
00:00 +6: compareSemVer ignores components beyond patch
00:00 +7: compareSemVer throws FormatException for malformed input
00:00 +8: compareSemVer includes offending input in FormatException message
00:00 +9: All tests passed!
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/widget_test.dart
00:00 +0: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +1: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +2: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +3: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +4: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +5: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +6: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +7: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +8: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +9: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +10: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +11: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +12: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +13: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +14: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +15: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +16: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +17: All tests passed!

Output:


## Acceptance criteria coverage

- AC 1: ✓ Implemented exact signature  in 
- AC 2: ✓ Numerical comparison (not lexicographic) - tests verify 
- AC 3: ✓ Short versions padded with zero -  treated as 
- AC 4: ✓ Extra components ignored -  compared as 
- AC 5: ✓ Return value uses sign contract (, , )
- AC 6: ✓  thrown for malformed input (non-numeric, empty, whitespace)
- AC 7: ✓ FormatException message contains offending input verbatim

## Non-goals acknowledged

- Did NOT modify files beyond expected set
- Did NOT add third-party dependencies
- Did NOT refactor unrelated code

## Notes

- Implementation uses only Dart core APIs (, , )
- All 9 new tests pass with existing 8 tests (17 total)
- Zero analyzer warnings on new files