### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,22 @@
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'must be greater than or equal to 1');
+    }
+
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final List<List<T>> chunks = [];
+    for (int start = 0; start < length; start += size) {
+      final int end = start + size < length ? start + size : length;
+      chunks.add(sublist(start, end));
+    }
+
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList.chunked', () {
+    test('splits list into consecutive chunks of requested size', () {
+      final input = [1, 2, 3, 4, 5];
+      final result = input.chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('returns one chunk when size equals list length', () {
+      final input = [1, 2, 3];
+      final result = input.chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('returns one chunk when size is greater than list length', () {
+      final input = [1, 2, 3];
+      final result = input.chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('returns empty list for empty input', () {
+      final input = <int>[];
+      final result = input.chunked(3);
+      expect(result, <List<int>>[]);
+    });
+
+    test('returns single chunk for single element list', () {
+      final input = [1];
+      final result = input.chunked(1);
+      expect(result, [[1]]);
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsA(isA<ArgumentError>()));
+    });
+
+    test('returns chunks independent from original list', () {
+      final original = [1, 2, 3, 4];
+      final chunks = original.chunked(2);
+
+      chunks[0][0] = 99;
+
+      expect(original, [1, 2, 3, 4]);
+      expect(chunks, [[99, 2], [3, 4]]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #347

## What changed

- Created `lib/core/utils/list_extensions.dart` and added `ChunkedList.chunked(int size)` extension on `List<T>`.
- Implemented chunking logic using `sublist` to ensure returned chunks are independent.
- Added argument validation to throw `ArgumentError` when `size < 1`.
- Created `test/core/utils/list_extensions_test.dart` with comprehensive coverage for happy path, boundaries, empty lists, and error cases.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
\`\`\`
Output:
All tests passed! (7 tests)

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body. ✓ Addressed in `lib/core/utils/list_extensions.dart`
- AC 2: All named tests pass the verification command. ✓ Verified by `flutter test test/core/utils/list_extensions_test.dart`
- AC 3: No dependencies added unless absolutely required. ✓ Only used Dart core `List` APIs and existing `flutter_test` package.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

The implementation uses `sublist()` which creates a new list, satisfying the requirement that mutating a chunk does not affect the original list.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- No dependencies added unless absolutely required: ✓ addressed in lib/core/utils/list_extensions.dart