### PR TITLE
feat(strings): Add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,41 @@
+/// Truncates a string in the middle, keeping the start and end visible.
+///
+/// If the input length is less than or equal to [maxLength], returns the input
+/// unchanged. Otherwise, replaces the middle with [ellipsis].
+///
+/// The [maxLength] includes the length of the ellipsis. The returned string
+/// length is guaranteed to be less than or equal to [maxLength].
+///
+/// For odd visible capacity (`maxLength - ellipsis.length`), the function uses
+/// floor division for both sides, intentionally leaving one unused character of
+/// capacity. This ensures consistent start/end character counts.
+///
+/// Throws [ArgumentError] if [maxLength] is negative.
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'` (7 chars total)
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'` (3 chars total)
+/// - `truncateMiddle('abcdef', 2, ellipsis: '...')` → `'..'` (truncated ellipsis)
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  if (maxLength < 0) {
+    throw ArgumentError.value(
+      maxLength,
+      'maxLength',
+      'Must be greater than or equal to 0',
+    );
+  }
+
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  if (ellipsis.length >= maxLength) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  final visiblePerSide = (maxLength - ellipsis.length) ~/ 2;
+
+  return '${input.substring(0, visiblePerSide)}$ellipsis${input.substring(input.length - visiblePerSide)}';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns input unchanged when input length is less than maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+    });
+
+    test('returns input unchanged when input length equals maxLength', () {
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test('replaces the middle with the default ellipsis', () {
+      final result = truncateMiddle('abcdefghijklmn', 8);
+      expect(result, 'abc…lmn');
+      expect(result.length, lessThanOrEqualTo(8));
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+    });
+
+    test('keeps both ends visible for very small maxLength when possible', () {
+      final result = truncateMiddle('abcdef', 3);
+      expect(result, 'a…f');
+      expect(result.length, lessThanOrEqualTo(3));
+    });
+
+    test('returns truncated ellipsis alone when maxLength is shorter than ellipsis', () {
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+    });
+
+    test('accounts for custom ellipsis length in maxLength', () {
+      final result = truncateMiddle('abcdefghijklmn', 10, ellipsis: '[...]');
+      expect(result, 'ab[...]mn');
+      expect(result.length, lessThanOrEqualTo(10));
+    });
+
+    test('throws ArgumentError when maxLength is negative', () {
+      expect(() => truncateMiddle('abcdef', -1), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
## Description
Add a `truncateMiddle()` helper function that truncates long strings by replacing the middle portion with an ellipsis, keeping the start and end visible.

## Related Issue
Closes #418

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## What changed
- Created `lib/core/utils/string_utils.dart` with `truncateMiddle()` function
- Created `test/core/utils/string_utils_test.dart` with 8 test cases covering all behaviors
- Function handles edge cases: empty string, input shorter than maxLength, maxLength shorter than ellipsis
- Throws `ArgumentError` for negative maxLength values
- Uses floor division for odd visible capacity (documented design choice: may leave 1 unused character)

## How verified
```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
```
Output: 8 tests passed (All tests passed!)

```bash
flutter analyze lib/core/utils/string_utils.dart test/core/utils/string_utils_test.dart
```
Output: No issues found!

## Acceptance criteria coverage
- AC 1: Implementation matches all behaviors described in the task body (see Notes) ✓
  - Returns input unchanged when `input.length <= maxLength`
  - Replaces middle with ellipsis, keeping start/end visible
  - `maxLength` includes ellipsis length
  - Return value length is always `<= maxLength`
  - Handles empty string, single char, maxLength shorter than ellipsis (returns truncated ellipsis)
  - Throws ArgumentError for negative maxLength
- AC 2: All named tests pass the verification command ✓
  - 8 test cases covering all behaviors pass
- AC 3: No dependencies added unless absolutely required ✓
  - Uses only Dart standard library functionality
  - Tests use existing flutter_test dependency

## Non-goals acknowledged
- Do NOT modify files beyond the expected set below: not violated (only created the 2 expected files)
- Do NOT add third-party dependencies unless required by the task body: not violated (no new dependencies)
- Do NOT refactor unrelated code in the touched files: not violated (new files only)

## Implementation Notes

### Design Choice for Odd Capacity
When `maxLength - ellipsis.length` is odd, the function uses floor division (`~/ 2`) for both sides, keeping the same number of characters from start and end. This intentionally leaves one unused character of capacity.

Example: `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'` (7 chars total, ≤ 8 maxLength)

### Edge Cases Handled
1. **Negative maxLength**: Throws `ArgumentError` with clear message
2. **Empty input**: Returns empty string unchanged
3. **Input shorter than maxLength**: Returns input unchanged
4. **maxLength = 0**: Returns empty string
5. **maxLength shorter than ellipsis**: Returns truncated ellipsis (e.g., maxLength=2 with ellipsis='...' returns '..')

### Coverage
- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/string_utils.dart` truncateMiddle() function
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/string_utils_test.dart` - 8 tests pass
- AC 3 (No dependencies added unless absolutely required): ✓ no dependencies added

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed (doc comments added)
- [x] My changes generate no new warnings