### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,55 @@
+/// Utility functions for string manipulation.
+library string_utils;
+
+/// Truncates the middle of a string with an ellipsis.
+///
+/// If [input] length is less than or equal to [maxLength], returns [input] unchanged.
+/// Otherwise, replaces the middle of the string with [ellipsis], keeping the start
+/// and end visible.
+///
+/// The [maxLength] parameter includes the length of the ellipsis.
+/// The return value length will be less than or equal to [maxLength].
+///
+/// Handles edge cases:
+/// - Empty string: returns empty string
+/// - MaxLength shorter than ellipsis: returns ellipsis truncated to maxLength
+/// - MaxLength <= 0: returns empty string
+///
+/// For balanced truncation, the visible parts are equal in length. If the 
+/// available budget for visible characters (maxLength - ellipsis.length) is odd, 
+/// one character of the budget is intentionally left unused to ensure symmetry.
+///
+/// Example:
+/// ```dart
+/// truncateMiddle('hello', 10); // 'hello'
+/// truncateMiddle('abcdefghijklmn', 8); // 'abc…lmn'
+/// truncateMiddle('', 5); // ''
+/// truncateMiddle('abcdef', 3); // 'a…f'
+/// ```
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // Fast path for strings that don't need truncation
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  // Handle zero or negative maxLength
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  final ellipsisLength = ellipsis.length;
+
+  // If maxLength is shorter than the ellipsis, return truncated ellipsis
+  if (maxLength <= ellipsisLength) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  // Calculate balanced visible halves
+  final availableChars = maxLength - ellipsisLength;
+  final sideLength = availableChars ~/ 2;
+
+  // Build the result: start + ellipsis + end
+  return '${input.substring(0, sideLength)}'
+      '$ellipsis'
+      '${input.substring(input.length - sideLength)}';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns unchanged input when input length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('replaces the middle while keeping start and end visible', () {
+      // maxLength = 8, ellipsis = 1. budget = 7. side = 3. result length = 3+1+3 = 7 <= 8.
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+    });
+
+    test('returns empty string unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('uses documented small maxLength behavior', () {
+      // maxLength = 3, ellipsis = 1. budget = 2. side = 1. result = 'a…f'
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+
+    test('truncates ellipsis when maxLength is shorter than ellipsis', () {
+      expect(truncateMiddle('abcdef', 2, ellipsis: '---'), '--');
+      expect(truncateMiddle('abcdef', 0), '');
+    });
+
+    test('counts custom ellipsis length in maxLength budget', () {
+      // maxLength = 9, ellipsis = 3. budget = 6. side = 3. result length = 3+3+3 = 9.
+      expect(truncateMiddle('abcdefghijklmn', 9, ellipsis: '...'), 'abc...lmn');
+      expect(truncateMiddle('abcdefghijklmn', 9, ellipsis: '...').length, lessThanOrEqualTo(9));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #342

## What changed

- Created `lib/core/utils/string_utils.dart` containing the `truncateMiddle` helper.
- Created `test/core/utils/string_utils_test.dart` with tests covering:
    - Unchanged short strings
    - Middle truncation preserving balanced start and end
    - Empty input
    - Small `maxLength` behavior (including `maxLength` shorter than ellipsis)
    - Custom ellipsis length consideration

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
```
Output: 6 tests passed.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) -> `lib/core/utils/string_utils.dart` implements balanced halves as specified and handles the truncation of the ellipsis when `maxLength` is too small.
- AC 2: All named tests pass the verification command -> Verified by `flutter test test/core/utils/string_utils_test.dart`.
- AC 3: No dependencies added unless absolutely required -> No new dependencies added to `pubspec.yaml`.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated.
- Do NOT add third-party dependencies unless required by the task body: not violated.
- Do NOT refactor unrelated code in the touched files: not violated.

## Notes

For the case where `maxLength - ellipsis.length` is odd, I implemented a balanced distribution that intentionally leaves one character of the budget unused. This ensures symmetry between the start and end parts and exactly matches the task's provided example: `truncateMiddle('abcdefghijklmn', 8)` -> `'abc…lmn'`.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/string_utils.dart
- All named tests pass the verification command: ✓ addressed in test/core/utils/string_utils_test.dart
- No dependencies added unless absolutely required: ✓ addressed by only using Dart core String methods