### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,44 @@
+/// Truncates a string by replacing its middle with an ellipsis while preserving
+/// the start and end.
+///
+/// [maxLength] includes the length of the [ellipsis]. If [input.length] is
+/// less than or equal to [maxLength], [input] is returned unchanged.
+///
+/// When the visible budget after removing the ellipsis is odd, the extra
+/// character is discarded so that equal prefix and suffix lengths are shown:
+///
+/// ```dart
+/// truncateMiddle('abcdefghijklmn', 8) // 'abc…lmn' (3 + 1 + 3 = 7 ≤ 8)
+/// truncateMiddle('abcdef', 3)           // 'a…f'     (1 + 1 + 1 = 3 ≤ 3)
+/// truncateMiddle('hello', 10)           // 'hello'
+/// truncateMiddle('', 5)                 // ''
+/// truncateMiddle('abcdef', 1)           // '…'
+/// truncateMiddle('abcdef', 0)           // ''
+/// ```
+///
+/// If [maxLength] is shorter than [ellipsis.length], the ellipsis itself is
+/// truncated to fit within [maxLength].
+String truncateMiddle(
+  String input,
+  int maxLength, {
+  String ellipsis = '…',
+}) {
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  if (ellipsis.length >= maxLength) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  final visibleLength = maxLength - ellipsis.length;
+  final sideLength = visibleLength ~/ 2;
+  final start = input.substring(0, sideLength);
+  final end = input.substring(input.length - sideLength);
+
+  return '$start$ellipsis$end';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('should return short strings unchanged', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('should truncate the middle of long strings', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+
+    test('should return empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('should return truncated ellipsis when maxLength is too small', () {
+      expect(truncateMiddle('abcdef', 1), '…');
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+      expect(truncateMiddle('abcdef', 0), '');
+    });
+
+    test('should include custom ellipsis length in maxLength budget', () {
+      expect(truncateMiddle('abcdefghijklmn', 8, ellipsis: '...'), 'ab...mn');
+      expect(
+        truncateMiddle('abcdefghijklmn', 8, ellipsis: '...').length,
+        lessThanOrEqualTo(8),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #337

## What changed

- Created `lib/core/utils/string_utils.dart` with `String truncateMiddle(String input, int maxLength, {String ellipsis = '…'})`
  - Unchanged-input guard: returns `input` if `input.length <= maxLength`
  - Boundary handling: returns `''` when `maxLength <= 0`; returns truncated ellipsis when ellipsis is longer than `maxLength`
  - Middle truncation: splits visible budget equally between prefix and suffix, discarding the odd budget character
  - Dart doc comments with usage examples
- Created `test/core/utils/string_utils_test.dart` with 5 focused tests
  - short strings unchanged
  - middle truncation for long strings
  - empty input unchanged
  - too-small `maxLength` edge cases
  - custom ellipsis length included in `maxLength` budget

## How verified
```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
```
Output:
```
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/string_utils_test.dart
00:00 +0: truncateMiddle should return short strings unchanged
00:00 +1: truncateMiddle should truncate the middle of long strings
00:00 +2: truncateMiddle should return empty input unchanged
00:00 +3: truncateMiddle should return truncated ellipsis when maxLength is too small
00:00 +4: truncateMiddle should include custom ellipsis length in maxLength budget
00:00 +5: All tests passed!
```
Also ran `dart analyze lib/core/utils/string_utils.dart test/core/utils/string_utils_test.dart` — zero issues found.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body: ✓ addressed in `lib/core/utils/string_utils.dart` (`truncateMiddle` function, lines 21–44)
- AC 2: All named tests pass the verification command: ✓ addressed by `test/core/utils/string_utils_test.dart` (5 named tests, all pass under `flutter test`)
- AC 3: No dependencies added unless absolutely required: ✓ no `pubspec.yaml`/`pubspec.lock` changes; uses only Dart core `String` methods

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: respected — only `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart` changed
- Do NOT add third-party dependencies unless required by the task body: respected — no dependencies added
- Do NOT refactor unrelated code in the touched files: respected — both files are new, no existing code touched

## Notes

No deviations from plan. The `truncateMiddle` function design choice for `maxLength == 3` with default ellipsis is `'a…f'` (1 + 1 + 1 = 3 ≤ 3) rather than just `'…'`, documented in the Dart doc example.

### Coverage

- Implementation matches all behaviors described in the task body: ✓ addressed in `lib/core/utils/string_utils.dart` (`truncateMiddle`, lines 21–44)
- All named tests pass the verification command: ✓ addressed in `test/core/utils/string_utils_test.dart` (5 named tests)
- No dependencies added unless absolutely required: ✓ addressed — no package changes