### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,135 @@
+/// Trade margin calculation utilities.
+///
+/// Implements the Price Calculations section of the market module spec.
+class TradeCalculator {
+  TradeCalculator._();
+
+  /// Validates common inputs for margin calculations.
+  static void _validateInputs({
+    required double buyPrice,
+    double? sellPrice,
+    required double brokerFeePercent,
+    required double salesTaxPercent,
+  }) {
+    if (buyPrice <= 0) {
+      throw ArgumentError.value(
+        buyPrice,
+        'buyPrice',
+        'must be greater than zero',
+      );
+    }
+    if (sellPrice != null && sellPrice < 0) {
+      throw ArgumentError.value(
+        sellPrice,
+        'sellPrice',
+        'must be non-negative',
+      );
+    }
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must be non-negative',
+      );
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must be non-negative',
+      );
+    }
+    if (brokerFeePercent + salesTaxPercent >= 100) {
+      throw ArgumentError(
+        'brokerFeePercent + salesTaxPercent must be less than 100, '
+        'got ${brokerFeePercent + salesTaxPercent}',
+      );
+    }
+  }
+
+  /// Calculates the margin for a trade.
+  ///
+  /// [buyPrice] is the price paid per unit (must be > 0).
+  /// [sellPrice] is the price received per unit (must be >= 0).
+  /// [brokerFeePercent] is the broker fee percentage (default 1.0).
+  /// [salesTaxPercent] is the sales tax percentage (default 2.0).
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateInputs(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet = sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+    final brokerFee = buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculates the break-even sell price for a trade.
+  ///
+  /// [buyPrice] is the price paid per unit (must be > 0).
+  /// [brokerFeePercent] is the broker fee percentage (default 1.0).
+  /// [salesTaxPercent] is the sales tax percentage (default 2.0).
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateInputs(
+      buyPrice: buyPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    return buyTotal / denominator;
+  }
+}
+
+/// Immutable value class representing the result of a margin calculation.
+class TradeMargin {
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  /// Returns `true` if the trade is profitable (profit > 0).
+  bool get isProfitable => profit > 0;
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('calculateMargin', () {
+    test('returns spec values with default fees', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 150.0,
+      );
+
+      expect(margin.buyTotal, closeTo(101.0, 0.0001));
+      expect(margin.sellNet, closeTo(145.5, 0.0001));
+      expect(margin.profit, closeTo(44.5, 0.0001));
+      expect(margin.marginPercent, closeTo(44.05940594059406, 0.0001));
+      expect(margin.brokerFee, closeTo(2.5, 0.0001));
+      expect(margin.salesTax, closeTo(3.0, 0.0001));
+      expect(margin.isProfitable, isTrue);
+    });
+
+    test('returns loss and negative margin when sell net is below buy total', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 90.0,
+      );
+
+      expect(margin.profit, lessThan(0.0));
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('applies custom broker fee and sales tax percentages', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 200.0,
+        sellPrice: 260.0,
+        brokerFeePercent: 2.0,
+        salesTaxPercent: 4.0,
+      );
+
+      expect(margin.buyTotal, closeTo(204.0, 0.0001));
+      expect(margin.sellNet, closeTo(244.4, 0.0001));
+      expect(margin.profit, closeTo(40.4, 0.0001));
+      expect(margin.brokerFee, closeTo(9.2, 0.0001));
+      expect(margin.salesTax, closeTo(10.4, 0.0001));
+    });
+
+    test('rejects non-positive buy price', () {
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: 0.0, sellPrice: 100.0),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: -1.0, sellPrice: 100.0),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects negative sell price', () {
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: 100.0, sellPrice: -1.0),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects negative broker fee percent', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 150.0,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects negative sales tax percent', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 150.0,
+          salesTaxPercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects fee and tax totals at or above 100 percent', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 150.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 150.0,
+          brokerFeePercent: 51.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('breakEvenSellPrice', () {
+    test('returns sell price where sell net equals buy total', () {
+      final breakEven = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 100.0,
+      );
+
+      expect(breakEven, closeTo(104.12371134020619, 0.0001));
+
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: breakEven,
+      );
+
+      expect(margin.profit, closeTo(0.0, 0.0001));
+    });
+
+    test('rejects non-positive buy price', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: 0.0),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: -1.0),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects fee and tax totals at or above 100 percent', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 51.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeMargin', () {
+    test('isProfitable returns true when profit is positive', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 150.0,
+      );
+
+      expect(margin.isProfitable, isTrue);
+    });
+
+    test('isProfitable returns false when profit is negative', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 90.0,
+      );
+
+      expect(margin.isProfitable, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #438

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` with:
  - `TradeCalculator` pure static utility class (private constructor)
  - `calculateMargin` — computes buy total, sell net, profit, margin percent, broker fee, and sales tax; validates inputs
  - `breakEvenSellPrice` — computes the minimum sell price to break even; validates inputs
  - `TradeMargin` immutable value class with all calculated fields and `isProfitable` getter
- Added `test/features/market/calculators/margin_calculator_test.dart` with tests for:
  - Successful margin calculation with default fees
  - Loss / negative margin path
  - Custom broker fee and sales tax percentages
  - Break-even sell price calculation (round-trip verified with `calculateMargin`)
  - Validation error paths: non-positive buy price, negative sell price, negative broker fee, negative sales tax, fee+tax >= 100%

## How verified

Exact commands run (from the card's `verification` field) and their output digest:

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
```
Output: `13 tests passed!` (all named test cases in the task body pass)

```bash
cd ~/workspace/infiquetra/mimir
flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
```
Output: `No issues found!`

```bash
cd ~/workspace/infiquetra/mimir
flutter test --coverage test/features/market/calculators/margin_calculator_test.dart
```
Coverage from `coverage/lcov.info` for `lib/features/market/calculators/margin_calculator.dart`:
- LF:29, LH:28 → **~96.6% line coverage**

## Acceptance criteria coverage

- AC 1 ("Implementation matches all behaviors described in the task body"): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `calculateMargin`, `breakEvenSellPrice`, and `TradeMargin.isProfitable` match the market spec Price Calculations section exactly.
- AC 2 ("All named tests pass the verification command"): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — all 13 tests pass.
- AC 3 ("No dependencies added unless absolutely required"): ✓ `margin_calculator.dart` uses only Dart language features, no package imports, no `pubspec.yaml` changes.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only `lib/features/market/calculators/margin_calculator.dart` and `test/features/market/calculators/margin_calculator_test.dart` were added.
- Do NOT add third-party dependencies unless required by the task body: not violated — no new dependencies.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new and contain only the margin calculator implementation and its tests.

## Notes

- Line 5 (`DA:5,0`) is the private constructor `TradeCalculator._();`, uncovered by tests because callers are statically prevented from instantiating it. This is structurally untestable and harmless.
- Coverage calculation: `(28 / 29) * 100 = 96.55%`, which exceeds the ≥ 90% requirement.
