### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,31 @@
+library list_extensions;
+
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws an [ArgumentError] if [size] is less than 1.
+  ///
+  /// Example:
+  /// ```dart
+  /// final list = [1, 2, 3, 4, 5];
+  /// final chunks = list.chunked(2);
+  /// // chunks is [[1, 2], [3, 4], [5]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(
+          size, 'size', 'Must be greater than or equal to 1');
+    }
+
+    if (isEmpty) {
+      return [];
+    }
+
+    final chunks = <List<T>>[];
+    for (int i = 0; i < length; i += size) {
+      final end = i + size < length ? i + size : length;
+      chunks.add(sublist(i, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      final result = [1, 2, 3, 4, 5].chunked(2);
+      expect(
+          result,
+          equals([
+            [1, 2],
+            [3, 4],
+            [5]
+          ]));
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      final result = [1, 2, 3].chunked(3);
+      expect(
+          result,
+          equals([
+            [1, 2, 3]
+          ]));
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      final result = [1, 2, 3].chunked(10);
+      expect(
+          result,
+          equals([
+            [1, 2, 3]
+          ]));
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      final result = <int>[].chunked(3);
+      expect(result, equals(<List<int>>[]));
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      final result = [1].chunked(1);
+      expect(
+          result,
+          equals([
+            [1]
+          ]));
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('chunked throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final original = [1, 2, 3, 4];
+      final result = original.chunked(2);
+      result[0][0] = 99;
+      expect(original, equals([1, 2, 3, 4]));
+      expect(result[0][0], equals(99));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #332

## What changed

- Added `lib/core/utils/list_extensions.dart` with `ChunkedList<T>` extension containing `chunked(int size)` method
- Added `test/core/utils/list_extensions_test.dart` with comprehensive tests for the chunked method

## How verified

```bash
$ flutter test test/core/utils/list_extensions_test.dart
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: ChunkedList chunked splits a list into consecutive chunks
00:00 +1: ChunkedList chunked returns one chunk when size equals list length
00:00 +2: ChunkedList chunked returns one chunk when size exceeds list length
00:00 +3: ChunkedList chunked returns an empty list for an empty source list
00:00 +4: ChunkedList chunked returns a single-item chunk for a one-element list
00:00 +5: ChunkedList chunked throws ArgumentError when size is zero
00:00 +6: ChunkedList chunked throws ArgumentError when size is negative
00:00 +7: ChunkedList chunked returns independent chunk lists
00:00 +8: All tests passed!
```

Analyzer also passed with no issues:
```bash
$ dart analyze lib/core/utils/list_extensions.dart
Analyzing list_extensions.dart...
No issues found!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body - ✓ addressed in `lib/core/utils/list_extensions.dart` 
- AC 2: All named tests pass the verification command - ✓ addressed in `test/core/utils/list_extensions_test.dart`
- AC 3: No dependencies added unless absolutely required - ✓ no dependencies added, using only Dart core features

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated - only modified the expected files
- Do NOT add third-party dependencies unless required by the task body: not violated - no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated - created new files, no refactoring

## Notes

The implementation follows the exact specification from the issue:
1. Extension signature: `extension ChunkedList<T> on List<T> { List<List<T>> chunked(int size) }`
2. Validates size parameter and throws `ArgumentError` if less than 1
3. Handles all edge cases: empty list, single element, size equals/exceeds list length
4. Returns independent chunks using `sublist` so mutations don't affect the original list

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- No dependencies added unless absolutely required: ✓ addressed - no new dependencies