### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,46 @@
+/// Parses a semver string into its [major, minor, patch] integer components.
+///
+/// Throws [FormatException] if the input is empty, purely whitespace, or
+/// contains a non-numeric component in the first three positions.
+/// Components beyond patch (index > 2) are ignored.
+List<int> _parseSemVerCore(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+  final result = <int>[];
+  for (var i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final value = int.tryParse(parts[i]);
+      if (value == null) {
+        throw FormatException('Malformed semantic version: $input');
+      }
+      result.add(value);
+    } else {
+      result.add(0);
+    }
+  }
+  return result;
+}
+
+/// Compares two semantic-version strings numerically.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b],
+/// and a positive integer if [a] > [b].
+///
+/// Missing components (e.g. "1.2" for "1.2.0") default to zero.
+/// Extra components beyond patch are ignored (e.g. "1.2.3.4" == "1.2.3").
+///
+/// Throws [FormatException] if either input is empty, purely whitespace,
+/// or contains a non-numeric major/minor/patch component.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVerCore(a);
+  final bParts = _parseSemVerCore(b);
+
+  for (var i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) return cmp;
+  }
+  return 0;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares differing major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares differing minor components numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares differing patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders numeric components rather than lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores components after patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for blank input', () {
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            contains('   '),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #349

## What changed

- `lib/core/utils/semver.dart` (new): defines `int compareSemVer(String a, String b)` and a private `_parseSemVerCore` helper
- `test/core/utils/semver_test.dart` (new): 10 test cases covering equal versions, per-component comparisons, numeric ordering, short-form padding, extra-component truncation, malformed input, and message-content assertions

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/semver.dart test/core/utils/semver_test.dart
# Formatted 2 files (0 changed) in 0.04 seconds.

flutter test test/core/utils/semver_test.dart
# 00:00 +10: All tests passed!

dart analyze lib/core/utils/semver.dart
# No issues found!
```

## Acceptance criteria coverage

- Implementation matches all behaviors described in the task body: ✓ compareSemVer() in lib/core/utils/semver.dart with numeric comparison, zero-padding, extra-component ignore, FormatException on malformed input
- All named tests pass the verification command: ✓ verified above — 10/10 pass
- No dependencies added unless absolutely required: ✓ uses only core Dart APIs + existing flutter_test dev dependency

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only the two expected files were created
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — both files are new; no existing code modified

## Notes

Followed the approved plan exactly. Both files are new and follow the existing test style in test/core/utils/ (group/test pattern, flutter_test imports).

### Coverage

- AC 1 (Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`): ✓ addressed in `lib/core/utils/semver.dart` line 29
- AC 2 (Accepts versions of the form `MAJOR.MINOR.PATCH` and compares major → minor → patch NUMERICALLY): ✓ addressed in `_parseSemVerCore` (numeric parsing via int.tryParse) and `compareSemVer` (compareTo in order 0,1,2)
- AC 3 (Short version treated as `1.2.0` — missing components default to zero): ✓ addressed in `_parseSemVerCore` line 22-24 (default 0 when index >= parts.length)
- AC 4 (Extra trailing components ignored): ✓ addressed in `_parseSemVerCore` loop limit at 3 (indexes 0,1,2 only)
- AC 5 (Return value sign matters, not magnitude): ✓ addressed — all non-equality tests use isPositive/isNegative, only equal tests use equals(0)
- AC 6 (Malformed input throws FormatException): ✓ addressed in `_parseSemVerCore` lines 6-7 (empty/whitespace) and line 14-15 (non-numeric component)
- AC 7 (FormatException.message includes offending input verbatim): ✓ addressed in `_parseSemVerCore` lines 7 and 16 (throw FormatException('Malformed semantic version: $input')), verified by test `includes offending input in FormatException message`