### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,52 @@
+/// Utility functions for string manipulation.
+
+/// Truncates a long string by replacing the middle with an ellipsis.
+///
+/// Keeps the beginning and end of the string visible, replacing the middle
+/// with the specified ellipsis string. The total length of the result
+/// will never exceed [maxLength].
+///
+/// If [input.length] is already <= [maxLength], returns [input] unchanged.
+///
+/// If [maxLength] is shorter than [ellipsis.length], the ellipsis itself
+/// is truncated to fit within [maxLength].
+///
+/// When the available space for visible characters (after accounting for
+/// the ellipsis) is odd, the leftover character is intentionally left
+/// unused to maintain balanced start/end visibility. For example:
+/// `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'` (3 + 1 + 3 = 7 chars,
+/// leaving one character of the 8-character budget unused).
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 0)` → `''`
+/// - `truncateMiddle('abcdef', 1)` → `'…'`
+///
+/// Throws [ArgumentError] if [maxLength] is negative.
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  if (maxLength < 0) {
+    throw ArgumentError.value(maxLength, 'maxLength', 'must be non-negative');
+  }
+
+  // Already within limit - return unchanged
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  // Not enough room for even the ellipsis - truncate ellipsis itself
+  if (maxLength <= ellipsis.length) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  // Calculate available space for visible characters
+  final available = maxLength - ellipsis.length;
+  // Use floor division to keep start/end balanced; odd leftover is intentionally unused
+  final sideLength = available ~/ 2;
+
+  final start = input.substring(0, sideLength);
+  final end = input.substring(input.length - sideLength);
+
+  return '$start$ellipsis$end';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns unchanged input when length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('replaces the middle with the default ellipsis', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns truncated ellipsis when maxLength is shorter than ellipsis', () {
+      expect(truncateMiddle('abcdef', 0), '');
+      expect(truncateMiddle('abcdef', 1), '…');
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+    });
+
+    test('counts custom ellipsis length toward maxLength', () {
+      expect(truncateMiddle('abcdefghijklmn', 9, ellipsis: '...'), 'abc...lmn');
+      expect(truncateMiddle('abcdefghijklmn', 10, ellipsis: '[...]'), 'ab[...]mn');
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #371

## What changed

- Created `lib/core/utils/string_utils.dart` with new `truncateMiddle()` function
- Created `test/core/utils/string_utils_test.dart` with comprehensive tests
- `truncateMiddle(String input, int maxLength, {String ellipsis = '…'})` truncates strings by replacing the middle with ellipsis
- Returns input unchanged when already within maxLength (including empty strings)
- Returns truncated ellipsis when maxLength is shorter than ellipsis.length
- Throws ArgumentError for negative maxLength
- Odd leftover characters intentionally unused to maintain balanced start/end visibility (e.g., `'abc…lmn'` for 8-char budget)

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
flutter test
```

Output:
```
00:00 +5: All tests passed!
...
00:01 +13: All tests passed!
```

## Acceptance criteria coverage

- AC 1 ("Implementation matches all behaviors described in the task body"): ✓ Implemented in `lib/core/utils/string_utils.dart`:
  - Returns input unchanged when `input.length <= maxLength` (line 29)
  - Replaces middle with ellipsis, keeping start/end visible (lines 37-42)
  - `maxLength` includes ellipsis length (`available = maxLength - ellipsis.length`, line 36)
  - Returns truncated ellipsis when `maxLength <= ellipsis.length` (lines 33-34)
  - Handles empty strings (line 29, covered by test)
- AC 2 ("All named tests pass the verification command"): ✓ All 5 tests in `test/core/utils/string_utils_test.dart` pass:
  - `returns unchanged input when length is within maxLength`
  - `replaces the middle with the default ellipsis`
  - `returns empty input unchanged`
  - `returns truncated ellipsis when maxLength is shorter than ellipsis`
  - `counts custom ellipsis length toward maxLength`
- AC 3 ("No dependencies added unless absolutely required"): ✓ No dependencies added. Uses only Dart core `String` methods.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: Compliant. Only modified `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart`.
- Do NOT add third-party dependencies unless required by the task body: Compliant. No new dependencies.
- Do NOT refactor unrelated code in the touched files: Compliant. Both files are new and focused solely on `truncateMiddle()`.

## Notes

- Implementation style matches existing `formatters.dart` in the same directory
- Design choice for odd `available`: Uses `available ~/ 2` to give equal characters to start and end, leaving one unused. Documented in doc comment.