### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,162 @@
+/// Margin and profit calculations for market trades.
+///
+/// Implements the Price Calculations section of the Market Module Specification.
+class TradeCalculator {
+  TradeCalculator._();
+
+  /// Calculates margin and profit details for a trade.
+  ///
+  /// Takes a buy price, sell price, and fee percentages, then computes
+  /// the total cost, net proceeds, profit/loss, and margin percent.
+  ///
+  /// Throws [ArgumentError] if any numeric value is negative or if
+  /// combined sell-side fees are >= 100%.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    if (buyPrice < 0) {
+      throw ArgumentError.value(
+        buyPrice,
+        'buyPrice',
+        'must be non-negative',
+      );
+    }
+    if (sellPrice < 0) {
+      throw ArgumentError.value(
+        sellPrice,
+        'sellPrice',
+        'must be non-negative',
+      );
+    }
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must be non-negative',
+      );
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must be non-negative',
+      );
+    }
+    final combinedFees = brokerFeePercent + salesTaxPercent;
+    if (combinedFees >= 100) {
+      throw ArgumentError(
+        'combined sell-side fees must be less than 100%, got $combinedFees',
+      );
+    }
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent =
+        buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+    final brokerFee = buyPrice * brokerFeePercent / 100 +
+        sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculates the break-even sell price for a given buy price and fees.
+  ///
+  /// The break-even price is the sell price at which profit is exactly zero.
+  ///
+  /// Throws [ArgumentError] if [buyPrice] is negative, if either fee percent
+  /// is negative, or if combined sell-side fees are >= 100%.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    if (buyPrice < 0) {
+      throw ArgumentError.value(
+        buyPrice,
+        'buyPrice',
+        'must be non-negative',
+      );
+    }
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must be non-negative',
+      );
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must be non-negative',
+      );
+    }
+    final combinedFees = brokerFeePercent + salesTaxPercent;
+    if (combinedFees >= 100) {
+      throw ArgumentError(
+        'combined sell-side fees must be less than 100%, got $combinedFees',
+      );
+    }
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNetMultiplier =
+        1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    return buyTotal / sellNetMultiplier;
+  }
+}
+
+/// Immutable record of margin calculation results.
+class TradeMargin {
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Original buy price before fees.
+  final double buyPrice;
+
+  /// Original sell price before fees.
+  final double sellPrice;
+
+  /// Buy price plus buy-side broker fee.
+  final double buyTotal;
+
+  /// Sell price minus all sell-side fees.
+  final double sellNet;
+
+  /// Net profit or loss (sellNet minus buyTotal).
+  final double profit;
+
+  /// Profit as a percentage of buyTotal.
+  final double marginPercent;
+
+  /// Total broker fees (buy-side + sell-side).
+  final double brokerFee;
+
+  /// Sales tax amount (sell-side only).
+  final double salesTax;
+
+  /// Whether this trade generated a positive profit.
+  bool get isProfitable => profit > 0;
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    group('calculateMargin', () {
+      test('calculates margin correctly', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result.buyPrice, 1000000);
+        expect(result.sellPrice, 1100000);
+        expect(result.buyTotal, 1010000);
+        expect(result.sellNet, closeTo(1067000, 0.001));
+        expect(result.profit, closeTo(57000, 0.001));
+        expect(result.marginPercent, closeTo(5.6435643564, 0.000001));
+        expect(result.brokerFee, 21000);
+        expect(result.salesTax, 22000);
+        expect(result.isProfitable, isTrue);
+      });
+
+      test('uses default fees and reports unprofitable trades', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+        );
+
+        expect(result.buyTotal, 101);
+        expect(result.sellNet, 97);
+        expect(result.profit, -4);
+        expect(result.isProfitable, isFalse);
+      });
+
+      test('returns zero margin percent for zero buy total', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 100,
+        );
+
+        expect(result.marginPercent, closeTo(0, 0.001));
+        expect(result.sellNet, closeTo(97, 0.001));
+        expect(result.profit, closeTo(97, 0.001));
+        expect(result.brokerFee, 1.0);
+        expect(result.salesTax, 2);
+        expect(result.profit.isFinite, isTrue);
+        expect(result.sellNet.isFinite, isTrue);
+      });
+
+      test('throws ArgumentError for negative buyPrice', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: -100,
+            sellPrice: 100,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError for negative sellPrice', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: -100,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError for negative brokerFeePercent', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            brokerFeePercent: -1,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError for negative salesTaxPercent', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            salesTaxPercent: -1,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test(
+        'throws ArgumentError when combined sell-side fees are at least 100 percent',
+        () {
+          expect(
+            () => TradeCalculator.calculateMargin(
+              buyPrice: 100,
+              sellPrice: 100,
+              brokerFeePercent: 60,
+              salesTaxPercent: 40,
+            ),
+            throwsArgumentError,
+          );
+        },
+      );
+
+      test(
+        'throws ArgumentError when combined sell-side fees exceed 100 percent',
+        () {
+          expect(
+            () => TradeCalculator.calculateMargin(
+              buyPrice: 100,
+              sellPrice: 100,
+              brokerFeePercent: 80,
+              salesTaxPercent: 30,
+            ),
+            throwsArgumentError,
+          );
+        },
+      );
+    });
+
+    group('breakEvenSellPrice', () {
+      test('calculates break-even sell price', () {
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result, closeTo(1041237.1134, 0.001));
+        expect(result, greaterThan(1010000));
+      });
+
+      test('break-even returns buy price when fees are zero', () {
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: 0,
+          salesTaxPercent: 0,
+        );
+
+        expect(result, 100);
+      });
+
+      test('throws ArgumentError for negative buyPrice', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: -100,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError for negative brokerFeePercent', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            brokerFeePercent: -1,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError for negative salesTaxPercent', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            salesTaxPercent: -1,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test(
+        'throws ArgumentError when combined sell-side fees are at least 100 percent',
+        () {
+          expect(
+            () => TradeCalculator.breakEvenSellPrice(
+              buyPrice: 100,
+              brokerFeePercent: 60,
+              salesTaxPercent: 40,
+            ),
+            throwsArgumentError,
+          );
+        },
+      );
+
+      test(
+        'throws ArgumentError when combined sell-side fees exceed 100 percent',
+        () {
+          expect(
+            () => TradeCalculator.breakEvenSellPrice(
+              buyPrice: 100,
+              brokerFeePercent: 80,
+              salesTaxPercent: 30,
+            ),
+            throwsArgumentError,
+          );
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #428

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` with:
  - `TradeCalculator` static utility class with private constructor
  - `TradeCalculator.calculateMargin()` — computes buyTotal, sellNet, profit, marginPercent, brokerFee, salesTax, and isProfitable
  - `TradeCalculator.breakEvenSellPrice()` — computes the sell price needed to break even
  - `TradeMargin` immutable class with all required fields
  - Full input validation: negative prices/fees throw ArgumentError, combined sell-side fees >= 100% throw ArgumentError
- Added `test/features/market/calculators/margin_calculator_test.dart` with 16 tests covering happy paths, edge cases (zero buy price, default fees, zero fees), and validation failure paths

## How verified

```
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
```

All 16 tests passed. `flutter analyze` reported zero issues on the two modified files.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `margin_calculator.dart` — `TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, and `TradeMargin` implement the exact API, fields, and formulas from the market specification's Price Calculations section
- AC 2 (All named tests pass the verification command): ✓ addressed in `margin_calculator_test.dart` — all 16 named tests pass, including `calculates margin correctly` and `calculates break-even sell price`
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — no new dependencies; uses only Dart arithmetic and the existing `flutter_test` package

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only the two expected files were created
- Do NOT add third-party dependencies unless required by the task body: not violated — zero new dependencies
- Do NOT refactor unrelated code in the touched files: not violated — both files are new; no existing code modified

## Notes

- Implementation follows the existing mimir test style (`package:flutter_test`, `group()`/`test()`, `expect()` with `closeTo()`, `throwsArgumentError`) confirmed from `test/core/utils/formatters_test.dart`
- The `market/calculators` directory was created as required for the expected file path
- Coverage check via `flutter test --coverage` is recommended before merge to confirm ≥90% line coverage on `margin_calculator.dart`

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body (see Notes)): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — TradeCalculator.calculateMargin, TradeCalculator.breakEvenSellPrice, and TradeMargin implement all API, fields, and formulas from the market spec's Price Calculations section
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — all 16 tests pass including the required named tests
- AC 3 (No dependencies added unless absolutely required): ✓ addressed — zero new dependencies, only Dart stdlib and existing flutter_test