### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,24 @@
+/// Extension methods on List.
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The last chunk may be smaller than [size] if the list length is not
+  /// evenly divisible.
+  ///
+  /// Each returned chunk is independent — mutating a chunk does not affect
+  /// the original list.
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'chunk size must be at least 1');
+    }
+    if (isEmpty) return <List<T>>[];
+    final result = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = start + size < length ? start + size : length;
+      result.add(sublist(start, end));
+    }
+    return result;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('splits list into consecutive chunks of requested size', () {
+      expect(
+          [1, 2, 3, 4, 5].chunked(2),
+          equals([
+            [1, 2],
+            [3, 4],
+            [5]
+          ]));
+    });
+
+    test('returns one chunk when size equals list length', () {
+      expect(
+          [1, 2, 3].chunked(3),
+          equals([
+            [1, 2, 3]
+          ]));
+    });
+
+    test('returns one chunk when size is greater than list length', () {
+      expect(
+          [1, 2, 3].chunked(10),
+          equals([
+            [1, 2, 3]
+          ]));
+    });
+
+    test('returns empty list for empty input', () {
+      expect(<int>[].chunked(3), equals(<List<int>>[]));
+    });
+
+    test('returns one single-element chunk for single-element input', () {
+      expect(
+          [1].chunked(1),
+          equals([
+            [1]
+          ]));
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('returns chunks independent from the original list', () {
+      final original = [1, 2, 3];
+      final chunks = original.chunked(2);
+      chunks.first[0] = 99;
+      expect(original, equals([1, 2, 3]));
+      expect(
+          chunks,
+          equals([
+            [99, 2],
+            [3]
+          ]));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #397

## What changed

- Created `lib/core/utils/list_extensions.dart` with `ChunkedList<T>` extension providing `chunked(int size)` method on `List<T>`
- Created `test/core/utils/list_extensions_test.dart` with 7 tests covering all named test cases plus chunk independence

## How verified

```
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart
# Formatted 2 files in 0.01 seconds (exit 0)

flutter test test/core/utils/list_extensions_test.dart
# 00:00 +7: All tests passed! (exit 0)

dart analyze lib/core/utils/list_extensions.dart
# No issues found! (exit 0)

dart analyze test/core/utils/list_extensions_test.dart
# No issues found! (exit 0)
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors — `chunked()` validates size>=1 (ArgumentError), returns empty list for empty input, creates consecutive chunks via `sublist(start, end)` where last chunk may be smaller, and each returned chunk is independent from the original list. Verified in `lib/core/utils/list_extensions.dart`.
- AC 2: All named tests pass — 7 tests (happy path, size=list length, size>list length, empty list, single element, ArgumentError on size=0, chunk independence) all pass via `flutter test test/core/utils/list_extensions_test.dart`. Verified in `test/core/utils/list_extensions_test.dart`.
- AC 3: No dependencies added — uses only Dart core `List` APIs and existing `flutter_test`. No `pubspec.yaml` or lockfile changes. Verified by `git diff --stat` showing only 2 files.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` changed
- Do NOT add third-party dependencies unless required: not violated — zero dependency changes
- Do NOT refactor unrelated code in the touched files: not violated — both files are new with only `ChunkedList`-related code

## Notes

No deviations from plan. No unexpected findings.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `lib/core/utils/list_extensions.dart` — `ChunkedList<T>.chunked()` method (lines 16-26)
- All named tests pass the verification command: ✓ addressed in `test/core/utils/list_extensions_test.dart` — 7 tests in `group('ChunkedList', ...)` (lines 5-35)
- No dependencies added unless absolutely required: ✓ addressed — no pubspec or lockfile changes; uses only Dart core APIs and existing flutter_test