### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,49 @@
+/// Compares two semantic version strings numerically.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b],
+/// and a positive integer if [a] > [b].
+///
+/// Versions are of the form `MAJOR.MINOR.PATCH`. Missing components
+/// default to zero; extra trailing components are ignored.
+///
+/// Throws [FormatException] for non-numeric components, empty strings,
+/// or whitespace-only strings, with the offending input in the message.
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  for (var i = 0; i < 3; i++) {
+    final cmp = aComponents[i].compareTo(bComponents[i]);
+    if (cmp != 0) return cmp;
+  }
+
+  return 0;
+}
+
+/// Parses the major, minor, and patch components of [version] as integers.
+///
+/// Throws [FormatException] if [version] is empty, whitespace-only, or
+/// contains non-numeric components in the first three positions.
+List<int> _parseSemVerComponents(String version) {
+  if (version.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $version');
+  }
+
+  final parts = version.split('.');
+  final components = <int>[];
+
+  for (var i = 0; i < 3; i++) {
+    if (i < parts.length) {
+      final component = parts[i];
+      final value = int.tryParse(component);
+      if (value == null) {
+        throw FormatException('Malformed semantic version: $version');
+      }
+      components.add(value);
+    } else {
+      components.add(0);
+    }
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+    });
+
+    test('pads missing components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+      expect(compareSemVer('1', '1.0.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+      expect(compareSemVer('1.2.4.0', '1.2.3.9'), isPositive);
+    });
+
+    test('throws FormatException for malformed version component', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('1.2.a'),
+          ),
+        ),
+      );
+    });
+
+    test('throws FormatException for empty or whitespace versions', () {
+      expect(
+        () => compareSemVer('', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => compareSemVer('   ', '1.2.3'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #383

## What changed

- Created `lib/core/utils/semver.dart` with public function `int compareSemVer(String a, String b)` and private helper `_parseSemVerComponents(String version)`
- Created `test/core/utils/semver_test.dart` with 9 named tests covering equality, numeric ordering, short-form padding, extra-component truncation, and malformed input

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
# 00:00 +9: All tests passed!

flutter test
# 00:02 +17: All tests passed!

dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
# No issues found!
```

## Acceptance criteria coverage

- AC 1: Signature is exactly `int compareSemVer(String a, String b)` and lives in `lib/core/utils/semver.dart` — ✓ addressed in `lib/core/utils/semver.dart` `compareSemVer` function declaration
- AC 2: Accepts versions of the form `MAJOR.MINOR.PATCH` and compares major → minor → patch NUMERICALLY (not lexicographically), so `1.10.0 > 1.2.0` — ✓ addressed in `_parseSemVerComponents` numeric parsing and `compares minor components numerically` test
- AC 3: A short version (e.g. `1.2`) is treated as `1.2.0` — missing components default to zero — ✓ addressed in `_parseSemVerComponents` padding logic and `pads missing components with zero` test
- AC 4: A version with extra trailing components (e.g. `1.2.3.4`) is treated as `1.2.3` — components beyond patch are ignored — ✓ addressed in `_parseSemVerComponents` 3-component limit and `ignores components beyond patch` test
- AC 5: Return value contract mirrors `Comparable.compareTo`: the SIGN is what matters (not magnitude). Tests assert `isNegative`/`isPositive`/`equals(0)` — ✓ addressed in all sign-assertion tests
- AC 6: Malformed input throws `FormatException` for non-numeric component, empty string, or purely whitespace string — ✓ addressed in `throws FormatException for malformed version component` and `throws FormatException for empty or whitespace versions` tests
- AC 7: `FormatException.message` includes the offending input string verbatim — ✓ addressed in `includes offending input in FormatException message` test using `.having(... contains('1.2.a'))`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` were created
- Do NOT add third-party dependencies: implementation uses Dart core library only, tests use existing `flutter_test`
- Do NOT refactor unrelated code: both touched files are new, no existing files were modified

## Notes

No deviations from the plan. The implementation follows the approved plan exactly.

### Coverage

- AC 1 (verbatim): ✓ addressed in `lib/core/utils/semver.dart`
- AC 2 (verbatim): ✓ addressed in `_parseSemVerComponents` + `compares minor components numerically` test
- AC 3 (verbatim): ✓ addressed in `_parseSemVerComponents` padding logic + `pads missing components with zero` test
- AC 4 (verbatim): ✓ addressed in `_parseSemVerComponents` 3-component loop + `ignores components beyond patch` test
- AC 5 (verbatim): ✓ addressed in all sign-assertion tests using `isPositive`/`isNegative`/`equals(0)`
- AC 6 (verbatim): ✓ addressed in `_parseSemVerComponents` validation + two malformed-input tests
- AC 7 (verbatim): ✓ addressed in `includes offending input in FormatException message` test
- All named tests pass the verification command: ✓ 9/9 tests pass, `dart analyze` clean
- No dependencies added unless absolutely required: ✓ Dart core + existing `flutter_test` only