### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,47 @@
+/// String utility functions.
+library;
+
+/// Truncates a string by replacing the middle with an ellipsis.
+///
+/// If [input]'s length is less than or equal to [maxLength], returns
+/// [input] unchanged.
+///
+/// Otherwise, replaces the middle of the string with [ellipsis],
+/// keeping characters from the start and end such that the total length
+/// does not exceed [maxLength].
+///
+/// The function guarantees that:
+/// - The returned length is ≤ [maxLength].
+/// - If [maxLength] ≤ 0, an empty string is returned.
+/// - If [ellipsis.length] ≥ [maxLength], [ellipsis] is truncated to
+///   [maxLength] characters and returned.
+/// - When [maxLength] – [ellipsis.length] is odd, the extra character
+///   is left unused, preserving symmetry.
+///
+/// ## Examples
+///
+/// ```dart
+/// truncateMiddle('hello', 10);               // 'hello'
+/// truncateMiddle('abcdefghijklmn', 8);      // 'abc…lmn'
+/// truncateMiddle('', 5);                     // ''
+/// truncateMiddle('abcdef', 2, ellipsis: '---'); // '--'
+/// truncateMiddle('abcdef', 3);               // 'a…f'
+/// ```
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  if (input.length <= maxLength) {
+    return input;
+  }
+  if (maxLength <= 0) {
+    return '';
+  }
+  if (ellipsis.length >= maxLength) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  final available = maxLength - ellipsis.length;
+  final sideLength = available ~/ 2; // floor division
+
+  final start = input.substring(0, sideLength);
+  final end = input.substring(input.length - sideLength);
+  return '$start$ellipsis$end';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns unchanged input when length is less than maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('a', 5), 'a');
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('returns unchanged input when length equals maxLength', () {
+      expect(truncateMiddle('hello', 5), 'hello');
+      expect(truncateMiddle('', 0), '');
+    });
+
+    test('replaces the middle with the default ellipsis', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+      // length check: 3 + 1 + 3 = 7 ≤ 8
+      expect(truncateMiddle('abcdefghijklmn', 8).length, 7);
+    });
+
+    test('returns empty string when maxLength <= 0', () {
+      expect(truncateMiddle('hello', 0), '');
+      expect(truncateMiddle('hello', -5), '');
+      expect(truncateMiddle('', 0), '');
+      expect(truncateMiddle('', -1), '');
+    });
+
+    test('returns truncated ellipsis when maxLength is shorter than ellipsis',
+        () {
+      expect(truncateMiddle('abcdef', 2, ellipsis: '---'), '--');
+      expect(truncateMiddle('abcdef', 2, ellipsis: '---').length, 2);
+      expect(truncateMiddle('abcdef', 0, ellipsis: 'xyz'), '');
+      expect(truncateMiddle('abcdef', 1, ellipsis: 'xyz'), 'x');
+    });
+
+    test('uses ellipsis length when calculating the result length', () {
+      expect(truncateMiddle('abcdefghijklmn', 9, ellipsis: '...'), 'abc...lmn');
+      expect(truncateMiddle('abcdefghijklmn', 9, ellipsis: '...').length, 9);
+      // ellipsis length = 3, available = 6, sideLength = 3 each
+      expect(truncateMiddle('abcdefghijklmn', 9, ellipsis: '...').length, 9);
+    });
+
+    test('documents the small maxLength design choice', () {
+      // maxLength = 3, ellipsis length = 1 (default), available = 2, sideLength = 1
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+      expect(truncateMiddle('abcdef', 3).length, 3);
+    });
+
+    test('handles odd available length leaving leftover unused', () {
+      // maxLength = 9, ellipsis length = 1, available = 8, sideLength = 4 each
+      expect(truncateMiddle('abcdefghijklmnop', 9), 'abcd…mnop');
+      expect(truncateMiddle('abcdefghijklmnop', 9).length, 9);
+    });
+
+    test('works with multi-character ellipsis', () {
+      expect(truncateMiddle('abcdefghijklmnop', 12, ellipsis: '<...>'),
+          'abc<...>nop');
+      // length check: 3 + 5 + 3 = 11 ≤ 12
+      expect(
+          truncateMiddle('abcdefghijklmnop', 12, ellipsis: '<...>').length, 11);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #379

## What changed

- Added `String truncateMiddle(String input, int maxLength, {String ellipsis = '…'})` to `lib/core/utils/string_utils.dart`
- Added comprehensive test suite covering all described behaviors in `test/core/utils/string_utils_test.dart`
- Function handles edge cases: empty string, maxLength ≤ 0, ellipsis longer than maxLength, odd leftover characters

## How verified

Exact commands run (from the card's `verification` field) and their output digest:

```bash
cd ~/workspace/infiquetra/mimir
flutter test
```

All tests pass (17 total, including the new string utility tests):
- 9 new tests for `truncateMiddle` (all pass)
- 8 existing widget tests (all pass)

Static analysis clean: `dart analyze lib/core/utils/string_utils.dart test/core/utils/string_utils_test.dart` reports no issues.

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body  
  ✓ Addressed in `lib/core/utils/string_utils.dart` lines 30‑47 (`truncateMiddle` function) and corresponding tests in `test/core/utils/string_utils_test.dart`.

- AC 2: All named tests pass the verification command  
  ✓ The verification command `flutter test` passes (see output digest above). The new test file includes the named cases: unchanged input, exact length, middle truncation, empty input, maxLength‑too‑small, ellipsis length consideration, small‑maxLength design choice, odd available length, multi‑character ellipsis.

- AC 3: No dependencies added unless absolutely required  
  ✓ Only core Dart `String` APIs used; no changes to `pubspec.yaml` or `pubspec.lock`.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart` were created.
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new, no existing code altered.

## Notes

Implementation matches the exact behavior specified in the card:
- Returns `input` unchanged when `input.length <= maxLength`.
- When `maxLength <= 0`, returns empty string `''`.
- When `ellipsis.length >= maxLength`, returns `ellipsis.substring(0, maxLength)` (truncates ellipsis).
- Otherwise splits available characters (`maxLength - ellipsis.length`) evenly, using integer division (`~/`), leaving leftover character unused to preserve symmetry (as demonstrated in example `truncateMiddle('abcdefghijklmn', 8) → 'abc…lmn'`).
- Design choice documented in code and tests: for small `maxLength` (e.g., `maxLength == 3`, `ellipsis = '…'`) returns `'a…f'` (3 characters total), consistent with the documented expectation.

All examples from the task body pass:
- `truncateMiddle('hello', 10)` → `'hello'`
- `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
- `truncateMiddle('', 5)` → `''`
- `truncateMiddle('abcdef', 2, ellipsis: '---')` → `'--'`
- `truncateMiddle('abcdef', 3)` → `'a…f'`