### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,30 @@
+/// Extension that adds utility methods to Lists.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Example:
+  /// ```dart
+  /// [1,2,3,4,5].chunked(2) // [[1,2],[3,4],[5]]
+  /// [1,2,3].chunked(10)    // [[1,2,3]]
+  /// [].chunked(3)          // []
+  /// [1].chunked(1)         // [[1]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'Must be greater than or equal to 1');
+    }
+
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final List<List<T>> chunks = <List<T>>[];
+    for (int i = 0; i < length; i += size) {
+      final int end = (i + size < length) ? i + size : length;
+      chunks.add(sublist(i, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      final List<int> list = [1, 2, 3, 4, 5];
+      final List<List<int>> result = list.chunked(2);
+      expect(result, [
+        [1, 2],
+        [3, 4],
+        [5]
+      ]);
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      final List<int> list = [1, 2, 3];
+      final List<List<int>> result = list.chunked(3);
+      expect(result, [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      final List<int> list = [1, 2, 3];
+      final List<List<int>> result = list.chunked(10);
+      expect(result, [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      final List<int> list = <int>[];
+      final List<List<int>> result = list.chunked(3);
+      expect(result, <List<int>>[]);
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      final List<int> list = [1];
+      final List<List<int>> result = list.chunked(1);
+      expect(result, [
+        [1]
+      ]);
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      final List<int> list = [1, 2, 3];
+      expect(() => list.chunked(0), throwsArgumentError);
+    });
+
+    test('chunked throws ArgumentError when size is negative', () {
+      final List<int> list = [1, 2, 3];
+      expect(() => list.chunked(-1), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final List<int> list = [1, 2, 3, 4];
+      final List<List<int>> result = list.chunked(2);
+      
+      // Mutate one of the chunks
+      result[0][0] = 99;
+      
+      // Original list should remain unchanged
+      expect(list, [1, 2, 3, 4]);
+      
+      // The result should reflect our mutation
+      expect(result[0], [99, 2]);
+      expect(result[1], [3, 4]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #345

## What changed

- Added `ChunkedList<T>` extension on `List<T>` in `lib/core/utils/list_extensions.dart`
- Implemented `chunked(int size)` method that splits list into consecutive sub‑lists of at most `size` elements
- Throws `ArgumentError` if `size < 1`
- Empty source list returns empty list
- Last chunk may be smaller than `size`
- Returned chunks are independent (mutating a chunk doesn't affect the original list)

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```

Output:
```
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: ChunkedList chunked splits a list into consecutive chunks
00:00 +1: ChunkedList chunked returns one chunk when size equals list length
00:00 +2: ChunkedList chunked returns one chunk when size exceeds list length
00:00 +3: ChunkedList chunked returns an empty list for an empty source list
00:00 +4: ChunkedList chunked returns a single-item chunk for a one-element list
00:00 +5: ChunkedList chunked throws ArgumentError when size is zero
00:00 +6: ChunkedList chunked throws ArgumentError when size is negative
00:00 +7: ChunkedList chunked returns independent chunk lists
00:00 +8: All tests passed!
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — ✓ addressed in `lib/core/utils/list_extensions.dart` `ChunkedList.chunked()`
- AC 2: All named tests pass the verification command — ✓ all 7 named tests (plus an extra `size < 0` test) pass `flutter test`
- AC 3: No dependencies added unless absolutely required — ✓ uses only Dart core APIs; no changes to `pubspec.yaml` or `pubspec.lock`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — ✓ only changed `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart`
- Do NOT add third-party dependencies unless required by the task body — ✓ no dependencies added
- Do NOT refactor unrelated code in the touched files — ✓ no unrelated refactoring

## Notes

Created two new files as required. The implementation exactly follows the approved plan, using `sublist` to ensure returned chunks are independent lists.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body) — ✓ addressed in `lib/core/utils/list_extensions.dart` extension method
- AC 2 (All named tests pass the verification command) — ✓ all named tests pass `flutter test` (8 tests total)
- AC 3 (No dependencies added unless absolutely required) — ✓ no dependencies added