### PR TITLE
feat(collections): Add chunked() extension method on List

### DIFF
--- a/lib/core/utils/list_extensions.dart
+++ b/lib/core/utils/list_extensions.dart
@@ -1,0 +1,28 @@
+library list_extensions;
+
+extension ChunkedList<T> on List<T> {
+  /// Splits this list into consecutive sub-lists of at most [size] elements.
+  ///
+  /// The returned chunks are independent copies created via [sublist].
+  ///
+  /// Throws [ArgumentError] if [size] is less than 1.
+  List<List<T>> chunked(int size) {
+    if (size < 1) {
+      throw ArgumentError.value(
+        size,
+        'size',
+        'Must be greater than or equal to 1',
+      );
+    }
+    if (isEmpty) {
+      return <List<T>>[];
+    }
+
+    final List<List<T>> chunks = <List<T>>[];
+    for (int start = 0; start < length; start += size) {
+      final int end = (start + size < length) ? start + size : length;
+      chunks.add(sublist(start, end));
+    }
+    return chunks;
+  }
+}

--- a/test/core/utils/list_extensions_test.dart
+++ b/test/core/utils/list_extensions_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/list_extensions.dart';
+
+void main() {
+  group('ChunkedList', () {
+    test('chunked splits a list into consecutive chunks', () {
+      final result = [1, 2, 3, 4, 5].chunked(2);
+      expect(result, [[1, 2], [3, 4], [5]]);
+    });
+
+    test('chunked returns one chunk when size equals list length', () {
+      final result = [1, 2, 3].chunked(3);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('chunked returns one chunk when size exceeds list length', () {
+      final result = [1, 2, 3].chunked(10);
+      expect(result, [[1, 2, 3]]);
+    });
+
+    test('chunked returns an empty list for an empty source list', () {
+      final result = <int>[].chunked(3);
+      expect(result, <List<int>>[]);
+    });
+
+    test('chunked returns a single-item chunk for a one-element list', () {
+      final result = [1].chunked(1);
+      expect(result, [[1]]);
+    });
+
+    test('chunked throws ArgumentError when size is zero', () {
+      expect(() => [1, 2, 3].chunked(0), throwsArgumentError);
+    });
+
+    test('chunked returns independent chunk lists', () {
+      final List<int> source = [1, 2, 3, 4];
+      final chunks = source.chunked(2);
+      chunks[0][0] = 99;
+      expect(source, [1, 2, 3, 4]);
+      expect(chunks[0], [99, 2]);
+      expect(chunks[1], [3, 4]);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #417

## What changed

- Added `ChunkedList<T>` extension on `List<T>` in `lib/core/utils/list_extensions.dart`
- Added `chunked(int size)` method that splits a list into consecutive sub-lists of at most `size` elements
- Created comprehensive test suite in `test/core/utils/list_extensions_test.dart` with 7 test cases

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/list_extensions_test.dart
```

Output:
```
00:00 +7: All tests passed!
```

Static analysis:
```
dart analyze lib/core/utils/list_extensions.dart test/core/utils/list_extensions_test.dart
No issues found!
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/core/utils/list_extensions.dart` — `ChunkedList<T>.chunked(int size)` implements all required behaviors: signature matches, size >= 1 validation via `ArgumentError`, empty list returns empty list, last chunk may be smaller than size, independent chunks via `sublist()`
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/core/utils/list_extensions_test.dart` — all 7 named tests pass: chunked splits a list into consecutive chunks, chunked returns one chunk when size equals list length, chunked returns one chunk when size exceeds list length, chunked returns an empty list for an empty source list, chunked returns a single-item chunk for a one-element list, chunked throws ArgumentError when size is zero, chunked returns independent chunk lists
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — implementation uses only Dart core `List` members (`isEmpty`, `length`, `sublist`) and existing `flutter_test` package. No `pubspec.yaml` or lockfile changes.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/list_extensions.dart` and `test/core/utils/list_extensions_test.dart` modified
- Do NOT add third-party dependencies unless required by the task body: not violated — no new dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — no refactoring of other code

## Notes

None