### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,51 @@
+/// Compares two semantic-version strings.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b], or a
+/// positive integer if [a] > [b].
+///
+/// Each version is parsed into exactly three numeric components by
+/// splitting on `.`. Missing components (e.g. `1.2`) are padded with
+/// `0`; components beyond patch (e.g. `1.2.3.4`) are ignored.
+///
+/// Throws [FormatException] if either input is empty, only whitespace,
+/// or contains a non-numeric component.
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVerComponents(a);
+  final bParts = _parseSemVerComponents(b);
+
+  for (var i = 0; i < 3; i++) {
+    final cmp = aParts[i].compareTo(bParts[i]);
+    if (cmp != 0) {
+      return cmp;
+    }
+  }
+
+  return 0;
+}
+
+/// Parses [input] into exactly three integer components.
+///
+/// Missing components are padded with `0`. Extra components beyond
+/// the third are ignored. Throws [FormatException] for malformed input.
+List<int> _parseSemVerComponents(String input) {
+  if (input.isEmpty || input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+  final result = <int>[];
+
+  for (var i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final parsed = int.tryParse(parts[i]);
+      if (parsed == null) {
+        throw FormatException('Malformed semantic version: $input');
+      }
+      result.add(parsed);
+    } else {
+      result.add(0);
+    }
+  }
+
+  return result;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major versions numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor versions numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch versions numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('compares components numerically instead of lexicographically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty input', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException for whitespace-only input', () {
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description
Adds a standalone semantic-version comparator helper in `lib/core/utils/semver.dart` with comprehensive tests in `test/core/utils/semver_test.dart`.

## Related Issue
Closes #374

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] My changes generate no new warnings

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
flutter analyze lib/core/utils/semver.dart
```

Output digest:
- `flutter test test/core/utils/semver_test.dart`: 11 tests passed, 0 failures
- `flutter analyze lib/core/utils/semver.dart`: No issues found

## Acceptance criteria coverage

- **AC 1** (Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart`): ✓ addressed in `lib/core/utils/semver.dart` lines 9–25
- **AC 2** (Accepts versions of the form `MAJOR.MINOR.PATCH` and compares major → minor → patch NUMERICALLY): ✓ addressed in `_parseSemVerComponents` using `int.tryParse` + `compareTo`, verified by `compares components numerically instead of lexicographically` test
- **AC 3** (A short version is treated as `1.2.0` — missing components default to zero): ✓ addressed in `_parseSemVerComponents` (pads missing indexes with `0`), verified by `pads short versions with zero components` test
- **AC 4** (A version with extra trailing components is treated as `1.2.3` — components beyond patch are ignored): ✓ addressed in `_parseSemVerComponents` (loops only `i < 3`), verified by `ignores components beyond patch` test
- **AC 5** (Return value contract mirrors `Comparable.compareTo`): ✓ addressed in `compareSemVer` returning `int.compareTo` per component; tests use `isNegative`/`isPositive`/`equals(0)`
- **AC 6** (Malformed input throws `FormatException`): ✓ addressed in `_parseSemVerComponents` throwing `FormatException` for empty/whitespace/non-numeric, verified by `throws FormatException for malformed input` and `throws FormatException for empty input` tests
- **AC 7** (The `FormatException` message MUST include the offending input string verbatim): ✓ addressed in `_parseSemVerComponents` message `'Malformed semantic version: $input'`; verified by `includes offending input in FormatException message` test using `.having(... contains('1.2.a'))`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were created
- Do NOT add third-party dependencies: not violated — no `pubspec.yaml` or lockfile changes
- Do NOT refactor unrelated code: not violated — no edits to existing files

## Notes

No deviations from the plan. The unrelated pre-existing test failures observed during `flutter test` (sqlite3 dynamic library errors on this Linux runner) are environment-specific and not caused by this change — the targeted semver tests all pass.
