### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,43 @@
+// Utility functions for string manipulation.
+
+/// Truncates a long string by replacing its middle with an ellipsis,
+/// preserving characters from both the start and end.
+///
+/// If [input] is already [maxLength] or shorter, it is returned unchanged.
+/// The total length of the returned string (including [ellipsis]) will
+/// never exceed [maxLength].
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'`
+String truncateMiddle(
+  String input,
+  int maxLength, {
+  String ellipsis = '…',
+}) {
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  if (maxLength < ellipsis.length) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  if (maxLength == ellipsis.length) {
+    return ellipsis;
+  }
+
+  final availableVisibleChars = maxLength - ellipsis.length;
+  final sideLength = availableVisibleChars ~/ 2;
+
+  final start = input.substring(0, sideLength);
+  final end = input.substring(input.length - sideLength);
+
+  return '$start$ellipsis$end';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when input length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('truncates the middle while preserving start and end', () {
+      final result = truncateMiddle('abcdefghijklmn', 8);
+      expect(result, 'abc…lmn');
+      expect(result.length <= 8, isTrue);
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns truncated ellipsis when maxLength is shorter than ellipsis', () {
+      expect(truncateMiddle('abcdef', 1), '…');
+      expect(truncateMiddle('abcdef', 0), '');
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+    });
+
+    test('accounts for custom ellipsis length in maxLength', () {
+      final result = truncateMiddle('abcdefghijklmn', 8, ellipsis: '...');
+      expect(result, 'ab...mn');
+      expect(result.length <= 8, isTrue);
+    });
+
+    test('uses documented design choice for very small maxLength', () {
+      final result = truncateMiddle('abcdef', 3);
+      expect(result, 'a…f');
+      expect(result.length <= 3, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #320

## What changed

- Added  with  top-level function.
- Added  with 6 named tests covering all behaviors.

## How verified

00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart
00:00 +0: truncateMiddle returns input unchanged when input length is within maxLength
00:00 +1: truncateMiddle truncates the middle while preserving start and end
00:00 +2: truncateMiddle returns empty input unchanged
00:00 +3: truncateMiddle returns truncated ellipsis when maxLength is shorter than ellipsis
00:00 +4: truncateMiddle accounts for custom ellipsis length in maxLength
00:00 +5: truncateMiddle uses documented design choice for very small maxLength
00:00 +6: All tests passed!

Output:


Also verified Analyzing mimir...

   info - lib/core/utils/formatters.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments

1 issue found. reports zero issues on both modified files and 00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/widget_test.dart
00:00 +0: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +1: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +2: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +3: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +4: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +5: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +6: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +7: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:02 +8: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle returns input unchanged when input length is within maxLength
00:02 +9: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle truncates the middle while preserving start and end
00:02 +10: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle returns empty input unchanged
00:02 +11: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle returns truncated ellipsis when maxLength is shorter than ellipsis
00:02 +12: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle accounts for custom ellipsis length in maxLength
00:02 +13: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle uses documented design choice for very small maxLength
00:02 +14: All tests passed! passes across the full suite.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in  function  — handles unchanged short strings, middle truncation with symmetric visible halves, empty input, maxLength shorter than ellipsis (returns truncated ellipsis), and custom ellipsis length accounting.
- AC 2 (All named tests pass the verification command): ✓ addressed in  — 6 named tests all pass with 00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/widget_test.dart
00:00 +0: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +1: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +2: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +3: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +4: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +5: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +6: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +7: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:03 +8: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle returns input unchanged when input length is within maxLength
00:03 +9: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle truncates the middle while preserving start and end
00:03 +10: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle returns empty input unchanged
00:03 +11: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle returns truncated ellipsis when maxLength is shorter than ellipsis
00:03 +12: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle accounts for custom ellipsis length in maxLength
00:03 +13: /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart: truncateMiddle uses documented design choice for very small maxLength
00:03 +14: All tests passed!.
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — no  or dependency files touched.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only  and  created.
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added.
- Do NOT refactor unrelated code in the touched files: not violated — only the requested helper and focused tests were added.

## Notes

Design choice documented: for very small  (e.g., ), the function returns  by keeping symmetric visible halves from the start and end rather than collapsing to just the ellipsis. This matches the requirement to preserve both start and end while keeping total length within bounds.