### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,35 @@
+/// Truncates a string in the middle, replacing the center with an ellipsis.
+///
+/// When the input is longer than maxLength, this function keeps the start
+/// and end visible while replacing the middle with an ellipsis character.
+///
+/// For odd visible budgets (maxLength - ellipsis.length), the implementation
+/// uses a balanced floor split: both sides get floor(visibleLength / 2)
+/// characters, leaving one character unused when the budget is odd.
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'` (unchanged)
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'` (3+1+3=7 ≤ 8)
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 2, ellipsis: '...')` → `'..'`
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // Fast path: input fits within maxLength
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  // Handle maxLength too small to fit any visible characters
+  final ellipsisLength = ellipsis.length;
+  if (maxLength <= ellipsisLength) {
+    return ellipsis.substring(0, maxLength.clamp(0, ellipsisLength));
+  }
+
+  // Normal truncation: compute visible budget
+  final visibleLength = maxLength - ellipsisLength;
+  final sideLength = visibleLength ~/ 2;
+
+  final start = input.substring(0, sideLength);
+  final end = input.substring(input.length - sideLength);
+
+  return '$start$ellipsis$end';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('replaces the middle with an ellipsis', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+      expect(truncateMiddle('abcdefghijklmn', 8).length, lessThanOrEqualTo(8));
+    });
+
+    test('returns empty string unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('truncates ellipsis when maxLength is shorter than ellipsis', () {
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+      expect(truncateMiddle('abcdef', 0), '');
+    });
+
+    test('includes custom ellipsis length in maxLength budget', () {
+      expect(truncateMiddle('abcdefghijklmn', 9, ellipsis: '...'), 'abc...lmn');
+      expect(truncateMiddle('abcdefghijklmn', 9, ellipsis: '...').length, lessThanOrEqualTo(9));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #330

## What changed

- Added `lib/core/utils/string_utils.dart` with `truncateMiddle()` function
- Added `test/core/utils/string_utils_test.dart` with comprehensive test coverage

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
flutter analyze lib/core/utils/string_utils.dart
```

**Output digest:**
- All 5 tests passed
- Static analysis: No issues found

## Acceptance criteria coverage

- Implementation matches all behaviors described in the task body: ✓ Covered by `truncateMiddle()` in `lib/core/utils/string_utils.dart` with all edge cases
- All named tests pass the verification command: ✓ All 5 tests pass
- No dependencies added unless absolutely required: ✓ No new dependencies added (uses only Dart core)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: No other files modified
- Do NOT add third-party dependencies unless required by the task body: No dependencies added
- Do NOT refactor unrelated code in the touched files: Both files are new and contain only the requested function

## Notes

The implementation uses a balanced floor split for odd visible budgets: both start and end get `floor((maxLength - ellipsis.length) / 2)` characters, leaving one character unused when the budget is odd. This matches the card's example: `truncateMiddle('abcdefghijklmn', 8) == 'abc…lmn'` (3 + 1 + 3 = 7 ≤ 8).

### Coverage

- [ ] Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/string_utils.dart` function `truncateMiddle()` lines 16-30
- [ ] All named tests pass the verification command: ✓ addressed in `test/core/utils/string_utils_test.dart` tests 5 tests passing
- [ ] No dependencies added unless absolutely required: ✓ addressed in `lib/core/utils/string_utils.dart` no third-party imports