### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,33 @@
+/// Extension providing list manipulation utilities.
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// - [size] must be >= 1; throws [ArgumentError] if not
+  /// - Empty list returns an empty list
+  /// - Last chunk may be smaller than [size]
+  /// - Returned chunks are independent (mutating one does not affect the original)
+  ///
+  /// Examples:
+  /// - `[1, 2, 3, 4, 5].chunked(2)` → `[[1, 2], [3, 4], [5]]`
+  /// - `[1, 2, 3].chunked(10)` → `[[1, 2, 3]]`
+  /// - `[].chunked(3)` → `[]`
+  /// - `[1].chunked(1)` → `[[1]]`
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(
+          size, 'size', 'Must be greater than or equal to 1');
+    }
+
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final List<List<T>> chunks = <List<T>>[];
+    for (int i = 0; i < length; i += size) {
+      final int end = (i + size < length) ? i + size : length;
+      chunks.add(sublist(i, end));
+    }
+
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [
+        [1, 2],
+        [3, 4],
+        [5]
+      ]);
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      expect([1, 2, 3].chunked(3), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      expect(<int>[].chunked(3), <List<int>>[]);
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      expect([1].chunked(1), [
+        [1]
+      ]);
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('chunked throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final original = [1, 2, 3, 4];
+      final result = original.chunked(2);
+
+      // Mutate the first chunk
+      result[0][0] = 99;
+
+      // Original should be unchanged
+      expect(original, [1, 2, 3, 4]);
+      // First chunk should have the mutation
+      expect(result[0], [99, 2]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #372

## What changed

- Added  in 
- Implemented  method:
  - Validates  and throws  with descriptive message if not
  - Returns empty list  for empty source list
  - Uses  to create independent chunks
- Added comprehensive tests in :
  - Happy path: consecutive chunks
  - Boundary: size equals list length
  - Boundary: size exceeds list length  
  - Edge case: empty source list
  - Edge case: single element list
  - Error case: ArgumentError on size == 0
  - Error case: ArgumentError on negative size
  - Independence check: mutating chunks doesn't affect original

## How verified

Resolving dependencies...
Downloading packages...
  async 2.11.0 (2.13.1 available)
  boolean_selector 2.1.1 (2.1.2 available)
> characters 1.4.1 (was 1.3.0)
> clock 1.1.2 (was 1.1.1)
> collection 1.19.1 (was 1.18.0)
  cupertino_icons 1.0.8 (1.0.9 available)
> fake_async 1.3.3 (was 1.3.1)
  flutter_lints 3.0.2 (6.0.0 available)
> leak_tracker 11.0.2 (was 10.0.0)
> leak_tracker_flutter_testing 3.0.10 (was 2.0.1)
> leak_tracker_testing 3.0.2 (was 2.0.1)
  lints 3.0.0 (6.1.0 available)
> matcher 0.12.19 (was 0.12.16+1)
> material_color_utilities 0.13.0 (was 0.8.0)
> meta 1.17.0 (was 1.11.0) (1.18.2 available)
> path 1.9.1 (was 1.9.0)
< sky_engine 0.0.0 from sdk flutter (was 0.0.99 from sdk flutter)
  source_span 1.10.0 (1.10.2 available)
> stack_trace 1.12.1 (was 1.11.1)
> stream_channel 2.1.4 (was 2.1.2)
  string_scanner 1.2.0 (1.4.1 available)
  term_glyph 1.2.1 (1.2.2 available)
> test_api 0.7.10 (was 0.6.1) (0.7.11 available)
> vector_math 2.2.0 (was 2.1.4) (2.3.0 available)
  vm_service 13.0.0 (15.1.0 available)
Changed 16 dependencies!
12 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: ChunkedList chunked splits a list into consecutive chunks
00:00 +1: ChunkedList chunked returns one chunk when size equals list length
00:00 +2: ChunkedList chunked returns one chunk when size exceeds list length
00:00 +3: ChunkedList chunked returns an empty list for an empty source list
00:00 +4: ChunkedList chunked returns a single-item chunk for a one-element list
00:00 +5: ChunkedList chunked throws ArgumentError when size is zero
00:00 +6: ChunkedList chunked throws ArgumentError when size is negative
00:00 +7: ChunkedList chunked returns independent chunk lists
00:00 +8: All tests passed!
Resolving dependencies...
Downloading packages...
  async 2.11.0 (2.13.1 available)
  boolean_selector 2.1.1 (2.1.2 available)
  cupertino_icons 1.0.8 (1.0.9 available)
  flutter_lints 3.0.2 (6.0.0 available)
  lints 3.0.0 (6.1.0 available)
  meta 1.17.0 (1.18.2 available)
  source_span 1.10.0 (1.10.2 available)
  string_scanner 1.2.0 (1.4.1 available)
  term_glyph 1.2.1 (1.2.2 available)
  test_api 0.7.10 (0.7.11 available)
  vector_math 2.2.0 (2.3.0 available)
  vm_service 13.0.0 (15.1.0 available)
Got dependencies!
12 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/widget_test.dart
00:00 +0: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +1: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +2: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +3: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +4: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +5: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +6: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +7: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +8: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +9: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +10: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +11: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +12: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +13: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +14: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +15: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:02 +16: All tests passed!

Output:
-  (list_extensions_test.dart)
-  (full suite)
- Analyzing mimir...

   info - lib/core/utils/formatters.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments

1 issue found.: No issues found
- : Completed successfully

## Acceptance criteria coverage

- AC 1: ✓ Implementation matches all behaviors (signature, validation, empty list, independent chunks)
- AC 2: ✓ All 8 named tests pass verification command
- AC 3: ✓ No dependencies added (uses only Dart core List APIs)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: ✓ Only touched  and 
- Do NOT add third-party dependencies: ✓ No new dependencies
- Do NOT refactor unrelated code: ✓ No changes to existing files

## Notes

None - straightforward implementation following existing patterns in the codebase.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in  lines 12-27
- AC 2 (All named tests pass the verification command): ✓ addressed in  lines 8-41
- AC 3 (No dependencies added unless absolutely required): ✓ verified - only uses Dart core List APIs (isEmpty, length, sublist)