### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,82 @@
+/// Utility functions for semantic version comparison.
+library;
+
+/// Parses a semantic version string into exactly three numeric components.
+///
+/// [version] must be a non-empty, non-whitespace-only string using dot-separated
+/// numeric components. Malformed input throws [FormatException] with the
+/// offending value included in the message.
+///
+/// Behavior:
+/// - Short versions (e.g., '1.2') are padded with zeros → [1, 2, 0].
+/// - Extra components (e.g., '1.2.3.4') are truncated → [1, 2, 3].
+/// - Non-numeric components throw [FormatException].
+/// - Empty or whitespace-only strings throw [FormatException].
+List<int> _parseSemVerComponents(String version) {
+  // Validate non-empty input
+  if (version.isEmpty) {
+    throw FormatException('Malformed semantic version: $version');
+  }
+
+  // Validate not purely whitespace
+  if (version.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $version');
+  }
+
+  final parts = version.split('.');
+
+  // Consider only the first three components
+  final componentsToParse = parts.take(3);
+  final parsed = <int>[];
+
+  for (final component in componentsToParse) {
+    final value = int.tryParse(component);
+    if (value == null) {
+      throw FormatException('Malformed semantic version: $version');
+    }
+    parsed.add(value);
+  }
+
+  // Pad with zeros for missing components
+  while (parsed.length < 3) {
+    parsed.add(0);
+  }
+
+  return parsed;
+}
+
+/// Compares two semantic-version strings.
+///
+/// Returns a comparator-style integer: negative if [a] < [b], zero if [a] == [b],
+/// positive if [a] > [b]. The magnitude of the result is not specified; only
+/// the sign matters.
+///
+/// Accepts versions of the form `MAJOR.MINOR.PATCH` (e.g., `1.2.3`). Comparison
+/// is numeric (not lexicographic), so `1.10.0 > 1.2.0`.
+///
+/// Short versions (e.g., `1.2`) are treated as `1.2.0`. Extra trailing
+/// components (e.g., `1.2.3.4`) are treated as `1.2.3`.
+///
+/// Throws [FormatException] if either input is malformed: empty string,
+/// whitespace-only string, or contains non-numeric components. The exception
+/// message includes the offending input verbatim.
+///
+/// Examples:
+/// - `compareSemVer('1.2.3', '1.2.3')` → `0`
+/// - `compareSemVer('1.2.3', '1.2.4')` → negative
+/// - `compareSemVer('1.10.0', '1.2.0')` → positive
+/// - `compareSemVer('1.2', '1.2.0')` → `0`
+/// - `compareSemVer('1.2.3.4', '1.2.3')` → `0`
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  for (var i = 0; i < 3; i++) {
+    final comparison = aComponents[i].compareTo(bComponents[i]);
+    if (comparison != 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major component numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor component numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch component numerically', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+    });
+
+    test('uses numeric ordering instead of lexicographic ordering', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+      expect(compareSemVer('2.0', '1.999.999'), isPositive);
+    });
+
+    test('ignores extra trailing components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3.4.5.6', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', '1.x.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+      expect(
+        () => compareSemVer('1.2.3', '1.x.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.x.3'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty input', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3', ''), throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException for whitespace-only input and preserves it in the message', () {
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('   '),
+          ),
+        ),
+      );
+    });
+
+    test('handles zero values correctly', () {
+      expect(compareSemVer('0.0.0', '0.0.0'), equals(0));
+      expect(compareSemVer('0.1.0', '0.0.1'), isPositive);
+    });
+
+    test('handles large version numbers', () {
+      expect(compareSemVer('999.999.999', '999.999.998'), isPositive);
+      expect(compareSemVer('1000.0.0', '999.999.999'), isPositive);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #368

## What changed

- Created `lib/core/utils/semver.dart` with the public function `int compareSemVer(String a, String b)`
- Created `test/core/utils/semver_test.dart` with comprehensive tests covering all acceptance criteria
- Implementation uses numeric comparison for major.minor.patch components
- Handles short versions (e.g., `1.2`) by padding with zeros to `1.2.0`
- Handles extra trailing components (e.g., `1.2.3.4`) by truncating to `1.2.3`
- Throws `FormatException` for malformed input with offending string preserved in message

## How verified

Exact commands run:
```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
```

Test output:
```
00:00 +13: All tests passed!
```

Analyzer output:
```
Analyzing semver.dart, semver_test.dart...
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`): ✓ addressed in `lib/core/utils/semver.dart` lines 47-62
- AC 2 (Accepts versions `MAJOR.MINOR.PATCH` and compares numerically): ✓ addressed in `_parseSemVerComponents` and `compareSemVer`, verified by test `uses numeric ordering instead of lexicographic ordering`
- AC 3 (Short versions treated as `MAJOR.MINOR.0`): ✓ addressed in `_parseSemVerComponents`, verified by test `pads short versions with zero components`
- AC 4 (Extra components truncated): ✓ addressed in `_parseSemVerComponents` lines 30-31, verified by test `ignores extra trailing components beyond patch`
- AC 5 (Return value contract uses sign only): ✓ addressed in `compareSemVer`, tests use `isNegative`/`isPositive`/`equals(0)` only
- AC 6 (Malformed input throws `FormatException`): ✓ addressed in `_parseSemVerComponents` lines 10-28, verified by tests `throws FormatException for malformed input` and `throws FormatException for empty input`
- AC 7 (`FormatException.message` includes offending input verbatim): ✓ addressed in `_parseSemVerComponents`, verified by test `includes offending input in FormatException message`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` modified
- Do NOT add third-party dependencies unless required by the task body: not violated — no changes to `pubspec.yaml`
- Do NOT refactor unrelated code in the touched files: not violated — both files are new, no existing code modified

## Notes

No deviations from the approved plan. Implementation follows the existing Flutter/Dart conventions seen in `lib/core/utils/formatters.dart` and `test/core/utils/formatters_test.dart`.
