### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,66 @@
+/// Utility functions for semantic version comparison.
+///
+/// Follows SemVer 2.0.0 specification for format but only implements
+/// basic numeric component comparison (MAJOR.MINOR.PATCH).
+library;
+
+/// Compares two semantic version strings.
+///
+/// Compares versions numerically (not lexicographically) in MAJOR.MINOR.PATCH order.
+/// Short versions are padded with zeros (e.g. '1.2' becomes '1.2.0').
+/// Extra components beyond PATCH are ignored (e.g. '1.2.3.4' becomes '1.2.3').
+///
+/// Returns:
+/// * negative integer if [a] < [b]
+/// * zero if [a] == [b]
+/// * positive integer if [a] > [b]
+///
+/// Throws [FormatException] if either input is malformed (non-numeric components,
+/// empty string, or purely whitespace).
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVerComponents(a);
+  final bParts = _parseSemVerComponents(b);
+
+  // Compare each component in order
+  for (int i = 0; i < 3; i++) {
+    final result = aParts[i].compareTo(bParts[i]);
+    if (result != 0) {
+      return result;
+    }
+  }
+
+  // All components equal
+  return 0;
+}
+
+/// Parses a semantic version string into exactly 3 numeric components.
+///
+/// Takes the first three dot-separated components, ignoring extras.
+/// Pads with zeros if fewer than three components.
+/// Throws [FormatException] for non-numeric components, empty strings, or whitespace.
+List<int> _parseSemVerComponents(String input) {
+  // Check for empty or whitespace-only input
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  // Split on dots and take first three components
+  final parts = input.split('.').take(3).toList();
+
+  // Parse each component to int
+  final components = <int>[];
+  for (final part in parts) {
+    final parsed = int.tryParse(part);
+    if (parsed == null) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+    components.add(parsed);
+  }
+
+  // Pad with zeros if needed
+  while (components.length < 3) {
+    components.add(0);
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major versions numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor versions numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch versions numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares numeric components instead of lexicographic text', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('pads missing components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores extra trailing components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('includes malformed input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((error) => error.message, 'message', contains('1.2.a'))),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((error) => error.message, 'message', contains('   '))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #343

## What changed

- Created `lib/core/utils/semver.dart` with the `compareSemVer(String a, String b)` function.
- Implemented numeric comparison of MAJOR.MINOR.PATCH components.
- Added support for short-form versions (padded with zero) and truncation of extra components.
- Implemented `FormatException` for malformed inputs, including the original input string in the message.
- Created `test/core/utils/semver_test.dart` covering all specified test cases.

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/semver.dart test/core/utils/semver_test.dart
flutter test test/core/utils/semver_test.dart
```
- `dart format` exited 0.
- `flutter test` exited 0: 9 tests passed.

## Acceptance criteria coverage

- AC 1: Exact signature `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`.
- AC 2: Numeric comparison verified in `test/core/utils/semver_test.dart` (e.g., `1.10.0 > 1.2.0`).
- AC 3: Short-form padding verified (`1.2` treated as `1.2.0`).
- AC 4: Extra component truncation verified (`1.2.3.4` treated as `1.2.3`).
- AC 5: Returns signed integers consistent with `Comparable.compareTo`; tests use `isPositive`/`isNegative`/`equals(0)`.
- AC 6: Throws `FormatException` for non-numeric, empty, or whitespace strings.
- AC 7: `FormatException` message contains the offending input string verbatim.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were created.
- Do NOT add third-party dependencies: no new dependencies added.
- Do NOT refactor unrelated code: no unrelated code touched.

## Notes

None.

### Coverage

- AC 1 (verbatim): ✓ addressed in `lib/core/utils/semver.dart`: `int compareSemVer(String a, String b)`
- AC 2 (verbatim): ✓ addressed in `lib/core/utils/semver.dart`: numeric comparison of components.
- AC 3 (verbatim): ✓ addressed in `lib/core/utils/semver.dart`: `while (components.length < 3) { components.add(0); }`
- AC 4 (verbatim): ✓ addressed in `lib/core/utils/semver.dart`: `.split('.').take(3).toList()`
- AC 5 (verbatim): ✓ addressed in `lib/core/utils/semver.dart`: returns result of `aParts[i].compareTo(bParts[i])`.
- AC 6 (verbatim): ✓ addressed in `lib/core/utils/semver.dart`: `throw FormatException('Malformed semantic version: $input');` for empty/whitespace and parsed == null.
- AC 7 (verbatim): ✓ addressed in `lib/core/utils/semver.dart`: `FormatException` message includes `$input`.
