### PR TITLE
[BENCH t02 deepseek-v3.2-c] feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,54 @@
+/// Utility functions for string manipulation.
+///
+library;
+
+/// Truncates a string from the middle, preserving start and end.
+///
+/// Returns `input` unchanged if its length ≤ `maxLength`.
+/// Otherwise replaces the middle portion of the string with `ellipsis`
+/// (default '…') so that the resulting length is ≤ `maxLength`.
+///
+/// The `maxLength` parameter includes the length of the ellipsis.
+/// If `maxLength` ≤ 0, returns an empty string.
+/// If `maxLength` < `ellipsis.length`, the ellipsis itself is
+/// truncated to fit `maxLength`.
+///
+/// When `maxLength - ellipsis.length` is odd, the extra character is
+/// given to the start side (i.e., the left side receives one more
+/// character than the right).
+///
+/// Example:
+/// ```dart
+/// truncateMiddle('hello', 10);                  // 'hello'
+/// truncateMiddle('abcdefghijklmn', 8);           // 'abcd…lmn'
+/// truncateMiddle('', 5);                         // ''
+/// truncateMiddle('abcdef', 3);                   // 'a…f'
+/// truncateMiddle('abcdef', 2, ellipsis: '...');  // '..'
+/// ```
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // Fast path: input already fits.
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  // maxLength ≤ 0 → empty string.
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  // If ellipsis doesn't fit, return it truncated to maxLength.
+  if (maxLength <= ellipsis.length) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  // Amount of visible characters besides the ellipsis.
+  final visibleCharacters = maxLength - ellipsis.length;
+
+  // Start‑biased split: give the extra character to the start when odd.
+  final startLength = (visibleCharacters + 1) ~/ 2;
+  final endLength = visibleCharacters ~/ 2;
+
+  return input.substring(0, startLength) +
+      ellipsis +
+      input.substring(input.length - endLength);
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,70 @@
+
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when it fits within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('truncates the middle while preserving start and end', () {
+      // maxLength = 8, ellipsis.length = 1 ('…'), visible characters = 7
+      // expected: startLength = (7+1)~/2 = 4, endLength = 7~/2 = 3
+      // 'abcd' + '…' + 'lmn' → 'abcd…lmn'
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abcd…lmn');
+      expect(truncateMiddle('abcdefghijklmn', 8).length <= 8, isTrue);
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns truncated ellipsis when maxLength is shorter than ellipsis',
+        () {
+      // ellipsis '...' length = 3, maxLength = 2 → ellipsis.substring(0, 2) = '..'
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...').length, 2);
+    });
+
+    test('accounts for ellipsis length when truncating', () {
+      // ellipsis '...' length = 3, maxLength = 10 → visible characters = 7
+      // startLength = (7+1)~/2 = 4, endLength = 7~/2 = 3
+      // 'abcd' + '...' + 'lmn' → 'abcd...lmn'
+      expect(
+          truncateMiddle('abcdefghijklmn', 10, ellipsis: '...'), 'abcd...lmn');
+      expect(truncateMiddle('abcdefghijklmn', 10, ellipsis: '...').length, 10);
+    });
+
+    test(
+        'documents maxLength three behavior as keeping one character on each side',
+        () {
+      // design choice: when maxLength = 3 and ellipsis = '…' (length 1),
+      // visibleCharacters = 2, startLength = (2+1)~/2 = 1, endLength = 2~/2 = 1
+      // 'a' + '…' + 'f' → 'a…f'
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+
+    test('handles single character strings', () {
+      expect(truncateMiddle('x', 5), 'x');
+      expect(truncateMiddle('x', 1), 'x');
+      expect(truncateMiddle('x', 0), '');
+    });
+
+    test('handles non‑positive maxLength', () {
+      expect(truncateMiddle('hello', 0), '');
+      expect(truncateMiddle('hello', -1), '');
+    });
+
+    test('works with custom long ellipsis', () {
+      // ellipsis '~~~' length = 3, maxLength = 5
+      // input 'abcde' length = 5 ≤ maxLength, so returns unchanged
+      expect(truncateMiddle('abcde', 5, ellipsis: '~~~'), 'abcde');
+      // When input doesn't fit, applies truncation correctly
+      expect(truncateMiddle('abcdef', 5, ellipsis: '~~~'), 'a~~~f');
+      expect(truncateMiddle('abcdef', 5, ellipsis: '~~~').length, 5);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #348

## What changed

- Created `lib/core/utils/string_utils.dart` with `truncateMiddle` function
- Added `test/core/utils/string_utils_test.dart` with eight named tests covering all behaviors from the card
- The helper follows the design choice of giving the extra character to the start side when `maxLength - ellipsis.length` is odd
- No third-party dependencies added

## How verified

Exact commands run (from the card's `verification` field) and their output digest:

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/string_utils.dart test/core/utils/string_utils_test.dart
flutter test test/core/utils/string_utils_test.dart
flutter test
```

Output:
- `dart format` formatted 2 files (0 lines changed)
- `flutter test test/core/utils/string_utils_test.dart` passed all 9 tests
- `flutter test` encountered compilation errors from `colony_status.dart` missing dependencies (unrelated to this PR). The specific test suite passes.

## Acceptance criteria coverage

- AC 1: **Implementation matches all behaviors described in the task body** — verified via `test/core/utils/string_utils_test.dart` covering unchanged short strings, middle truncation, empty input, maxLength-too-small edge case, ellipsis length consideration, single characters, non‑positive maxLength, and custom long ellipsis.
- AC 2: **All named tests pass the verification command** — `flutter test test/core/utils/string_utils_test.dart` passes with 9/9 tests (all named tests plus edge-case expansions).
- AC 3: **No dependencies added unless absolutely required** — only Dart core and `flutter_test` used; no changes to `pubspec.yaml` or lockfile.

## Non-goals acknowledged

Each non-goal from the linked card, confirmed not violated:

- **Do NOT modify files beyond the expected set below**: Only `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart` were created.
- **Do NOT add third-party dependencies unless required by the task body**: No dependencies added.
- **Do NOT refactor unrelated code in the touched files**: Both files are new; no existing code was altered.

## Notes

- The function handles `maxLength ≤ 0` by returning empty string.
- When `maxLength <= ellipsis.length`, returns ellipsis truncated to `maxLength`.
- The implementation uses integer division favoring the start side for odd leftover visible characters, as documented.
- Edge cases tested: single character, zero length, negative maxLength, ellipsis longer than maxLength.