### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,34 @@
+library list_extensions;
+
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The last chunk may be smaller than [size] if the list length is not
+  /// evenly divisible by [size].
+  ///
+  /// Returns independent lists - mutating a chunk does not affect the
+  /// original list.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Examples:
+  /// - `[1, 2, 3, 4, 5].chunked(2)` → `[[1, 2], [3, 4], [5]]`
+  /// - `[1, 2, 3].chunked(10)` → `[[1, 2, 3]]`
+  /// - `[].chunked(3)` → `[]`
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'Must be greater than or equal to 1');
+    }
+
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final result = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = start + size < length ? start + size : length;
+      result.add(sublist(start, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      final result = [1, 2, 3, 4, 5].chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      final result = [1, 2, 3].chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      final result = [1, 2, 3].chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      final result = <int>[].chunked(3);
+      expect(result, <List<int>>[]);
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      final result = [1].chunked(1);
+      expect(result, [[1]]);
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('chunked throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final original = [1, 2, 3, 4];
+      final result = original.chunked(2);
+      
+      // Mutate the first chunk
+      result[0][0] = 99;
+      
+      // Original should be unchanged
+      expect(original, [1, 2, 3, 4]);
+      // Mutated chunk should reflect the change
+      expect(result[0], [99, 2]);
+      // Second chunk should be unaffected
+      expect(result[1], [3, 4]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #333

## What changed

- Added `ChunkedList<T>` extension on `List<T>` in `lib/core/utils/list_extensions.dart`
- Implemented `chunked(int size)` method that splits a list into consecutive sub-lists
- Added comprehensive tests in `test/core/utils/list_extensions_test.dart`

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
flutter test
```

Output:
```
00:00 +0: ChunkedList chunked splits a list into consecutive chunks
00:00 +1: ChunkedList chunked returns one chunk when size equals list length
00:00 +2: ChunkedList chunked returns one chunk when size exceeds list length
00:00 +3: ChunkedList chunked returns an empty list for an empty source list
00:00 +4: ChunkedList chunked returns a single-item chunk for a one-element list
00:00 +5: ChunkedList chunked throws ArgumentError when size is zero
00:00 +6: ChunkedList chunked throws ArgumentError when size is negative
00:00 +7: ChunkedList chunked returns independent chunk lists
00:00 +8: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body:
  - Extension `ChunkedList<T>` on `List<T>` with `List<List<T>> chunked(int size)` implemented in `lib/core/utils/list_extensions.dart`
  - Size validation throws `ArgumentError` when `size < 1`
  - Empty list returns `<List<T>>[]`
  - Last chunk may be smaller than size
  - Returns independent chunks using `sublist()`
- AC 2: All named tests pass the verification command:
  - 8 tests pass (7 from spec + 1 added for negative size)
  - Tests use `flutter_test` conventions: `group('ChunkedList', ...)` with named `test()` cases
- AC 3: No dependencies added:
  - Only uses Dart core `List` APIs (`isEmpty`, `length`, `sublist()`)
  - No changes to `pubspec.yaml` or `pubspec.lock`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: Only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` modified
- Do NOT add third-party dependencies: Verified no dependency changes
- Do NOT refactor unrelated code: Only added new extension and tests, no other files touched

## Notes

- Added an extra test for negative size input (`-1`) which also correctly throws `ArgumentError`
- Full test suite has unrelated failures in `lib/features/pi/data/colony_status.freezed.dart` which are pre-existing issues not related to this change