### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,143 @@
+/// Market margin calculator for trade profit analysis.
+///
+/// Rates are expressed as decimals (e.g. 0.05 means 5%).
+library;
+
+/// Immutable input for a margin calculation.
+///
+/// Fee and tax rates are expressed as decimals, so 0.05 means 5%.
+class MarginCalculationInput {
+  final double buyPrice;
+  final double sellPrice;
+  final int quantity;
+  final double brokerFeeRate;
+  final double salesTaxRate;
+
+  const MarginCalculationInput({
+    required this.buyPrice,
+    required this.sellPrice,
+    this.quantity = 1,
+    this.brokerFeeRate = 0,
+    this.salesTaxRate = 0,
+  });
+}
+
+/// Immutable result of a margin calculation.
+class MarginCalculationResult {
+  final double totalCost;
+  final double grossRevenue;
+  final double brokerFees;
+  final double salesTax;
+  final double netRevenue;
+  final double profit;
+  final double profitPerUnit;
+  final double marginPercent;
+  final double returnOnInvestmentPercent;
+  final double breakEvenSellPrice;
+  final bool isProfitable;
+
+  const MarginCalculationResult({
+    required this.totalCost,
+    required this.grossRevenue,
+    required this.brokerFees,
+    required this.salesTax,
+    required this.netRevenue,
+    required this.profit,
+    required this.profitPerUnit,
+    required this.marginPercent,
+    required this.returnOnInvestmentPercent,
+    required this.breakEvenSellPrice,
+    required this.isProfitable,
+  });
+}
+
+/// Calculates margin details for a buy/sell trade.
+///
+/// Returns a [MarginCalculationResult] containing total cost, revenue,
+/// fees, profit, margin percentage, ROI, break-even price, and
+/// profitability flag.
+///
+/// Throws [ArgumentError] if any input is invalid.
+MarginCalculationResult calculateMargin(MarginCalculationInput input) {
+  _validate(input);
+
+  final totalCost = input.buyPrice * input.quantity;
+  final grossRevenue = input.sellPrice * input.quantity;
+  final brokerFees = grossRevenue * input.brokerFeeRate;
+  final salesTax = grossRevenue * input.salesTaxRate;
+  final netRevenue = grossRevenue - brokerFees - salesTax;
+  final profit = netRevenue - totalCost;
+  final profitPerUnit = profit / input.quantity;
+  final marginPercent =
+      grossRevenue == 0 ? 0.0 : (profit / grossRevenue) * 100;
+  final returnOnInvestmentPercent = (profit / totalCost) * 100;
+  final breakEvenSellPrice =
+      input.buyPrice / (1 - input.brokerFeeRate - input.salesTaxRate);
+  // Use a tiny epsilon to avoid floating-point drift classifying
+  // mathematically-zero profit as profitable.
+  final isProfitable = profit > 1e-9;
+
+  return MarginCalculationResult(
+    totalCost: totalCost,
+    grossRevenue: grossRevenue,
+    brokerFees: brokerFees,
+    salesTax: salesTax,
+    netRevenue: netRevenue,
+    profit: profit,
+    profitPerUnit: profitPerUnit,
+    marginPercent: marginPercent,
+    returnOnInvestmentPercent: returnOnInvestmentPercent,
+    breakEvenSellPrice: breakEvenSellPrice,
+    isProfitable: isProfitable,
+  );
+}
+
+void _validate(MarginCalculationInput input) {
+  if (input.buyPrice <= 0) {
+    throw ArgumentError.value(
+      input.buyPrice,
+      'buyPrice',
+      'Expected a positive value greater than 0',
+    );
+  }
+
+  if (input.sellPrice < 0) {
+    throw ArgumentError.value(
+      input.sellPrice,
+      'sellPrice',
+      'Expected a non-negative value',
+    );
+  }
+
+  if (input.quantity <= 0) {
+    throw ArgumentError.value(
+      input.quantity,
+      'quantity',
+      'Expected a positive integer greater than 0',
+    );
+  }
+
+  if (input.brokerFeeRate < 0 || input.brokerFeeRate >= 1) {
+    throw ArgumentError.value(
+      input.brokerFeeRate,
+      'brokerFeeRate',
+      'Expected a value in the range [0, 1)',
+    );
+  }
+
+  if (input.salesTaxRate < 0 || input.salesTaxRate >= 1) {
+    throw ArgumentError.value(
+      input.salesTaxRate,
+      'salesTaxRate',
+      'Expected a value in the range [0, 1)',
+    );
+  }
+
+  if (input.brokerFeeRate + input.salesTaxRate >= 1) {
+    throw ArgumentError.value(
+      input.brokerFeeRate + input.salesTaxRate,
+      'brokerFeeRate + salesTaxRate',
+      'Combined fee and tax rates must be less than 1',
+    );
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('calculateMargin', () {
+    test(
+        'calculates profit, margin, roi, and fees for a profitable trade',
+        () {
+      const input = MarginCalculationInput(
+        buyPrice: 100,
+        sellPrice: 150,
+        quantity: 10,
+        brokerFeeRate: 0.03,
+        salesTaxRate: 0.08,
+      );
+
+      final result = calculateMargin(input);
+
+      expect(result.totalCost, 1000);
+      expect(result.grossRevenue, 1500);
+      expect(result.brokerFees, 45);
+      expect(result.salesTax, 120);
+      expect(result.netRevenue, 1335);
+      expect(result.profit, 335);
+      expect(result.profitPerUnit, 33.5);
+      expect(result.marginPercent, closeTo(22.3333333333, 0.000001));
+      expect(result.returnOnInvestmentPercent, 33.5);
+      expect(result.breakEvenSellPrice,
+          closeTo(112.3595505618, 0.000001));
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('reports a loss when fees and sell price exceed proceeds',
+        () {
+      const input = MarginCalculationInput(
+        buyPrice: 100,
+        sellPrice: 90,
+        quantity: 2,
+        brokerFeeRate: 0.05,
+        salesTaxRate: 0.05,
+      );
+
+      final result = calculateMargin(input);
+
+      expect(result.grossRevenue, 180);
+      expect(result.brokerFees, 9);
+      expect(result.salesTax, 9);
+      expect(result.netRevenue, 162);
+      expect(result.profit, -38);
+      expect(result.profitPerUnit, -19);
+      expect(result.marginPercent, closeTo(-21.1111111111, 0.000001));
+      expect(result.returnOnInvestmentPercent, -19);
+      expect(result.isProfitable, isFalse);
+    });
+
+    test(
+        'calculates zero profit at the fee-adjusted break-even sell price',
+        () {
+      const buyPrice = 100.0;
+      const brokerFeeRate = 0.03;
+      const salesTaxRate = 0.08;
+      const sellPrice = buyPrice / (1 - brokerFeeRate - salesTaxRate);
+
+      const input = MarginCalculationInput(
+        buyPrice: buyPrice,
+        sellPrice: sellPrice,
+        quantity: 5,
+        brokerFeeRate: brokerFeeRate,
+        salesTaxRate: salesTaxRate,
+      );
+
+      final result = calculateMargin(input);
+
+      expect(result.breakEvenSellPrice, closeTo(sellPrice, 0.000001));
+      expect(result.profit, closeTo(0, 0.000001));
+      expect(result.marginPercent, closeTo(0, 0.000001));
+      expect(result.returnOnInvestmentPercent, closeTo(0, 0.000001));
+      expect(result.isProfitable, isFalse);
+    });
+
+    group('validation', () {
+      test('throws ArgumentError for invalid prices and quantity',
+          () {
+        expect(
+          () => calculateMargin(
+            const MarginCalculationInput(
+              buyPrice: 0,
+              sellPrice: 100,
+              quantity: 1,
+            ),
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => calculateMargin(
+            const MarginCalculationInput(
+              buyPrice: 1,
+              sellPrice: -1,
+              quantity: 1,
+            ),
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => calculateMargin(
+            const MarginCalculationInput(
+              buyPrice: 1,
+              sellPrice: 100,
+              quantity: 0,
+            ),
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError for invalid fee and tax rates',
+          () {
+        expect(
+          () => calculateMargin(
+            const MarginCalculationInput(
+              buyPrice: 1,
+              sellPrice: 100,
+              quantity: 1,
+              brokerFeeRate: -0.01,
+            ),
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => calculateMargin(
+            const MarginCalculationInput(
+              buyPrice: 1,
+              sellPrice: 100,
+              quantity: 1,
+              brokerFeeRate: 1,
+            ),
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => calculateMargin(
+            const MarginCalculationInput(
+              buyPrice: 1,
+              sellPrice: 100,
+              quantity: 1,
+              salesTaxRate: -0.01,
+            ),
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => calculateMargin(
+            const MarginCalculationInput(
+              buyPrice: 1,
+              sellPrice: 100,
+              quantity: 1,
+              salesTaxRate: 1,
+            ),
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => calculateMargin(
+            const MarginCalculationInput(
+              buyPrice: 1,
+              sellPrice: 100,
+              quantity: 1,
+              brokerFeeRate: 0.6,
+              salesTaxRate: 0.4,
+            ),
+          ),
+          throwsArgumentError,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #434

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` with:
  - `MarginCalculationInput` value type (immutable)
  - `MarginCalculationResult` value type (immutable)
  - Top-level `calculateMargin(MarginCalculationInput input)` function
  - Private `_validate` helpers rejecting invalid prices, quantity, and fee/tax rates with `ArgumentError`
- Fee-adjusted profit, margin percentage, ROI, and break-even sell price computed per spec formulas
- Added `test/features/market/calculators/margin_calculator_test.dart` with tests covering:
  - Profitable trade math
  - Loss-making trade math
  - Exact break-even math
  - Validation failures (prices, quantity, fee rates, tax rates, combined rate)

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
flutter test
flutter analyze
```

Results:
- Targeted tests: 5 passed, 0 failed
- Full suite: 13 passed, 0 failed
- `flutter analyze`: 0 new warnings (1 pre-existing unrelated info in `formatters. dart`)

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body
  → `calculateMargin` implements fee-adjusted profit, margin percentage, ROI, break-even sell price, and validation per the spec excerpt. See `lib/features/market/calculators/margin_calculator.dart`.
- AC 2: All named tests pass the verification command
  → All 5 targeted tests and 13 total tests pass.
- AC 3: No dependencies added unless absolutely required
  → Only Dart standard library and existing `flutter_test` used.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below → only `margin_calculator.dart` and `margin_calculator_test.dart` changed
- Do NOT add third-party dependencies unless required by the task body → no dependencies added
- Do NOT refactor unrelated code in the touched files → no unrelated code modified

## Notes

The branch already contained an older `TradeCalculator` class with different API shape and semantics (percentage-based instead of decimal rates, no quantity). The card and plan explicitly call for `MarginCalculationInput`, `MarginCalculationResult`, and `calculateMargin`, so the old code was fully replaced with the spec-aligned implementation.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body (see Notes)): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `calculateMargin`, `MarginCalculationInput`, `MarginCalculationResult`
- AC 2 (All named tests pass the verification command): ✓ addressed in target test file — 5/5 targeted tests pass
- AC 3 (No dependencies added unless absolutely required): ✓ no dependencies added

## Spec section addressed

Market Module `Trade Calculator: Margin and profit analysis` capability — specifically fee-adjusted profit, margin percentage, ROI, break-even sell price, and invalid-input validation.