### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,36 @@
+/// Truncates the middle of a string to fit within [maxLength].
+///
+/// If [input].length is less than or equal to [maxLength], the [input] is returned unchanged.
+/// Otherwise, the string is truncated from the middle, inserting the [ellipsis].
+///
+/// The resulting string length will always be <= [maxLength].
+///
+/// Design choices:
+/// - [maxLength] includes the length of the [ellipsis].
+/// - If [maxLength] <= 0 and truncation is needed, returns an empty string.
+/// - If [maxLength] <= [ellipsis].length and truncation is needed, returns
+///   the [ellipsis] truncated to fit [maxLength].
+/// - To maintain symmetry, the remaining available characters ([maxLength] - [ellipsis].length)
+///   are divided equally between the start and end. Any odd leftover character is dropped,
+///   ensuring the result is always <= [maxLength].
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  if (maxLength <= ellipsis.length) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  final visibleChars = maxLength - ellipsis.length;
+  final sideLength = visibleChars ~/ 2;
+
+  final start = input.substring(0, sideLength);
+  final end = input.substring(input.length - sideLength);
+
+  return '$start$ellipsis$end';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when shorter than maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+    });
+
+    test('returns input unchanged when equal to maxLength', () {
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('truncates the middle while keeping start and end visible', () {
+      final result = truncateMiddle('abcdefghijklmn', 8);
+      expect(result, 'abc…lmn');
+      expect(result.length, lessThanOrEqualTo(8));
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns truncated ellipsis when maxLength is shorter than ellipsis',
+        () {
+      final result = truncateMiddle('abcdef', 2, ellipsis: '...');
+      expect(result, '..');
+      expect(result.length, lessThanOrEqualTo(2));
+    });
+
+    test('uses custom ellipsis length when calculating output length', () {
+      final result = truncateMiddle('abcdefghijklmn', 9, ellipsis: '...');
+      expect(result, 'abc...lmn');
+      expect(result.length, lessThanOrEqualTo(9));
+    });
+
+    test('returns an empty string when truncating to non-positive maxLength',
+        () {
+      expect(truncateMiddle('abcdef', 0), '');
+      expect(truncateMiddle('abcdef', -1), '');
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #326

## What changed

- Created `lib/core/utils/string_utils.dart` and implemented `truncateMiddle` helper.
- Created `test/core/utils/string_utils_test.dart` with comprehensive test cases for `truncateMiddle`.

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
flutter test
```
Output: All tests passed!

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body. Verified by tests covering short strings, middle truncation, empty input, and small maxLength.
- AC 2: All named tests pass the verification command. Verified by `flutter test`.
- AC 3: No dependencies added unless absolutely required. No new dependencies added.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated.
- Do NOT add third-party dependencies unless required by the task body: not violated.
- Do NOT refactor unrelated code in the touched files: not violated.

## Notes

The implementation follows the design choice of dropping the odd leftover slot when calculating symmetric side lengths, ensuring the total length is always <= maxLength.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/string_utils.dart
- All named tests pass the verification command: ✓ addressed in test/core/utils/string_utils_test.dart
- No dependencies added unless absolutely required: ✓ addressed in lib/core/utils/string_utils.dart