### PR TITLE
feat(collections): add chunked extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,19 @@
+library list_extensions;
+
+extension ChunkedList<T> on List<T> {
+  /// Splits the list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'Must be greater than or equal to 1');
+    }
+
+    final List<List<T>> chunks = <List<T>>[];
+    for (int start = 0; start < length; start += size) {
+      final int end = start + size < length ? start + size : length;
+      chunks.add(sublist(start, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [[1, 2], [3, 4], [5]]);
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      expect([1, 2, 3].chunked(3), [[1, 2, 3]]);
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), [[1, 2, 3]]);
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      expect(<int>[].chunked(3), <List<int>>[]);
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      expect([1].chunked(1), [[1]]);
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('chunked throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final list = [1, 2, 3, 4];
+      final result = list.chunked(2);
+      
+      result[0][0] = 99;
+      
+      expect(list, [1, 2, 3, 4]);
+      expect(result[0], [99, 2]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #378

## What changed

- Created \`lib/core/utils/list_extensions.dart\` with \`ChunkedList\` extension providing the \`chunked(int size)\` method.
- Created \`test/core/utils/list_extensions_test.dart\` with comprehensive tests for the \`chunked\` method, including happy path, boundaries, empty lists, and mutation independence.

## How verified

\`\`\`bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
\`\`\`
Output:
All tests passed! (8 tests)

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body. ✓ addressed in \`lib/core/utils/list_extensions.dart\`.
- AC 2: All named tests pass the verification command. ✓ addressed in \`test/core/utils/list_extensions_test.dart\`.
- AC 3: No dependencies added unless absolutely required. ✓ No new dependencies added.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated.
- Do NOT add third-party dependencies unless required by the task body: not violated.
- Do NOT refactor unrelated code in the touched files: not violated.

## Notes

Internal implementation uses \`sublist\` to ensure returned chunks are independent of the original list.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in \`lib/core/utils/list_extensions.dart\`
- All named tests pass the verification command: ✓ addressed in \`test/core/utils/list_extensions_test.dart\`
- No dependencies added unless absolutely required: ✓ addressed in \`lib/core/utils/list_extensions.dart\`