### PR TITLE
feat(collections): add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,25 @@
+/// Extension methods for List<T>.
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive chunks of at most `size` elements.
+  ///
+  /// Example:
+  /// ```dart
+  /// [1, 2, 3, 4, 5].chunked(2)  // → [[1, 2], [3, 4], [5]]
+  /// [1, 2, 3].chunked(10)       // → [[1, 2, 3]]
+  /// [].chunked(3)               // → []
+  /// ```
+  ///
+  /// throws ArgumentError if size < 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(size, 'size', 'must be >= 1');
+    }
+
+    final chunks = <List<T>>[];
+    for (var start = 0; start < length; start += size) {
+      final end = (start + size < length) ? start + size : length;
+      chunks.add(List<T>.of(sublist(start, end)));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList.chunked', () {
+    test('splits list into consecutive chunks', () {
+      final result = [1, 2, 3, 4, 5].chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('returns one chunk when size equals list length', () {
+      final result = [1, 2, 3].chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('returns one chunk when size is greater than list length', () {
+      final result = [1, 2, 3].chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('returns empty list for empty input', () {
+      final result = <int>[].chunked(3);
+      expect(result, <List<int>>[]);
+    });
+
+    test('returns single-element chunk for single-element list', () {
+      final result = [1].chunked(1);
+      expect(result, [[1]]);
+    });
+
+    test('throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('returned chunks are independent from the original list', () {
+      final original = [1, 2, 3];
+      final chunks = original.chunked(2);
+      chunks.first[0] = 99;
+      expect(original, [1, 2, 3]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #410

## What changed

- Created lib/core/utils/list_extensions.dart with ChunkedList<T> extension on List<T>
- Implements chunked(int size) splitting list into consecutive sublists of at most size elements
- Validates size >= 1, throws ArgumentError.value if not satisfied
- Returns independent chunk copies via List<T>.of to avoid mutation side effects

## How verified

00:00 +0: loading /home/agent/workspace/infiquetra/mimir/test/core/utils/list_extensions_test.dart
00:00 +0: ChunkedList.chunked splits list into consecutive chunks
00:00 +1: ChunkedList.chunked returns one chunk when size equals list length
00:00 +2: ChunkedList.chunked returns one chunk when size is greater than list length
00:00 +3: ChunkedList.chunked returns empty list for empty input
00:00 +4: ChunkedList.chunked returns single-element chunk for single-element list
00:00 +5: ChunkedList.chunked throws ArgumentError when size is zero
00:00 +6: ChunkedList.chunked returned chunks are independent from the original list
00:00 +7: All tests passed!

Output: 00:00 +7: All tests passed!

Analyzing list_extensions.dart, list_extensions_test.dart...
No issues found!

Output: No issues found!

## Acceptance criteria coverage

- AC 1: ✓ addressed in lib/core/utils/list_extensions.dart: extension ChunkedList<T> on List<T> with chunked(int size) implementing all required behaviors
- AC 2: ✓ addressed in test/core/utils/list_extensions_test.dart: all 7 tests pass (consecutive chunks, size equals length, size greater than length, empty input, single element, ArgumentError on zero, independence)
- AC 3: ✓ addressed - no dependencies added; uses only Dart core List methods and flutter_test from pubspec.yaml

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated (only list_extensions.dart and list_extensions_test.dart touched)
- Do NOT add third-party dependencies unless required: not violated (no pubspec.yaml changes, only core Dart/List and flutter_test used)
- Do NOT refactor unrelated code in the touched files: not violated (new files created, no refactoring of existing code)

## Notes

- Empty directories lib/features/ and test/features/ were created along with the test directory structure per existing pattern for formatters_test.dart
- No pubspec.lock changes; pubspec.yaml and dependencies remain unchanged as specified in non-goals