### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,28 @@
+library list_extensions;
+
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The returned chunks are independent copies created via [sublist].
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(
+        size,
+        'size',
+        'Must be greater than or equal to 1',
+      );
+    }
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final List<List<T>> chunks = <List<T>>[];
+    for (int start = 0; start < length; start += size) {
+      final int end = (start + size < length) ? start + size : length;
+      chunks.add(sublist(start, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      expect(
+        [1, 2, 3, 4, 5].chunked(2),
+        [
+          [1, 2],
+          [3, 4],
+          [5]
+        ],
+      );
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      expect(
+        [1, 2, 3].chunked(3),
+        [
+          [1, 2, 3]
+        ],
+      );
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      expect(
+        [1, 2, 3].chunked(10),
+        [
+          [1, 2, 3]
+        ],
+      );
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      expect(
+        <int>[].chunked(3),
+        <List<int>>[],
+      );
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      expect(
+        [1].chunked(1),
+        [
+          [1]
+        ],
+      );
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(
+        () => [1, 2, 3].chunked(0),
+        throwsArgumentError,
+      );
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final list = [1, 2, 3, 4];
+      final result = list.chunked(2);
+      result[0][0] = 99;
+      expect(list, [1, 2, 3, 4]);
+      expect(result[0], [99, 2]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #344

## What changed

- Added `lib/core/utils/list_extensions.dart` with `extension ChunkedList<T> on List<T>` and the `chunked(int size)` method.
  - Validates `size >= 1` throwing `ArgumentError` otherwise.
  - Returns `[]` for an empty source list.
  - Iterates with `for (int start = 0; start < length; start += size)` and caps `end` at `length`.
  - Uses `sublist(start, end)` so chunks are independent of the source list.
- Added 7 focused widget tests in `test/core/utils/list_extensions_test.dart`.

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart
flutter test test/core/utils/list_extensions_test.dart
```

Output digest:
```
Formatted 2 files in 0.01s.
00:00 +7: All tests passed!
```

Additionally ran `dart analyze` on the two changed files with zero issues.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body
  - Covered in `lib/core/utils/list_extensions.dart` lines 10–25: the exact `extension ChunkedList<T> on List<T>` / `List<List<T>> chunked(int size)` API; validation via `if (size < 1)`; early return for `isEmpty`; loop increments by `size` and caps `end` at `length` to produce smaller last chunk; `sublist(start, end)` ensures independence.
- AC 2: All named tests pass the verification command
  - Covered by `test/core/utils/list_extensions_test.dart`: all 7 tests pass under `flutter test test/core/utils/list_extensions_test.dart`.
- AC 3: No dependencies added unless absolutely required
  - Covered: no `pubspec.yaml`/`pubspec.lock` changes; only core Dart `List` APIs used.

## Non-goals acknowledged

- Did NOT modify files beyond `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart`.
- Did NOT add third-party dependencies.
- Did NOT refactor unrelated code in touched files.

## Notes

None.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/list_extensions.dart` extension `ChunkedList<T>.chunked(int size)`
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/list_extensions_test.dart` 7 passing tests
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — no dependency files changed