### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,43 @@
+/// Truncates a string from the middle when it exceeds [maxLength], replacing
+/// the removed middle portion with [ellipsis].
+///
+/// Strings with `input.length <= maxLength` are returned unchanged.
+/// Otherwise, the middle is replaced by [ellipsis].
+/// [maxLength] includes the ellipsis length, so the total output length is
+/// always `<= maxLength`.
+///
+/// For very small [maxLength], the ellipsis itself is truncated so it still
+/// fits — for example, `truncateMiddle('abcdef', 1)` returns `'…'`.
+///
+/// Odd visible-character budgets are handled consistently by assigning the
+/// extra character to the start.
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abcd…lmn'`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'`
+String truncateMiddle(
+  String input,
+  int maxLength, {
+  String ellipsis = '…',
+}) {
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  if (ellipsis.length >= maxLength) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  final visibleLength = maxLength - ellipsis.length;
+  final startLength = (visibleLength + 1) ~/ 2;
+  final endLength = visibleLength ~/ 2;
+
+  return input.substring(0, startLength) +
+      ellipsis +
+      input.substring(input.length - endLength);
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns unchanged input when length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), equals('hello'));
+      expect(truncateMiddle('hello', 5), equals('hello'));
+    });
+
+    test('replaces the middle while preserving start and end', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), equals('abcd…lmn'));
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), equals(''));
+    });
+
+    test('returns a truncated ellipsis when maxLength is too small', () {
+      expect(truncateMiddle('abcdef', 0), equals(''));
+      expect(truncateMiddle('abcdef', 1), equals('…'));
+    });
+
+    test('accounts for custom ellipsis length', () {
+      expect(
+        truncateMiddle('abcdefghijklmn', 8, ellipsis: '...'),
+        equals('abc...mn'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #367

## What changed

- Added `lib/core/utils/string_utils.dart` with `truncateMiddle(String input, int maxLength, {String ellipsis = '…'})` helper.
- Added `test/core/utils/string_utils_test.dart` with focused unit tests.

## How verified

Exact commands run (from the card's `verification` field) and their
output digest:

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
flutter test
```

Output:
- `test/core/utils/string_utils_test.dart`: 5/5 passed (truncateMiddle group)
- Full suite: 13/13 passed (8 existing widget tests + 5 new)
- `dart analyze`: zero new issues on touched files

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): addressed in `lib/core/utils/string_utils.dart` — implements all guard paths and middle-truncation logic per spec.
- AC 2 (All named tests pass the verification command): addressed in `test/core/utils/string_utils_test.dart` — 5 named tests pass under `flutter test`.
- AC 3 (No dependencies added unless absolutely required): addressed — no new packages added; only Dart core String APIs used.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart` modified.
- Do NOT add third-party dependencies unless required by the task body: not violated — no `pubspec.yaml` or lockfile changes.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new.

## Notes

Implementation documents the odd visible-character budget design choice explicitly: extra character assigned to the start (`(visibleLength + 1) ~/ 2`).