### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,124 @@
+/// Trade margin calculation utilities for market trading analysis.
+library;
+
+/// Immutable value object representing the margin analysis of a trade.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Returns true if the trade generated a positive profit.
+  bool get isProfitable => profit > 0;
+}
+
+/// Static calculator for trade margin and break-even analysis.
+class TradeCalculator {
+  TradeCalculator._();
+
+  /// Calculates the full margin analysis for a trade.
+  ///
+  /// [buyPrice] is the purchase price of the item.
+  /// [sellPrice] is the selling price of the item.
+  /// [brokerFeePercent] is the broker fee percentage applied to both buy and sell (default 1.0).
+  /// [salesTaxPercent] is the sales tax percentage applied to the sell price (default 2.0).
+  ///
+  /// Throws [ArgumentError] if any input is not finite, if buyPrice <= 0,
+  /// or if sellPrice, brokerFeePercent, or salesTaxPercent is negative.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateFinitePositive(buyPrice, 'buyPrice');
+    _validateFiniteNonNegative(sellPrice, 'sellPrice');
+    _validateFiniteNonNegative(brokerFeePercent, 'brokerFeePercent');
+    _validateFiniteNonNegative(salesTaxPercent, 'salesTaxPercent');
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculates the break-even sell price that covers all costs and fees.
+  ///
+  /// [buyPrice] is the purchase price of the item.
+  /// [brokerFeePercent] is the broker fee percentage applied to both buy and sell (default 1.0).
+  /// [salesTaxPercent] is the sales tax percentage applied to the sell price (default 2.0).
+  ///
+  /// Throws [ArgumentError] if any input is not finite, if buyPrice <= 0,
+  /// if either percentage is negative, or if fees consume the entire sell price.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateFinitePositive(buyPrice, 'buyPrice');
+    _validateFiniteNonNegative(brokerFeePercent, 'brokerFeePercent');
+    _validateFiniteNonNegative(salesTaxPercent, 'salesTaxPercent');
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellFeeMultiplier =
+        1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    if (sellFeeMultiplier <= 0) {
+      throw ArgumentError(
+        'sellFeeMultiplier must be positive, '
+        'but got $sellFeeMultiplier '
+        '(brokerFeePercent=$brokerFeePercent, salesTaxPercent=$salesTaxPercent)',
+      );
+    }
+
+    return buyTotal / sellFeeMultiplier;
+  }
+
+  static void _validateFinitePositive(double value, String name) {
+    if (!value.isFinite) {
+      throw ArgumentError('$name must be finite, got $value');
+    }
+    if (value <= 0) {
+      throw ArgumentError('$name must be positive, got $value');
+    }
+  }
+
+  static void _validateFiniteNonNegative(double value, String name) {
+    if (!value.isFinite) {
+      throw ArgumentError('$name must be finite, got $value');
+    }
+    if (value < 0) {
+      throw ArgumentError('$name must be non-negative, got $value');
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator.calculateMargin', () {
+    test('calculates margin correctly', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1100000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.buyTotal, 1010000);
+      expect(result.sellNet, 1067000);
+      expect(result.profit, 57000);
+      expect(result.marginPercent, closeTo(5.6435643564, 0.0001));
+      expect(result.brokerFee, 21000);
+      expect(result.salesTax, 22000);
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('identifies unprofitable trades', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.profit, lessThan(0));
+      expect(result.marginPercent, lessThan(0));
+      expect(result.isProfitable, isFalse);
+    });
+
+    test('supports custom fee and tax percentages', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 500000,
+        sellPrice: 600000,
+        brokerFeePercent: 2.0,
+        salesTaxPercent: 3.0,
+      );
+
+      // buyTotal = 500000 * 1.02 = 510000
+      expect(result.buyTotal, 510000);
+      // sellNet = 600000 * (1 - 0.02 - 0.03) = 600000 * 0.95 = 570000
+      expect(result.sellNet, 570000);
+      // profit = 570000 - 510000 = 60000
+      expect(result.profit, 60000);
+      // marginPercent = (60000 / 510000) * 100 ≈ 11.7647
+      expect(result.marginPercent, closeTo(11.7647, 0.001));
+      // brokerFee = 500000*0.02 + 600000*0.02 = 10000 + 12000 = 22000
+      expect(result.brokerFee, 22000);
+      // salesTax = 600000 * 0.03 = 18000
+      expect(result.salesTax, 18000);
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('throws ArgumentError for invalid calculateMargin inputs', () {
+      // buyPrice: 0
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 1100000,
+        ),
+        throwsArgumentError,
+      );
+
+      // negative sellPrice
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: -100,
+        ),
+        throwsArgumentError,
+      );
+
+      // negative brokerFeePercent
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      // negative salesTaxPercent
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          salesTaxPercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      // double.nan
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.nan,
+          sellPrice: 1100000,
+        ),
+        throwsArgumentError,
+      );
+
+      // double.infinity
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.infinity,
+          sellPrice: 1100000,
+        ),
+        throwsArgumentError,
+      );
+
+      // negative infinity
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.negativeInfinity,
+          sellPrice: 1100000,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeCalculator.breakEvenSellPrice', () {
+    test('calculates break-even sell price', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result, closeTo(1041237.1134020619, 0.0001));
+      expect(result, greaterThan(1010000));
+    });
+
+    test('break-even price yields zero profit within rounding tolerance', () {
+      final breakEven = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: breakEven,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(margin.profit, closeTo(0, 0.01));
+      expect(margin.marginPercent, closeTo(0, 0.001));
+    });
+
+    test('throws ArgumentError when fees consume entire sell price', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for invalid breakEvenSellPrice inputs', () {
+      // non-finite buy price (nan)
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      // non-finite buy price (infinity)
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      // non-positive buy price
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 0,
+        ),
+        throwsArgumentError,
+      );
+
+      // negative broker fee
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      // negative sales tax
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          salesTaxPercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeMargin.isProfitable', () {
+    test('returns true for positive profit', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1100000,
+      );
+      expect(margin.isProfitable, isTrue);
+    });
+
+    test('returns false for zero profit', () {
+      // At break-even, profit is 0, so isProfitable should be false
+      final breakEven = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: breakEven,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+      // Due to floating point, profit might be a tiny epsilon, but isProfitable checks > 0
+      // After verifying it's close to 0, isProfitable should be false
+      expect(margin.profit.abs(), lessThan(1.0));
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('returns false for negative profit', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 900000,
+      );
+      expect(margin.isProfitable, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #426

## What changed

- Created `lib/features/market/calculators/margin_calculator.dart` with `TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, and immutable `TradeMargin` value object per market spec Price Calculations section.
- Created `test/features/market/calculators/margin_calculator_test.dart` with 11 tests covering happy paths, edge cases, and error cases.
- 94.1% line coverage on margin_calculator.dart (above 90% threshold).

## How verified

```
cd ~/workspace/infiquetra/mimir
dart format lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
# → Formatted 2 files in 0.06s

flutter test test/features/market/calculators/margin_calculator_test.dart
# → 00:00 +11: All tests passed!

flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
# → No issues found!

flutter test --coverage test/features/market/calculators/margin_calculator_test.dart
# → 32/34 lines covered = 94.1% line coverage on margin_calculator.dart
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `TradeCalculator.calculateMargin` and `TradeCalculator.breakEvenSellPrice` implemented per market spec Price Calculations section with exact formulas, default parameters, and full input validation.
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — 11 named tests covering `calculates margin correctly`, `identifies unprofitable trades`, `supports custom fee and tax percentages`, `throws ArgumentError for invalid calculateMargin inputs`, `calculates break-even sell price`, `break-even price yields zero profit within rounding tolerance`, `throws ArgumentError when fees consume entire sell price`, `throws ArgumentError for invalid breakEvenSellPrice inputs`, and three `TradeMargin.isProfitable` edge cases.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/features/market/calculators/margin_calculator.dart` and `test/features/market/calculators/margin_calculator_test.dart` were created.
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new with only the margin calculator capability.

## Notes

- The repo had no `lib/features/` or `test/features/` directories at card start; the new `lib/features/market/calculators/` and `test/features/market/calculators/` paths were created as required by the card's files_expected.
- 2 lint issues were found and fixed (unused `dart:math` import, unnecessary braces in string interpolation) before commit.
- Coverage: 32/34 lines = 94.1% line coverage on margin_calculator.dart.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, and `TradeMargin` with all spec fields and exact formulas
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — 11 named tests, 94.1% line coverage, all passing
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — zero new dependencies; only `dart:math` import removed during lint fix (was unused)