### PR TITLE
feat(collections): add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,29 @@
+/// Extension methods for [List].
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The last chunk may be smaller than [size]. Each returned chunk is an
+  /// independent list — mutating one does not affect the original list.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Examples:
+  /// ```dart
+  /// [1, 2, 3, 4, 5].chunked(2) // → [[1, 2], [3, 4], [5]]
+  /// [1, 2, 3].chunked(10)       // → [[1, 2, 3]]
+  /// [].chunked(3)               // → []
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'Must be greater than or equal to 1');
+    }
+    if (isEmpty) return <List<T>>[];
+
+    final chunks = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = start + size < length ? start + size : length;
+      chunks.add(sublist(start, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [
+        [1, 2],
+        [3, 4],
+        [5],
+      ]);
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      expect([1, 2, 3].chunked(3), [
+        [1, 2, 3],
+      ]);
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      expect([1, 2, 3].chunked(10), [
+        [1, 2, 3],
+      ]);
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      expect(<int>[].chunked(3), <List<int>>[]);
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      expect([1].chunked(1), [
+        [1],
+      ]);
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final original = [1, 2, 3, 4];
+      final result = original.chunked(2);
+      result[0][0] = 99;
+      expect(original, [1, 2, 3, 4]);
+      expect(result, [
+        [99, 2],
+        [3, 4],
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #387

## What changed

- Added `extension ChunkedList<T> on List<T>` in `lib/core/utils/list_extensions.dart` with a `List<List<T>> chunked(int size)` method that splits a list into consecutive sub-lists of at most `size` elements
- Added 7 test cases in `test/core/utils/list_extensions_test.dart` covering happy path, boundary conditions, edge cases, error handling, and chunk independence

## How verified

Exact commands run (from the card's `verification` field) and their
output digest:

```
$ cd ~/workspace/infiquetra/mimir
$ flutter test test/core/utils/list_extensions_test.dart
00:00 +7: All tests passed!
```

```
$ flutter analyze lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart
Analyzing 2 items...
No issues found! (ran in 3.6s)
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/list_extensions.dart` — extension with `chunked(int size)` method, `size < 1` guard, empty-list fast path, independent chunks via `sublist()`
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/list_extensions_test.dart` — 7 tests pass `flutter test` with exit code 0
- AC 3 (No dependencies added unless absolutely required): ✓ no changes to `pubspec.yaml`, `pubspec.lock`, or any dependency files

## Non-goals acknowledged

Each non-goal from the linked card, confirmed not violated:

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` changed
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — only the targeted extension method and its tests

## Notes

- `pubspec.lock` was temporarily modified by `flutter pub get` resolving dependency upgrades during test runs; reverted via `git checkout origin/main -- pubspec.lock` to maintain the clean expected file set
- The `formatters.dart` pattern in `lib/core/utils/formatters.dart` was used as a style reference for both the implementation and test files

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/list_extensions.dart` — `ChunkedList.chunked` method
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/list_extensions_test.dart` — all 7 tests pass
- AC 3 (No dependencies added unless absolutely required): ✓ no dependency files modified