### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,25 @@
+/// Extension methods for List operations.
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Returns an empty list when called on an empty list.
+  /// Each returned chunk is an independent [List] instance.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(
+        size,
+        'size',
+        'Must be greater than or equal to 1',
+      );
+    }
+
+    final chunks = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = (start + size < length) ? start + size : length;
+      chunks.add(sublist(start, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      final result = [1, 2, 3, 4, 5].chunked(2);
+      expect(result, equals([[1, 2], [3, 4], [5]]));
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      final result = [1, 2, 3].chunked(3);
+      expect(result, equals([[1, 2, 3]]));
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      final result = [1, 2, 3].chunked(10);
+      expect(result, equals([[1, 2, 3]]));
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      final result = <int>[].chunked(3);
+      expect(result, equals(<List<int>>[]));
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      final result = [1].chunked(1);
+      expect(result, equals([[1]]));
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(
+        () => [1, 2, 3].chunked(0),
+        throwsArgumentError,
+      );
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final list = [1, 2, 3, 4];
+      final result = list.chunked(2);
+      result[0][0] = 99;
+      expect(list, equals([1, 2, 3, 4]));
+      expect(result[0], equals([99, 2]));
+      expect(result[1], equals([3, 4]));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #329

## What changed

- Created `lib/core/utils/list_extensions.dart` with `extension ChunkedList<T> on List<T>`
  - Defined `List<List<T>> chunked(int size)`
  - Added `size < 1` guard that throws `ArgumentError`
  - Uses `sublist` to return independent chunk lists

- Created `test/core/utils/list_extensions_test.dart` with all required tests

## How verified

```bash
flutter test test/core/utils/list_extensions_test.dart
```

Output:
```
00:00 +0: loading test/core/utils/list_extensions_test.dart
00:00 +0: ChunkedList chunked splits a list into consecutive chunks
00:00 +1: ChunkedList chunked returns one chunk when size equals list length
00:00 +2: ChunkedList chunked returns one chunk when size exceeds list length
00:00 +3: ChunkedList chunked returns an empty list for an empty source list
00:00 +4: ChunkedList chunked returns a single-item chunk for a one-element list
00:00 +5: ChunkedList chunked throws ArgumentError when size is zero
00:00 +6: ChunkedList chunked returns independent chunk lists
00:00 +7: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — addressed in `lib/core/utils/list_extensions.dart` (`chunked` method)
- AC 2: All named tests pass the verification command — addressed in `test/core/utils/list_extensions_test.dart` (7 tests all pass)
- AC 3: No dependencies added unless absolutely required — no new dependencies added

## Non-goals acknowledged

- Did NOT modify files beyond the expected set
- Did NOT add third-party dependencies
- Did NOT refactor unrelated code in touched files

## Notes

- Zero new analyzer warnings (`dart analyze` clean on both files)