### PR TITLE
feat(semver): Add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,54 @@
+/// Utility functions for semantic version comparison.
+library;
+
+/// Compares two semantic-version strings numerically.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b],
+/// or a positive integer if [a] > [b].
+///
+/// Components beyond patch (e.g. the `.4` in `1.2.3.4`) are ignored.
+/// Missing components default to zero, so `1.2` is treated as `1.2.0`.
+///
+/// Throws [FormatException] if either input is malformed (empty,
+/// whitespace-only, or contains a non-numeric component). The message
+/// includes the offending input verbatim.
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  for (var i = 0; i < 3; i++) {
+    final result = aComponents[i].compareTo(bComponents[i]);
+    if (result != 0) return result;
+  }
+
+  return 0;
+}
+
+/// Parses a semantic-version string into exactly three integer components.
+///
+/// Takes at most the first three dot-separated components; pads missing
+/// components with zero. Throws [FormatException] for malformed input,
+/// including empty/whitespace-only strings and non-numeric components.
+List<int> _parseSemVerComponents(String input) {
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+  final components = <int>[];
+
+  for (final part in parts.take(3)) {
+    final value = int.tryParse(part);
+    if (value == null) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+    components.add(value);
+  }
+
+  // Pad missing components with zero.
+  while (components.length < 3) {
+    components.add(0);
+  }
+
+  return components;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.0.0', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.3.0', '1.2.99'), isPositive);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+    });
+
+    test('orders numeric components instead of lexicographic strings', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+    });
+
+    test('pads missing patch components with zero', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+    });
+
+    test('throws FormatException for empty or whitespace input', () {
+      expect(() => compareSemVer('', '1.0.0'), throwsA(isA<FormatException>()));
+      expect(
+          () => compareSemVer('  ', '1.0.0'), throwsA(isA<FormatException>()));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #402

## What changed

- Added `int compareSemVer(String a, String b)` top-level function in `lib/core/utils/semver.dart`
- Added private helper `List<int> _parseSemVerComponents(String input)` for parsing and validation
- Added `test/core/utils/semver_test.dart` with 10 test cases covering all acceptance criteria

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/core/utils/semver.dart test/core/utils/semver_test.dart
dart analyze lib/core/utils/semver.dart test/core/utils/semver_test.dart
flutter test test/core/utils/semver_test.dart
```

- `dart format`: 0 files changed (already formatted)
- `dart analyze`: No issues found
- `flutter test`: 10/10 tests passed

## Acceptance criteria coverage

- AC 1 (Signature): `int compareSemVer(String a, String b)` top-level function in `lib/core/utils/semver.dart` — verified by grep and analyzer
- AC 2 (Numeric comparison): `_parseSemVerComponents` parses with `int.tryParse`; `compareSemVer` uses `int.compareTo` so `1.10.0 > 1.2.0` — tested by `orders numeric components instead of lexicographic strings`
- AC 3 (Short-form padding): `_parseSemVerComponents` pads missing components with zero — tested by `pads missing patch components with zero`
- AC 4 (Extra-component truncation): `parts.take(3)` in `_parseSemVerComponents` — tested by `ignores components beyond patch`
- AC 5 (Return sign contract): Tests use `isPositive`/`isNegative`/`equals(0)`, never exact magnitudes
- AC 6 (FormatException on malformed): `_parseSemVerComponents` throws `FormatException` for empty, whitespace-only, and non-numeric input — tested by `throws FormatException for malformed input` and `throws FormatException for empty or whitespace input`
- AC 7 (Message contains offending input): `FormatException('Malformed semantic version: $input')` — tested by `includes offending input in FormatException message`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` changed
- Do NOT add third-party dependencies: not violated — uses only Dart core APIs and existing `flutter_test`
- Do NOT refactor unrelated code: not violated — both files are new, no existing code touched

## Notes

No deviations from plan. No follow-up suggestions beyond scope.

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in lib/core/utils/semver.dart — compareSemVer() and _parseSemVerComponents()
- All named tests pass the verification command: ✓ addressed in test/core/utils/semver_test.dart — 10/10 tests pass
- No dependencies added unless absolutely required: ✓ no new dependencies added