### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,128 @@
+/// Immutable data class representing the result of a margin calculation.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  bool get isProfitable => profit > 0;
+}
+
+/// Calculator for trading margins, fees, and break-even prices.
+class TradeCalculator {
+  TradeCalculator._();
+
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateInputs(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+
+    final brokerFeeBuy = buyPrice * brokerFeePercent / 100;
+    final brokerFeeSell = sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    final buyTotal = buyPrice + brokerFeeBuy;
+    final sellNet = sellPrice - brokerFeeSell - salesTax;
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFeeBuy + brokerFeeSell,
+      salesTax: salesTax,
+    );
+  }
+
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateInputs(
+      buyPrice: buyPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellFeeFactor = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    return buyTotal / sellFeeFactor;
+  }
+
+  static void _validateInputs({
+    required double buyPrice,
+    double? sellPrice,
+    required double brokerFeePercent,
+    required double salesTaxPercent,
+  }) {
+    if (buyPrice <= 0) {
+      throw ArgumentError.value(
+        buyPrice,
+        'buyPrice',
+        'must be positive',
+      );
+    }
+
+    if (sellPrice != null && sellPrice <= 0) {
+      throw ArgumentError.value(
+        sellPrice,
+        'sellPrice',
+        'must be positive',
+      );
+    }
+
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must not be negative',
+      );
+    }
+
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must not be negative',
+      );
+    }
+
+    final sellFeeFactor = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    if (sellFeeFactor <= 0) {
+      throw ArgumentError.value(
+        brokerFeePercent + salesTaxPercent,
+        'combined fees and taxes',
+        'must be less than 100%',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    test('calculates margin correctly', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1100000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.buyPrice, 1000000);
+      expect(result.sellPrice, 1100000);
+      expect(result.buyTotal, 1010000);
+      expect(result.sellNet, closeTo(1067000, 0.001));
+      expect(result.profit, closeTo(57000, 0.001));
+      expect(result.marginPercent, closeTo(5.6435643564, 0.000001));
+      expect(result.brokerFee, 21000);
+      expect(result.salesTax, 22000);
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('calculates break-even sell price', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result, closeTo(1041237.1134020619, 0.0001));
+      expect(result, greaterThan(1010000));
+    });
+
+    test('reports unprofitable trades', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1020000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.profit, lessThan(0));
+      expect(result.marginPercent, lessThan(0));
+      expect(result.isProfitable, isFalse);
+    });
+
+    test('rejects non-positive prices', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 1100000,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: -1,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: -1,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects invalid fee and tax percentages', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          salesTaxPercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 100.0,
+          salesTaxPercent: 0.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #440

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` with:
  - `TradeMargin` immutable result class (`buyPrice`, `sellPrice`, `buyTotal`, `sellNet`, `profit`, `marginPercent`, `brokerFee`, `salesTax`, `isProfitable`)
  - `TradeCalculator.calculateMargin(...)` — computes buy-side and sell-side fees/taxes, net profit, and margin percentage
  - `TradeCalculator.breakEvenSellPrice(...)` — solves for the sell price where profit is zero given fees and taxes
  - Centralised `_validateInputs` helper that rejects non-positive prices, negative percentages, and combined sell-side fee/tax ≥ 100%
- Added `test/features/market/calculators/margin_calculator_test.dart` with five tests covering happy path, break-even, unprofitable trades, non-positive prices, and invalid fee/tax percentages

## How verified

Exact commands run:

```bash
flutter test test/features/market/calculators/margin_calculator_test.dart
# → 5 passed

flutter test
# → 13 passed

flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
# → No issues found

flutter test --coverage
# → lib/features/market/calculators/margin_calculator.dart: 96.9% line coverage
```

Output digest: all tests green; zero new analyzer warnings on touched files; 96.9% line coverage on the new production file.

## Acceptance criteria coverage

- AC 1: “Implementation matches all behaviors described in the task body (see Notes)” — ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` (`TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, `TradeMargin`)
- AC 2: “All named tests pass the verification command” — ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` (5 tests, all pass)
- AC 3: “No dependencies added unless absolutely required” — ✓ no `pubspec.yaml` or lockfile changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — not violated (only `margin_calculator.dart` and `margin_calculator_test.dart` created)
- Do NOT add third-party dependencies unless required by the task body — not violated (pure Dart, no new packages)
- Do NOT refactor unrelated code in the touched files — not violated (both files are new)

## Notes

- The analyzer reports one existing info-level issue (`dangling_library_doc_comments` in `lib/core/utils/formatters.dart`); this is pre-existing and unrelated to this PR.
- Break-even formula used: `buyTotal / (1 - brokerFeePercent/100 - salesTaxPercent/100)` where `buyTotal = buyPrice * (1 + brokerFeePercent/100)`. This matches the spec’s `Price Calculations` section.

### Coverage

- AC 1 (“Implementation matches all behaviors described in the task body (see Notes)”): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart`
- AC 2 (“All named tests pass the verification command”): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart`
- AC 3 (“No dependencies added unless absolutely required”): ✓ no dependency changes