### PR TITLE
feat(strings): add truncateMiddle() helper for long strings

### DIFF
--- a/lib/core/utils/string_utils.dart
+++ b/lib/core/utils/string_utils.dart
@@ -1,0 +1,38 @@
+// Utility functions for string manipulation.
+
+/// Truncates [input] to at most [maxLength] characters, replacing the middle
+/// with [ellipsis] when the string exceeds [maxLength].
+///
+/// - If [input].length <= [maxLength], returns [input] unchanged.
+/// - Otherwise, keeps an equal number of characters from the start and end,
+///   separated by [ellipsis].
+/// - The returned string length is always <= [maxLength].
+/// - When [maxLength] - [ellipsis].length is odd, one character of capacity
+///   is left unused to keep the result balanced (e.g. 'a…f' for maxLength=3).
+///
+/// Examples:
+/// - `truncateMiddle('hello', 10)` → `'hello'`
+/// - `truncateMiddle('abcdefghijklmn', 8)` → `'abc…lmn'`
+/// - `truncateMiddle('', 5)` → `''`
+/// - `truncateMiddle('abcdef', 3)` → `'a…f'`
+String truncateMiddle(String input, int maxLength, {String ellipsis = '…'}) {
+  if (maxLength < 0) {
+    throw ArgumentError.value(
+      maxLength,
+      'maxLength',
+      'must be non-negative',
+    );
+  }
+
+  // Fits unchanged
+  if (input.length <= maxLength) return input;
+
+  // Ellipsis alone exceeds or fills the budget
+  if (ellipsis.length >= maxLength) {
+    return ellipsis.substring(0, maxLength);
+  }
+
+  // Balanced middle truncation
+  final visibleCharsPerSide = (maxLength - ellipsis.length) ~/ 2;
+  return '${input.substring(0, visibleCharsPerSide)}$ellipsis${input.substring(input.length - visibleCharsPerSide)}';
+}

--- a/test/core/utils/string_utils_test.dart
+++ b/test/core/utils/string_utils_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/core/utils/string_utils.dart';
+
+void main() {
+  group('truncateMiddle', () {
+    test('returns unchanged input when length is within maxLength', () {
+      expect(truncateMiddle('hello', 10), 'hello');
+      expect(truncateMiddle('hello', 5), 'hello');
+    });
+
+    test(
+        'replaces the middle with the default ellipsis while keeping both ends '
+        'visible', () {
+      expect(truncateMiddle('abcdefghijklmn', 8), 'abc…lmn');
+      expect(truncateMiddle('abcdef', 3), 'a…f');
+    });
+
+    test('returns empty input unchanged', () {
+      expect(truncateMiddle('', 5), '');
+      expect(truncateMiddle('', 0), '');
+    });
+
+    test('truncates the ellipsis alone when maxLength is too small', () {
+      expect(truncateMiddle('abcdef', 2, ellipsis: '...'), '..');
+      expect(truncateMiddle('abcdef', 0), '');
+    });
+
+    test('accounts for custom ellipsis length in the output length', () {
+      final result = truncateMiddle('abcdefghijklmn', 8, ellipsis: '...');
+      expect(result, 'ab...mn');
+      expect(result.length, lessThanOrEqualTo(8));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #161

## What changed

- Added `truncateMiddle()` function to `lib/core/utils/string_utils.dart` — a top-level helper that truncates strings exceeding `maxLength` while keeping the start and end characters visible, joined by an ellipsis.
- Added `test/core/utils/string_utils_test.dart` with five focused test cases covering: unchanged short strings, balanced middle truncation, empty input, ellipsis-only truncation when `maxLength` is too small, and custom ellipsis length accounting.

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/core/utils/string_utils_test.dart
flutter test
dart analyze lib/core/utils/string_utils.dart test/core/utils/string_utils_test.dart
```

Focused tests: 5 passed (00:00 +5).
Full suite: 13 passed (00:02 +13).
Analyzer: No issues found.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): Addressed in `lib/core/utils/string_utils.dart` — handles `input.length <= maxLength` (unchanged), `ellipsis.length >= maxLength` (ellipsis-only, truncated), balanced middle truncation with documented design choice, and negative `maxLength` via `ArgumentError`.
- AC 2 (All named tests pass the verification command): Addressed in `test/core/utils/string_utils_test.dart` — five named tests covering all required cases; verified via `flutter test test/core/utils/string_utils_test.dart` (5 passed) and `flutter test` (13 passed, no regressions).
- AC 3 (No dependencies added unless absolutely required): Addressed — no new dependencies added; `string_utils.dart` uses only Dart core `String` methods; test file uses existing `flutter_test` already in the project.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/core/utils/string_utils.dart` and `test/core/utils/string_utils_test.dart` were changed.
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added.
- Do NOT refactor unrelated code in the touched files: not violated — `string_utils.dart` is a new file and `string_utils_test.dart` contains only the new tests.

## Notes

- The implementation uses balanced truncation (equal characters from each end) rather than leaving the ellipsis alone for `truncateMiddle('abcdef', 3)`, producing `'a…f'` rather than `'…'`. This choice is documented in the function comment.