### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,38 @@
+/// Compares two semantic-version strings.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b], or a
+/// positive integer if [a] > [b].
+int compareSemVer(String a, String b) {
+  final left = _parseSemVer(a);
+  final right = _parseSemVer(b);
+
+  for (var i = 0; i < 3; i++) {
+    final cmp = left[i].compareTo(right[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+List<int> _parseSemVer(String input) {
+  if (input.isEmpty || input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.').take(3).toList();
+  final result = <int>[];
+
+  for (final part in parts) {
+    final parsed = int.tryParse(part);
+    if (parsed == null) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+    result.add(parsed);
+  }
+
+  while (result.length < 3) {
+    result.add(0);
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('orders versions by major component', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('orders versions by minor component', () {
+      expect(compareSemVer('1.3.0', '1.2.9'), isPositive);
+      expect(compareSemVer('1.2.9', '1.3.0'), isNegative);
+    });
+
+    test('orders versions by patch component', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares components numerically instead of lexicographically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3.4.5', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('1.2.3', ''),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #338

## What changed

-  -- new file defining  (public) and  (private).
-  -- new test file with 9 named test cases covering equality, component ordering, numeric ordering, short-form padding, extra-component truncation, malformed input type, and malformed input message content.

## How verified

Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (100.0.0 available)
  analyzer 8.4.0 (13.0.0 available)
  analyzer_buffer 0.1.11 (0.3.2 available)
  analyzer_plugin 0.13.10 (0.14.9 available)
  async 2.13.0 (2.13.1 available)
  build 4.0.3 (4.0.6 available)
  build_config 1.2.0 (1.3.0 available)
  build_runner 2.10.4 (2.14.1 available)
  built_value 8.12.1 (8.12.5 available)
  cli_util 0.4.2 (0.5.0 available)
  code_builder 4.11.0 (4.11.1 available)
  connectivity_plus 7.0.0 (7.1.1 available)
  connectivity_plus_platform_interface 2.0.1 (2.1.0 available)
  cupertino_icons 1.0.8 (1.0.9 available)
  custom_lint_core 0.8.1 (0.8.2 available)
  custom_lint_visitor 1.0.0+8.4.0 (1.0.0+9.0.0 available)
  dart_style 3.1.3 (3.1.8 available)
  dbus 0.7.11 (0.7.12 available)
  dio 5.9.0 (5.9.2 available)
  dio_web_adapter 2.1.1 (2.1.2 available)
  drift 2.29.0 (2.32.1 available)
  drift_dev 2.29.0 (2.32.1 available)
  equatable 2.0.7 (2.0.8 available)
  ffi 2.1.4 (2.2.0 available)
  fl_chart 1.1.1 (1.2.0 available)
  flutter_riverpod 3.0.3 (3.3.1 available)
  flutter_secure_storage 9.2.4 (10.0.0 available)
  flutter_secure_storage_linux 1.2.3 (3.0.0 available)
  flutter_secure_storage_macos 3.1.3 (4.0.0 available)
  flutter_secure_storage_platform_interface 1.1.2 (2.0.1 available)
  flutter_secure_storage_web 1.2.1 (2.1.0 available)
  flutter_secure_storage_windows 3.1.2 (4.1.0 available)
  flutter_svg 2.2.3 (2.2.4 available)
  freezed 3.2.3 (3.2.5 available)
  go_router 17.0.0 (17.2.2 available)
  google_fonts 6.3.3 (8.0.2 available)
  js 0.6.7 (0.7.2 available)
  json_annotation 4.9.0 (4.11.0 available)
  json_serializable 6.11.2 (6.13.1 available)
  lints 6.0.0 (6.1.0 available)
  logger 2.6.2 (2.7.0 available)
  meta 1.17.0 (1.18.2 available)
  mockito 5.6.1 (5.6.4 available)
  mocktail 1.0.4 (1.0.5 available)
  path_provider_android 2.2.22 (2.3.1 available)
  path_provider_foundation 2.5.1 (2.6.0 available)
  petitparser 7.0.1 (7.0.2 available)
  riverpod 3.0.3 (3.2.1 available)
  riverpod_analyzer_utils 1.0.0-dev.7 (1.0.0-dev.10 available)
  riverpod_annotation 3.0.3 (4.0.2 available)
  riverpod_generator 3.0.3 (4.0.3 available)
  source_gen 4.1.1 (4.2.2 available)
  source_helper 1.3.8 (1.3.11 available)
  source_span 1.10.1 (1.10.2 available)
  sqflite 2.4.2 (2.4.2+1 available)
  sqflite_android 2.4.2+2 (2.4.2+3 available)
  sqflite_common 2.5.6 (2.5.6+1 available)
  sqlite3 2.9.4 (3.3.1 available)
  sqlite3_flutter_libs 0.5.41 (0.6.0+eol available)
  sqlparser 0.42.0 (0.44.3 available)
  synchronized 3.4.0 (3.4.0+1 available)
  test 1.30.0 (1.31.0 available)
  test_api 0.7.10 (0.7.11 available)
  test_core 0.6.16 (0.6.17 available)
  url_launcher_android 6.3.28 (6.3.29 available)
  url_launcher_ios 6.3.6 (6.4.1 available)
  url_launcher_web 2.4.1 (2.4.2 available)
  uuid 4.5.2 (4.5.3 available)
  vector_graphics 1.1.19 (1.1.21 available)
  vector_graphics_compiler 1.1.19 (1.2.0 available)
  vector_math 2.2.0 (2.3.0 available)
  vm_service 15.0.2 (15.1.0 available)
  watcher 1.1.4 (1.2.1 available)
  win32 5.15.0 (6.1.0 available)
  xml 6.6.1 (7.0.1 available)
Got dependencies!
75 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/semver_test.dart
00:00 +0: compareSemVer returns zero for equal versions
00:00 +1: compareSemVer orders versions by major component
00:00 +2: compareSemVer orders versions by minor component
00:00 +3: compareSemVer orders versions by patch component
00:00 +4: compareSemVer compares components numerically instead of lexicographically
00:00 +5: compareSemVer pads short versions with zero components
00:00 +6: compareSemVer ignores components beyond patch
00:00 +7: compareSemVer throws FormatException for malformed input
00:00 +8: compareSemVer includes offending input in FormatException message
00:00 +9: All tests passed!

Output (9 tests, all passed):


Also ran Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (100.0.0 available)
  analyzer 8.4.0 (13.0.0 available)
  analyzer_buffer 0.1.11 (0.3.2 available)
  analyzer_plugin 0.13.10 (0.14.9 available)
  async 2.13.0 (2.13.1 available)
  build 4.0.3 (4.0.6 available)
  build_config 1.2.0 (1.3.0 available)
  build_runner 2.10.4 (2.14.1 available)
  built_value 8.12.1 (8.12.5 available)
  cli_util 0.4.2 (0.5.0 available)
  code_builder 4.11.0 (4.11.1 available)
  connectivity_plus 7.0.0 (7.1.1 available)
  connectivity_plus_platform_interface 2.0.1 (2.1.0 available)
  cupertino_icons 1.0.8 (1.0.9 available)
  custom_lint_core 0.8.1 (0.8.2 available)
  custom_lint_visitor 1.0.0+8.4.0 (1.0.0+9.0.0 available)
  dart_style 3.1.3 (3.1.8 available)
  dbus 0.7.11 (0.7.12 available)
  dio 5.9.0 (5.9.2 available)
  dio_web_adapter 2.1.1 (2.1.2 available)
  drift 2.29.0 (2.32.1 available)
  drift_dev 2.29.0 (2.32.1 available)
  equatable 2.0.7 (2.0.8 available)
  ffi 2.1.4 (2.2.0 available)
  fl_chart 1.1.1 (1.2.0 available)
  flutter_riverpod 3.0.3 (3.3.1 available)
  flutter_secure_storage 9.2.4 (10.0.0 available)
  flutter_secure_storage_linux 1.2.3 (3.0.0 available)
  flutter_secure_storage_macos 3.1.3 (4.0.0 available)
  flutter_secure_storage_platform_interface 1.1.2 (2.0.1 available)
  flutter_secure_storage_web 1.2.1 (2.1.0 available)
  flutter_secure_storage_windows 3.1.2 (4.1.0 available)
  flutter_svg 2.2.3 (2.2.4 available)
  freezed 3.2.3 (3.2.5 available)
  go_router 17.0.0 (17.2.2 available)
  google_fonts 6.3.3 (8.0.2 available)
  js 0.6.7 (0.7.2 available)
  json_annotation 4.9.0 (4.11.0 available)
  json_serializable 6.11.2 (6.13.1 available)
  lints 6.0.0 (6.1.0 available)
  logger 2.6.2 (2.7.0 available)
  meta 1.17.0 (1.18.2 available)
  mockito 5.6.1 (5.6.4 available)
  mocktail 1.0.4 (1.0.5 available)
  path_provider_android 2.2.22 (2.3.1 available)
  path_provider_foundation 2.5.1 (2.6.0 available)
  petitparser 7.0.1 (7.0.2 available)
  riverpod 3.0.3 (3.2.1 available)
  riverpod_analyzer_utils 1.0.0-dev.7 (1.0.0-dev.10 available)
  riverpod_annotation 3.0.3 (4.0.2 available)
  riverpod_generator 3.0.3 (4.0.3 available)
  source_gen 4.1.1 (4.2.2 available)
  source_helper 1.3.8 (1.3.11 available)
  source_span 1.10.1 (1.10.2 available)
  sqflite 2.4.2 (2.4.2+1 available)
  sqflite_android 2.4.2+2 (2.4.2+3 available)
  sqflite_common 2.5.6 (2.5.6+1 available)
  sqlite3 2.9.4 (3.3.1 available)
  sqlite3_flutter_libs 0.5.41 (0.6.0+eol available)
  sqlparser 0.42.0 (0.44.3 available)
  synchronized 3.4.0 (3.4.0+1 available)
  test 1.30.0 (1.31.0 available)
  test_api 0.7.10 (0.7.11 available)
  test_core 0.6.16 (0.6.17 available)
  url_launcher_android 6.3.28 (6.3.29 available)
  url_launcher_ios 6.3.6 (6.4.1 available)
  url_launcher_web 2.4.1 (2.4.2 available)
  uuid 4.5.2 (4.5.3 available)
  vector_graphics 1.1.19 (1.1.21 available)
  vector_graphics_compiler 1.1.19 (1.2.0 available)
  vector_math 2.2.0 (2.3.0 available)
  vm_service 15.0.2 (15.1.0 available)
  watcher 1.1.4 (1.2.1 available)
  win32 5.15.0 (6.1.0 available)
  xml 6.6.1 (7.0.1 available)
Got dependencies!
75 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Analyzing 2 items...                                            
No issues found! (ran in 1.2s) -- 0 issues.

## Acceptance criteria coverage

- AC 1 (Signature is exactly  and lives in ): ✓ defined in 
- AC 2 (Accepts MAJOR.MINOR.PATCH and compares numerically): ✓  parses with ,  loops major → minor → patch; test  asserts .
- AC 3 (Short versions padded with zeros): ✓  pads to length 3 with zeros; test  asserts .
- AC 4 (Extra trailing components ignored): ✓  takes only first 3 components via ; test  asserts .
- AC 5 (Return value contract mirrors ): ✓ returns  result or ; tests use //.
- AC 6 (Malformed input throws ): ✓ empty, whitespace-only, and non-numeric components all throw ; test .
- AC 7 (FormatException message includes offending input verbatim): ✓ message interpolates original ; test  proves message contains .

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated -- diff touches only  and .
- Do NOT add third-party dependencies unless required by the task body: not violated -- no  changes.
- Do NOT refactor unrelated code in the touched files: not violated -- both files are new.

## Notes

- None.