### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,35 @@
+/// Extension methods for List operations.
+library;
+
+/// Extension that adds chunking functionality to List.
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The [size] must be greater than or equal to 1.
+  /// Throws [ArgumentError] if [size] is less than 1.
+  ///
+  /// Returns an empty list if this list is empty.
+  /// The last chunk may be smaller than [size] if the list length
+  /// is not evenly divisible by [size].
+  ///
+  /// Each returned chunk is an independent list; mutating a chunk
+  /// does not affect the original list.
+  ///
+  /// Example:
+  /// ```dart
+  /// [1, 2, 3, 4, 5].chunked(2); // [[1, 2], [3, 4], [5]]
+  /// ```
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(
+          size, 'size', 'must be greater than or equal to 1');
+    }
+
+    final result = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = (start + size) > length ? length : start + size;
+      result.add(sublist(start, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunks list into consecutive sub-lists of requested size', () {
+      expect([1, 2, 3, 4, 5].chunked(2), [
+        [1, 2],
+        [3, 4],
+        [5]
+      ]);
+    });
+
+    test('returns one chunk when size equals list length', () {
+      expect([1, 2, 3].chunked(3), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('returns one chunk when size is greater than list length', () {
+      expect([1, 2, 3].chunked(10), [
+        [1, 2, 3]
+      ]);
+    });
+
+    test('returns empty list for empty input', () {
+      expect(<int>[].chunked(3), <List<int>>[]);
+    });
+
+    test('returns single one-element chunk for single element list', () {
+      expect([1].chunked(1), [
+        [1]
+      ]);
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('throws ArgumentError when size is negative', () {
+      expect(() => [1, 2, 3].chunked(-1), throwsArgumentError);
+    });
+
+    test('returns chunks independent from the original list', () {
+      final original = [1, 2, 3];
+      final chunks = original.chunked(2);
+
+      // Mutate the first chunk
+      chunks.first[0] = 99;
+
+      // Original should remain unchanged
+      expect(original, [1, 2, 3]);
+      // Chunk should reflect the mutation
+      expect(chunks, [
+        [99, 2],
+        [3]
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #389

## What changed

- Added `lib/core/utils/list_extensions.dart` with `ChunkedList<T>` extension on `List<T>`
- Implemented `List<List<T>> chunked(int size)` method that splits a list into consecutive sub-lists
- Added `test/core/utils/list_extensions_test.dart` with 8 test cases covering all required behaviors

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```

Output: 8 tests passed (00:00 total)
- Happy path chunking
- Boundary: size = list length
- Boundary: size > list length
- Empty list returns empty
- Single element list
- ArgumentError on size = 0
- ArgumentError on size < 0
- Chunk independence from original list

```bash
dart analyze lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart
```

Output: No issues found!

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) — ✓ Implementation in `lib/core/utils/list_extensions.dart` (lines 17-32) with ArgumentError validation, empty list handling, last-chunk-smaller handling, and independent chunks via `sublist()`
- AC 2: All named tests pass the verification command — ✓ All 8 tests in `test/core/utils/list_extensions_test.dart` pass with `flutter test`
- AC 3: No dependencies added unless absolutely required — ✓ Uses only Dart core library; no new dependencies

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — not violated (only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` modified)
- Do NOT add third-party dependencies unless required by the task body — not violated (zero new dependencies)
- Do NOT refactor unrelated code in the touched files — not violated (new files only)

## Notes

None — implementation follows plan exactly.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/list_extensions.dart
- All named tests pass the verification command: ✓ addressed in test/core/utils/list_extensions_test.dart
- No dependencies added unless absolutely required: ✓ addressed — no pubspec.yaml changes