### PR TITLE
feat(strings): add truncateMiddle() helper

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,38 @@
+/// Truncates [input] by replacing the middle with [ellipsis] so the result
+/// fits within [maxLength] characters.
+///
+/// [maxLength] includes the length of [ellipsis]. When the input already fits,
+/// it is returned unchanged.
+///
+/// When content must be trimmed, characters are split evenly between the start
+/// and end of the string: `sideLength = (maxLength - ellipsis.length) ~/ 2`.
+/// If the available content length is odd, one character of capacity is left
+/// unused so the result is always `<= maxLength`. For example,
+/// `truncateMiddle('abcdefghijklmn', 8)` produces `'abc…lmn'` (3 + 1 + 3 = 7).
+///
+/// When [maxLength] is very small, the design preserves one character on each
+/// side if possible: `truncateMiddle('abcdef', 3)` returns `'a…f'`.
+///
+/// If [ellipsis] is longer than [maxLength], the ellipsis itself is truncated
+/// to [maxLength] characters.
+///
+/// Throws [ArgumentError] if [maxLength] is negative.
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  if (maxLength < 0) {
+    throw ArgumentError.value(maxLength, 'maxLength', 'must be non-negative');
+  }
+
+  if (input.length <= maxLength) return input;
+
+  if (maxLength == 0) return '';
+
+  if (ellipsis.length >= maxLength) return ellipsis.substring(0, maxLength);
+
+  final availableContentLength = maxLength - ellipsis.length;
+  final sideLength = availableContentLength ~/ 2;
+
+  final start = input.substring(0, sideLength);
+  final end = input.substring(input.length - sideLength);
+
+  return '$start$ellipsis$end';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns unchanged input when length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('replaces the middle while keeping start and end visible', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('truncates ellipsis alone when maxLength is too small', () {
+      expect(truncateMiddle('abcdef', 0), '');
+      expect(truncateMiddle('abcdef', 1), '…');
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+    });
+
+    test('accounts for custom ellipsis length in the maximum length', () {
+      final result = truncateMiddle('abcdefghijklmn', 10, ellipsis: '...');
+      expect(result, 'abc...lmn');
+      expect(result.length, lessThanOrEqualTo(10));
+    });
+
+    test('throws for negative maxLength', () {
+      expect(() => truncateMiddle('abcdef', -1), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #392

## What changed

- Added `lib/core/utils/string_utils.dart` with `truncateMiddle()` — truncates long strings by replacing the middle with an ellipsis while preserving visible start/end characters
- Added `test/core/utils/string_utils_test.dart` with 6 focused test cases covering: unchanged short input, middle truncation, empty input, maxLength-too-small edges, custom ellipsis length, and negative maxLength error

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
```

Output: `00:00 +6: All tests passed!`

```bash
dart analyze lib/core/utils/string_utils.dart
```

Output: `No issues found!`

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — verified by `truncateMiddle()` in `lib/core/utils/string_utils.dart` (unchanged-input branch, middle-replacement branch, ellipsis-too-long branch, negative-maxLength ArgumentError)
- AC 2: All named tests pass the verification command — verified by 6/6 tests passing in `test/core/utils/string_utils_test.dart`
- AC 3: No dependencies added unless absolutely required — verified: no pubspec.yaml/pubspec.lock changes; only Dart core String APIs used

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart` changed
- Do NOT add third-party dependencies unless required: not violated — zero dependency changes
- Do NOT refactor unrelated code: not violated — no existing files modified

## Notes

Design choice for odd leftover capacity: `sideLength = (maxLength - ellipsis.length) ~/ 2` splits visible characters evenly between start and end. If the available content length is odd, one character of capacity is left unused, guaranteeing `result.length <= maxLength` and matching the spec example `truncateMiddle('abcdefghijklmn', 8) == 'abc…lmn'` (7 chars <= 8).

Design choice for very small maxLength: `truncateMiddle('abcdef', 3)` returns `'a…f'` — one character preserved on each side while staying within maxLength=3.

### Coverage

- Implementation matches all behaviors described in the task body: ✓ addressed in `lib/core/utils/string_utils.dart` / `truncateMiddle()`
- All named tests pass the verification command: ✓ addressed in `test/core/utils/string_utils_test.dart` (6 tests, all passing)
- No dependencies added unless absolutely required: ✓ addressed — no pubspec changes, only Dart core APIs