### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,70 @@
+// Semantic version comparison utilities.
+
+/// Compares two semantic version strings numerically.
+///
+/// Compares major, minor, and patch components in order. Missing components
+/// are treated as zero, and any components beyond patch are ignored for
+/// ordering purposes.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b], or a positive
+/// integer if [a] > [b]. The sign (not magnitude) is what matters.
+///
+/// Throws [FormatException] if either input is malformed. Malformed inputs
+/// are: empty strings, strings containing only whitespace, or strings with
+/// any non-numeric version component. The exception message includes the
+/// offending input string verbatim.
+///
+/// Examples:
+/// - `compareSemVer('1.2.3', '1.2.4')` → negative
+/// - `compareSemVer('1.10.0', '1.2.0')` → positive (numeric, not lexicographic)
+/// - `compareSemVer('1.2', '1.2.0')` → `0` (short form pads with zero)
+/// - `compareSemVer('1.2.3.4', '1.2.3')` → `0` (extra components ignored)
+/// - `compareSemVer('1.2.a', '1.2.3')` → throws `FormatException`
+int compareSemVer(String a, String b) {
+  final aParts = _parseSemVerComponents(a);
+  final bParts = _parseSemVerComponents(b);
+
+  for (var i = 0; i < 3; i++) {
+    final comparison = aParts[i].compareTo(bParts[i]);
+    if (comparison != 0) return comparison;
+  }
+
+  return 0;
+}
+
+/// Parses a semantic version string into exactly three integer components.
+///
+/// Takes the first three components from the input, appending zeroes for
+/// any missing components. Extra components beyond the third are ignored.
+///
+/// Throws [FormatException] with the full input string in the message if:
+/// - Input is empty or whitespace-only
+/// - Any version component contains non-digit characters
+List<int> _parseSemVerComponents(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final trimmed = input.trim();
+  final parts = trimmed.split('.');
+
+  for (final part in parts) {
+    if (!_isNumericComponent(part)) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+  }
+
+  final numericParts = parts.map(int.parse).toList();
+
+  // Take first 3, pad with zeros if needed
+  while (numericParts.length < 3) {
+    numericParts.add(0);
+  }
+
+  return numericParts.sublist(0, 3);
+}
+
+/// Returns true if [s] is a valid numeric version component (non-empty, digits only).
+bool _isNumericComponent(String s) {
+  return s.isNotEmpty && RegExp(r'^\d+$').hasMatch(s);
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+      expect(compareSemVer('1.2.99', '1.3.0'), isNegative);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders components numerically instead of lexicographically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores components beyond patch for comparison', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #403

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` function
- Created `test/core/utils/semver_test.dart` with 9 test cases covering all acceptance criteria

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/semver.dart test/core/utils/semver_test.dart
flutter analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
flutter test test/core/utils/semver_test.dart
```

Output:
- `dart format`: Formatted 2 files (2 changed)
- `flutter analyze`: No issues found!
- `flutter test`: 00:00 +9: All tests passed!

## Acceptance criteria coverage

- **Implementation matches all behaviors described in the task body**: ✓ Implemented `compareSemVer` with numeric comparison, zero-padding for short versions, truncation of extra components, and `FormatException` for malformed input with the offending string in the message
- **All named tests pass the verification command**: ✓ All 9 test cases pass (`flutter test test/core/utils/semver_test.dart`)
- **No dependencies added unless absolutely required**: ✓ Only Dart core library used (`RegExp`, `int.parse`), no third-party packages

## Non-goals acknowledged

- **Do NOT modify files beyond the expected set below**: ✓ Only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` modified
- **Do NOT add third-party dependencies unless required by the task body**: ✓ No dependencies added, uses only Dart core APIs
- **Do NOT refactor unrelated code in the touched files**: ✓ Both files are new with focused implementation

## Notes

AC coverage details:
- AC1 (exact signature): `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`
- AC2 (numeric comparison): `_parseSemVerComponents` uses `int.parse` for each component
- AC3 (short padding): Parser pads with zeros until 3 components exist
- AC4 (extra truncation): Parser returns `numericParts.sublist(0, 3)`
- AC5 (sign semantics): Returns `aParts[i].compareTo(bParts[i])` directly
- AC6 (FormatException): Throws on empty, whitespace-only, or non-numeric components
- AC7 (message includes input): `FormatException('Malformed semantic version: $input')`

### Coverage

- [x] Implementation matches all behaviors described in the task body (see Notes) → ✓ addressed in `lib/core/utils/semver.dart`
- [x] All named tests pass the verification command → ✓ verified with `flutter test test/core/utils/semver_test.dart` (9/9 passed)
- [x] No dependencies added unless absolutely required → ✓ only Dart core APIs used