### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,37 @@
+/// Utility functions for string manipulation.
+
+/// Truncates a string to [maxLength] by replacing the middle with [ellipsis],
+/// keeping the start and end visible.
+///
+/// - Returns [input] unchanged when `input.length <= maxLength`.
+/// - [maxLength] includes the ellipsis; the returned string length is always `<= maxLength`.
+/// - When `maxLength` is too small to display any visible characters on both sides,
+///   the ellipsis is truncated to fit (or returned alone if [ellipsis] itself fits).
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'` (3 + 1 + 3 = 7 chars ≤ 8)
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'` (2 chars on each side of '…' fits within maxLength=3)
+/// - `truncateMiddle('abcdef', 1)` → `'…'` (only the ellipsis fits)
+/// - `truncateMiddle('abcdef', 0)` → `''`
+///
+/// When `maxLength - ellipsis.length` is odd, the extra character is dropped
+/// to keep truncation visually balanced.
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  // Return input unchanged when it already fits.
+  if (input.length <= maxLength) return input;
+
+  // Non-positive maxLength: return empty string.
+  if (maxLength <= 0) return '';
+
+  // Ellipsis itself exceeds maxLength: truncate the ellipsis.
+  if (ellipsis.length >= maxLength) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  // Normal case: replace the middle with ellipsis, keeping both ends.
+  final available = maxLength - ellipsis.length;
+  final sideLength = available ~/ 2;
+  return '${input.substring(0, sideLength)}$ellipsis${input.substring(input.length - sideLength)}';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('replaces the middle with the default ellipsis', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+      expect(truncateMiddle('abcdefghijklmn', 8).length, lessThanOrEqualTo(8));
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('truncates to fit very small maxLength values', () {
+      // 'a…f': available = 3 - 1 = 2, sideLength = 1; result = 'a…f'
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+      // only the ellipsis fits
+      expect(truncateMiddle('abcdef', 1), '…');
+      // maxLength of 0: return empty string
+      expect(truncateMiddle('abcdef', 0), '');
+    });
+
+    test('accounts for custom ellipsis length', () {
+      // available = 10 - 3 = 7, sideLength = 3; result = 'abc...lmn'
+      expect(truncateMiddle('abcdefghijklmn', 10, ellipsis: '...'), 'abc...lmn');
+      expect(truncateMiddle('abcdefghijklmn', 10, ellipsis: '...').length, lessThanOrEqualTo(10));
+      // ellipsis truncated to fit
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #395

## What changed

- Created  with  function
- Created  with 5 named test groups covering all AC cases

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
```

Output: All 5 tests passed (+5) in 2s. Full suite (Resolving dependencies...
Downloading packages...
  async 2.11.0 (2.13.1 available)
  boolean_selector 2.1.1 (2.1.2 available)
> characters 1.4.1 (was 1.3.0)
> clock 1.1.2 (was 1.1.1)
> collection 1.19.1 (was 1.18.0)
  cupertino_icons 1.0.8 (1.0.9 available)
> fake_async 1.3.3 (was 1.3.1)
  flutter_lints 3.0.2 (6.0.0 available)
> leak_tracker 11.0.2 (was 10.0.0)
> leak_tracker_flutter_testing 3.0.10 (was 2.0.1)
> leak_tracker_testing 3.0.2 (was 2.0.1)
  lints 3.0.0 (6.1.0 available)
> matcher 0.12.19 (was 0.12.16+1)
> material_color_utilities 0.13.0 (was 0.8.0)
> meta 1.17.0 (was 1.11.0) (1.18.2 available)
> path 1.9.1 (was 1.9.0)
< sky_engine 0.0.0 from sdk flutter (was 0.0.99 from sdk flutter)
  source_span 1.10.0 (1.10.2 available)
> stack_trace 1.12.1 (was 1.11.1)
> stream_channel 2.1.4 (was 2.1.2)
  string_scanner 1.2.0 (1.4.1 available)
  term_glyph 1.2.1 (1.2.2 available)
> test_api 0.7.10 (was 0.6.1) (0.7.11 available)
> vector_math 2.2.0 (was 2.1.4) (2.3.0 available)
  vm_service 13.0.0 (15.1.0 available)
Changed 16 dependencies!
12 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/widget_test.dart
00:00 +0: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +1: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +2: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +3: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +4: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +5: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +6: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:00 +7: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +8: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +9: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +10: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +11: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:01 +12: /home/agent/workspace/infiquetra/mimir/test/widget_test.dart: Counter increments smoke test
00:02 +13: All tests passed!): 13 tests passed.

```
dart analyze lib/core/utils/string_utils.dart test/core/utils/string_utils_test.dart
```

Output: 1 info-level issue (dangling library doc comment) — same warning exists in the pre-existing ; not introduced by this PR.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): Addressed in  —  handles unchanged short input, middle replacement, maxLength includes ellipsis, empty input, single-char strings, maxLength shorter than ellipsis, odd leftover character distribution (floored to both sides).
- AC 2 (All named tests pass the verification command): Addressed in  — 5 named  cases: unchanged short strings, middle truncation with default ellipsis, empty input, very small maxLength values, custom ellipsis length.
- AC 3 (No dependencies added unless absolutely required): Addressed —  uses only Dart core  APIs;  and  not modified.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only  and  changed.
- Do NOT add third-party dependencies unless required by the task body: not violated — zero new dependencies.
- Do NOT refactor unrelated code in the touched files: not violated — new file contains only ; new test file contains only tests for .

## Notes

- The Analyzing mimir...

   info - lib/core/utils/formatters.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments
   info - lib/core/utils/string_utils.dart:1:1 - Dangling library doc comment. Add a 'library' directive after the library comment. - dangling_library_doc_comments

2 issues found. warning () is a pre-existing pattern in  — same style used here for consistency.
- Design choice for : returns  — with default , , , keeping one character on each side. This matches the documented choice from the plan.