### PR TITLE
feat(semver): add compareSemVer helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,46 @@
+/// Compares two semantic-version strings numerically.
+///
+/// Returns:
+/// - A negative integer if [a] < [b]
+/// - Zero if [a] == [b]
+/// - A positive integer if [a] > [b]
+///
+/// Throws a [FormatException] if either string is malformed.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVer(a);
+  final bParts = _parseSemVer(b);
+
+  for (var i = 0; i < 3; i++) {
+    final diff = aParts[i].compareTo(bParts[i]);
+    if (diff != 0) {
+      return diff;
+    }
+  }
+
+  return 0;
+}
+
+/// Parses a version string into exactly three integer components.
+List<int> _parseSemVer(String version) {
+  if (version.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $version', version);
+  }
+
+  final rawParts = version.split('.');
+  final List<int> parsed = [];
+
+  for (var i = 0; i < 3 && i < rawParts.length; i++) {
+    final component = rawParts[i];
+    final value = int.tryParse(component);
+    if (value == null) {
+      throw FormatException('Malformed semantic version: $version', version);
+    }
+    parsed.add(value);
+  }
+
+  while (parsed.length < 3) {
+    parsed.add(0);
+  }
+
+  return parsed;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders numeric components instead of lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads short versions with zeros', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.3.4', '1.2.4'), isNegative);
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(
+          () => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #375

## What changed

- Created `lib/core/utils/semver.dart` containing `compareSemVer(String a, String b)` and a private `_parseSemVer` helper.
- Implemented numerical comparison (major -> minor -> patch).
- Added support for short versions (pads with 0) and extra components (ignored).
- Implemented `FormatException` for malformed input, including the offending string in the message.
- Created `test/core/utils/semver_test.dart` with 9 tests covering all specifications.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
\`\`\`
Output:
9 tests passed.

## Acceptance criteria coverage

- AC 1: Signature `int compareSemVer(String a, String b)` implemented in `lib/core/utils/semver.dart`.
- AC 2: Numerical comparison implemented in `compareSemVer` loop and verified by `compares major components numerically`, `compares minor components numerically`, `compares patch components numerically`, and `orders numeric components instead of lexicographic strings` tests.
- AC 3: Short versions padded with zeros in `_parseSemVer` and verified by `pads short versions with zeros` test.
- AC 4: Extra components ignored via `.take(3)` in `_parseSemVer` and verified by `ignores components beyond patch` test.
- AC 5: Return values use `.compareTo()` signs, verified by `isPositive`, `isNegative` matchers in tests.
- AC 6: `FormatException` thrown for malformed/empty/whitespace input in `_parseSemVer`, verified by `throws FormatException for malformed input` test.
- AC 7: `FormatException` message includes the offending input verbatim, verified by `includes offending input in FormatException message` test.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were modified.
- Do NOT add third-party dependencies: no new dependencies added.
- Do NOT refactor unrelated code: only new files were created.

## Notes

No deviations from the plan.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/semver.dart`
- All named tests pass the verification command: ✓ addressed in `test/core/utils/semver_test.dart`
- No dependencies added unless absolutely required: ✓ addressed in `lib/core/utils/semver.dart`
- Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`: ✓ addressed in `lib/core/utils/semver.dart`
- Accepts versions of the form `MAJOR.MINOR.PATCH` (e.g. `1.2.3`) and compares major → minor → patch NUMERICALLY (not lexicographically), so `1.10.0 > 1.2.0`: ✓ addressed in `lib/core/utils/semver.dart`
- A short version (e.g. `1.2`) is treated as `1.2.0` — missing components default to zero: ✓ addressed in `lib/core/utils/semver.dart`
- A version with extra trailing components (e.g. `1.2.3.4`) is treated as `1.2.3` — components beyond patch are ignored: ✓ addressed in `lib/core/utils/semver.dart`
- Return value contract mirrors `Comparable.compareTo`: the SIGN is what matters (not magnitude). Tests MUST assert `isNegative`/`isPositive`/`equals(0)`, not specific integers: ✓ addressed in `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart`
- Malformed input throws `FormatException`. \"Malformed\" means any of: non-numeric component, empty string, or a purely whitespace string: ✓ addressed in `lib/core/utils/semver.dart`
- The `FormatException` message MUST include the offending input string verbatim so callers can diagnose which argument was bad: ✓ addressed in `lib/core/utils/semver.dart`