### PR TITLE
feat(semver): add compareSemVer() helper for version comparison

### DIFF
--- a/lib/core/utils/semver.dart
+++ b/lib/core/utils/semver.dart
@@ -1,0 +1,50 @@
+/// Semantic version comparison utilities.
+library;
+
+/// Compares two semantic version strings.
+///
+/// Returns a negative integer if [a] < [b], zero if [a] == [b],
+/// and a positive integer if [a] > [b], following [Comparable.compareTo] semantics.
+///
+/// Malformed input throws [FormatException] with the offending string preserved
+/// in the exception message.
+int compareSemVer(String a, String b) {
+  final aComponents = _parseSemVerComponents(a);
+  final bComponents = _parseSemVerComponents(b);
+
+  for (var i = 0; i < 3; i++) {
+    final cmp = aComponents[i].compareTo(bComponents[i]);
+    if (cmp != 0) return cmp;
+  }
+  return 0;
+}
+
+List<int> _parseSemVerComponents(String input) {
+  if (input.isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+  if (input.trim().isEmpty) {
+    throw FormatException('Malformed semantic version: $input');
+  }
+
+  final parts = input.split('.');
+  final ints = <int>[];
+
+  for (final part in parts) {
+    final parsed = int.tryParse(part);
+    if (parsed == null) {
+      throw FormatException('Malformed semantic version: $input');
+    }
+    ints.add(parsed);
+  }
+
+  // Truncate: ignore components beyond patch (index >= 3).
+  final truncated = ints.take(3).toList();
+
+  // Pad: append zeroes until length is exactly 3.
+  while (truncated.length < 3) {
+    truncated.add(0);
+  }
+
+  return truncated;
+}

--- a/test/core/utils/semver_test.dart
+++ b/test/core/utils/semver_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/semver.dart';
+
+void main() {
+  group('compareSemVer', () {
+    test('returns zero for equal versions', () {
+      expect(compareSemVer('1.2.3', '1.2.3'), equals(0));
+    });
+
+    test('compares major components numerically', () {
+      expect(compareSemVer('2.0.0', '1.99.99'), isPositive);
+      expect(compareSemVer('1.99.99', '2.0.0'), isNegative);
+    });
+
+    test('compares minor components numerically', () {
+      expect(compareSemVer('1.10.0', '1.2.0'), isPositive);
+      expect(compareSemVer('1.2.0', '1.10.0'), isNegative);
+    });
+
+    test('compares patch components numerically', () {
+      expect(compareSemVer('1.2.3', '1.2.4'), isNegative);
+      expect(compareSemVer('1.2.4', '1.2.3'), isPositive);
+    });
+
+    test('pads short versions with zero components', () {
+      expect(compareSemVer('1.2', '1.2.0'), equals(0));
+    });
+
+    test('ignores extra trailing numeric components beyond patch', () {
+      expect(compareSemVer('1.2.3.4', '1.2.3'), equals(0));
+    });
+
+    test('throws FormatException for malformed input', () {
+      expect(() => compareSemVer('1.2.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+      expect(() => compareSemVer('1.2.3.a', '1.2.3'),
+          throwsA(isA<FormatException>()));
+    });
+
+    test('throws FormatException for empty and whitespace versions', () {
+      expect(() => compareSemVer('', '1.2.3'), throwsA(isA<FormatException>()));
+      expect(
+          () => compareSemVer('   ', '1.2.3'), throwsA(isA<FormatException>()));
+    });
+
+    test('includes offending input in FormatException message', () {
+      expect(
+        () => compareSemVer('1.2.a', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((e) => e.message, 'message', contains('1.2.a'))),
+      );
+      expect(
+        () => compareSemVer('1.2.3.a', '1.2.3'),
+        throwsA(isA<FormatException>()
+            .having((e) => e.message, 'message', contains('1.2.3.a'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #419

## What changed

- Created `lib/core/utils/semver.dart` with `int compareSemVer(String a, String b)` and private helper `_parseSemVerComponents(String input)`.
- Created `test/core/utils/semver_test.dart` with 9 tests covering all acceptance criteria.
- Implementation uses Dart core only (`String`, `List<int>`, `int.tryParse`, `Comparable.compareTo`) — no third-party dependencies added.

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/semver_test.dart
```

Output: **00:00 +9 All tests passed!**

Static analysis: `dart analyze lib/core/utils/semver.dart` → **No issues found!**

## Acceptance criteria coverage

- AC 1 (exact signature `int compareSemVer(String a, String b)` in `lib/core/utils/semver.dart`): ✓ addressed in `lib/core/utils/semver.dart:9`
- AC 2 (numeric comparison, `1.10.0 > 1.2.0`): ✓ addressed in `compareSemVer` using integer `compareTo` on parsed components
- AC 3 (short version `1.2` treated as `1.2.0`): ✓ addressed by zero-padding in `_parseSemVerComponents`
- AC 4 (extra trailing components `1.2.3.4` truncated to `1.2.3`): ✓ addressed by `ints.take(3)` in `_parseSemVerComponents`
- AC 5 (sign-only return contract, `isNegative`/`isPositive`/`equals(0)`): ✓ all comparison tests use sign matchers only
- AC 6 (malformed input throws `FormatException`): ✓ empty, whitespace, and non-numeric components throw; tested in `throws FormatException for malformed input` and `throws FormatException for empty and whitespace versions`
- AC 7 (offending input verbatim in exception message): ✓ tested with `throwsA(...().having((e) => e.message, 'message', contains('1.2.a')))` and `contains('1.2.3.a')`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/core/utils/semver.dart` and `test/core/utils/semver_test.dart` changed
- Do NOT add third-party dependencies: not violated — implementation uses Dart core only
- Do NOT refactor unrelated code in the touched files: not violated — both files are new; no refactoring occurred

## Notes

- `pubspec.lock` was modified by `flutter pub get` during test runs; reverted via `git checkout origin/main -- pubspec.lock` before commit so the diff stays clean.
- `library;` directive added to `lib/core/utils/semver.dart` to satisfy `dangling_library_doc_comments` lint.