### PR TITLE
[BENCH t01 deepseek-v3.2-c] feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,58 @@
+/// Compares two semantic version strings.
+///
+/// Returns a comparator-style integer:
+/// - negative if `a < b`
+/// - zero if `a == b`
+/// - positive if `a > b`
+///
+/// Versions are of the form MAJOR.MINOR.PATCH (e.g. `1.2.3`).
+/// Comparison is numeric (not lexicographic): `1.10.0 > 1.2.0`.
+///
+/// Missing components are padded with zero: `1.2` is treated as `1.2.0`.
+///
+/// Extra components beyond patch are ignored: `1.2.3.4` is treated as `1.2.3`.
+///
+/// Malformed input (non‑numeric component, empty string, or purely whitespace string)
+/// throws a [FormatException] whose message includes the offending input string.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVerComponents(a);
+  final bParts = _parseSemVerComponents(b);
+
+  for (int i = 0; i < 3; i++) {
+    final comparison = aParts[i].compareTo(bParts[i]);
+    if (comparison != 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into [major, minor, patch].
+///
+/// Components are parsed as integers via [int.tryParse].
+/// Throws [FormatException] if a component is non‑numeric, or if the input
+/// is empty or purely whitespace.
+List<int> _parseSemVerComponents(String input) {
+  // Empty or whitespace‑only input is malformed.
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+
+  // Select three components, defaulting to '0' when missing.
+  final majorStr = parts.isNotEmpty ? parts[0] : '0';
+  final minorStr = parts.length > 1 ? parts[1] : '0';
+  final patchStr = parts.length > 2 ? parts[2] : '0';
+
+  final major = int.tryParse(majorStr);
+  final minor = int.tryParse(minorStr);
+  final patch = int.tryParse(patchStr);
+
+  if (major == null || minor == null || patch == null) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  return [major, minor, patch];
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+      expect(compareSemVer('0.0.0', '0.0.0'), equals(0));
+      expect(compareSemVer('10.20.30', '10.20.30'), equals(0));
+    });
+
+    test('compares differing major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares differing minor components numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares differing patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares numeric components instead of lexicographic order', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+      // Ensure numeric comparison, not lexicographic: '10' > '2'
+      expect(compareSemVer('2.2.0', '10.1.0'), isNegative);
+      expect(compareSemVer('10.1.0', '2.2.0'), isPositive);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      // Semantics: '1' → [1,0,0], '1.2' → [1,2,0], '1.2.3' → [1,2,3]
+      expect(compareSemVer('2', '1.9.9'), isPositive);
+      expect(compareSemVer('2.1', '2.0.9'), isPositive);
+    });
+
+    test('ignores extra trailing components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3', '1.2.3.4'), equals(0));
+      expect(compareSemVer('1.2.3.9', '1.2.3.9'), equals(0));
+      // Extra components do not affect comparison
+      expect(compareSemVer('1.2.3.100', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      // Non‑numeric component
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '1.2.a'), throwsA(isA<FormatException>()));
+      // Empty string
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      // Purely whitespace string
+      expect(() => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+      // Multiple malformed components
+      expect(() => compareSemVer('a.b.c', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', 'a.b.c'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      // Single malformed argument 'a' should appear in exception
+      expect(
+        () => compareSemVer('a', '1.2.3'),
+        throwsA(isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          contains('a'),
+        )),
+      );
+      // Malformed argument '1.2.a' appears
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          contains('1.2.a'),
+        )),
+      );
+      // Whitespace input appears
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          contains('   '),
+        )),
+      );
+      // Second argument malformed
+      expect(
+        () => compareSemVer('1.2.3', 'b.c.d'),
+        throwsA(isA<FormatException>().having(
+          (e) => e.message,
+          'message',
+          contains('b.c.d'),
+        )),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #346

## What changed

- Created `lib/core/utils/semver.dart` with `compareSemVer(String a, String b)` function and private helper `_parseSemVerComponents`
- Created `test/core/utils/semver_test.dart` with 9 tests covering all acceptance criteria:
  - Equal versions, differing majors/minors/patches numeric ordering
  - Short-form padding (`1.2` → `1.2.0`)
  - Extra-component truncation (`1.2.3.4` → `1.2.3`)
  - Malformed input throws `FormatException` (empty, whitespace, non‑numeric)
  - Exception message includes the offending input substring

## How verified

Exact commands run (from the card's `verification` field) and their output digest:

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```
→ All 9 tests passed (output digest: `00:00 +9: All tests passed!`)

```bash
cd ~/workspace/infiquetra/mimir
flutter test
```
→ All 17 tests passed (including existing widget tests)

```bash
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```
→ No new issues found (`No issues found!`)

## Acceptance criteria coverage

- AC 1 (Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`): ✓ addressed in `lib/core/utils/semver.dart:19`
- AC 2 (Accepts versions of the form `MAJOR.MINOR.PATCH` and compares major → minor → patch NUMERICALLY): ✓ implemented in `_parseSemVerComponents` + `int.compareTo`; verified by test `compares numeric components instead of lexicographic order`
- AC 3 (A short version is treated as missing components default to zero): ✓ `_parseSemVerComponents` defaults missing components to `'0'`; verified by test `pads short versions with zero components`
- AC 4 (Extra trailing components beyond patch are ignored): ✓ only first three components parsed; verified by test `ignores extra trailing components beyond patch`
- AC 5 (Return value contract mirrors `Comparable.compareTo`: the SIGN is what matters): ✓ returns `comparison` directly, tests assert `isPositive`/`isNegative`/`equals(0)`
- AC 6 (Malformed input throws `FormatException`): ✓ parser throws `FormatException` for `int.tryParse` null or empty/whitespace input; verified by test `throws FormatException for malformed input`
- AC 7 (The `FormatException` message MUST include the offending input string verbatim): ✓ `FormatException('Malformed semantic version: \$input')` includes `\$input`; verified by test `includes offending input in FormatException message`

## Non-goals acknowledged

Each non-goal from the linked card, confirmed not violated:

- Do NOT modify files beyond the expected set below: ✅ only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart`
- Do NOT add third-party dependencies unless required by the task body: ✅ no changes to `pubspec.yaml` or `pubspec.lock`
- Do NOT refactor unrelated code in the touched files: ✅ both files are new, no existing code modified

## Notes

No deviations from the approved plan; all tests pass; analyzer passes without new issues.