### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -47,7 +47,7 @@ class TradeCalculator {
     final buyTotal = buyPrice + brokerFeeBuy;
     final sellNet = sellPrice - brokerFeeSell - salesTax;
     final profit = sellNet - buyTotal;
-    final marginPercent = (profit / buyTotal) * 100;
+    final marginPercent = buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
 
     return TradeMargin(
       buyPrice: buyPrice,
@@ -84,35 +84,35 @@ class TradeCalculator {
     required double brokerFeePercent,
     required double salesTaxPercent,
   }) {
-    if (buyPrice <= 0) {
+    if (!buyPrice.isFinite || buyPrice < 0) {
       throw ArgumentError.value(
         buyPrice,
         'buyPrice',
-        'must be positive',
+        'must be a finite non-negative value',
       );
     }
 
-    if (sellPrice != null && sellPrice <= 0) {
+    if (sellPrice != null && (!sellPrice.isFinite || sellPrice < 0)) {
       throw ArgumentError.value(
         sellPrice,
         'sellPrice',
-        'must be positive',
+        'must be a finite non-negative value',
       );
     }
 
-    if (brokerFeePercent < 0) {
+    if (!brokerFeePercent.isFinite || brokerFeePercent < 0) {
       throw ArgumentError.value(
         brokerFeePercent,
         'brokerFeePercent',
-        'must not be negative',
+        'must be a finite non-negative value',
       );
     }
 
-    if (salesTaxPercent < 0) {
+    if (!salesTaxPercent.isFinite || salesTaxPercent < 0) {
       throw ArgumentError.value(
         salesTaxPercent,
         'salesTaxPercent',
-        'must not be negative',
+        'must be a finite non-negative value',
       );
     }
 

--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,128 @@
+/// Immutable data class representing the result of a margin calculation.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  bool get isProfitable => profit > 0;
+}
+
+/// Calculator for trading margins, fees, and break-even prices.
+class TradeCalculator {
+  TradeCalculator._();
+
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateInputs(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+
+    final brokerFeeBuy = buyPrice * brokerFeePercent / 100;
+    final brokerFeeSell = sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    final buyTotal = buyPrice + brokerFeeBuy;
+    final sellNet = sellPrice - brokerFeeSell - salesTax;
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFeeBuy + brokerFeeSell,
+      salesTax: salesTax,
+    );
+  }
+
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateInputs(
+      buyPrice: buyPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellFeeFactor = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    return buyTotal / sellFeeFactor;
+  }
+
+  static void _validateInputs({
+    required double buyPrice,
+    double? sellPrice,
+    required double brokerFeePercent,
+    required double salesTaxPercent,
+  }) {
+    if (buyPrice <= 0) {
+      throw ArgumentError.value(
+        buyPrice,
+        'buyPrice',
+        'must be positive',
+      );
+    }
+
+    if (sellPrice != null && sellPrice <= 0) {
+      throw ArgumentError.value(
+        sellPrice,
+        'sellPrice',
+        'must be positive',
+      );
+    }
+
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must not be negative',
+      );
+    }
+
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must not be negative',
+      );
+    }
+
+    final sellFeeFactor = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    if (sellFeeFactor <= 0) {
+      throw ArgumentError.value(
+        brokerFeePercent + salesTaxPercent,
+        'combined fees and taxes',
+        'must be less than 100%',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    test('calculates margin correctly', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1100000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.buyPrice, 1000000);
+      expect(result.sellPrice, 1100000);
+      expect(result.buyTotal, 1010000);
+      expect(result.sellNet, closeTo(1067000, 0.001));
+      expect(result.profit, closeTo(57000, 0.001));
+      expect(result.marginPercent, closeTo(5.6435643564, 0.000001));
+      expect(result.brokerFee, 21000);
+      expect(result.salesTax, 22000);
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('calculates break-even sell price', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result, closeTo(1041237.1134020619, 0.0001));
+      expect(result, greaterThan(1010000));
+    });
+
+    test('reports unprofitable trades', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1020000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.profit, lessThan(0));
+      expect(result.marginPercent, lessThan(0));
+      expect(result.isProfitable, isFalse);
+    });
+
+    test('rejects non-positive prices', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 1100000,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: -1,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: -1,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects invalid fee and tax percentages', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          salesTaxPercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 100.0,
+          salesTaxPercent: 0.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -46,10 +46,27 @@ void main() {
       expect(result.isProfitable, isFalse);
     });
 
-    test('rejects non-positive prices', () {
+    test('accepts zero buyPrice with zero margin', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 0,
+        sellPrice: 1100000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.buyPrice, 0);
+      expect(result.sellPrice, 1100000);
+      expect(result.buyTotal, 0);
+      expect(result.sellNet, closeTo(1067000, 0.001));
+      expect(result.profit, closeTo(1067000, 0.001));
+      expect(result.marginPercent, 0.0);
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('rejects negative prices', () {
       expect(
         () => TradeCalculator.calculateMargin(
-          buyPrice: 0,
+          buyPrice: -1,
           sellPrice: 1100000,
         ),
         throwsArgumentError,
@@ -59,13 +76,6 @@ void main() {
         () => TradeCalculator.calculateMargin(
           buyPrice: 1000000,
           sellPrice: -1,
-        ),
-        throwsArgumentError,
-      );
-
-      expect(
-        () => TradeCalculator.breakEvenSellPrice(
-          buyPrice: 0,
         ),
         throwsArgumentError,
       );
@@ -112,6 +122,46 @@ void main() {
           buyPrice: 1000000,
           brokerFeePercent: 100.0,
           salesTaxPercent: 0.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects NaN and Infinity inputs', () {
+      // NaN buyPrice
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.nan,
+          sellPrice: 1100000,
+        ),
+        throwsArgumentError,
+      );
+
+      // Infinity buyPrice
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.infinity,
+          sellPrice: 1100000,
+        ),
+        throwsArgumentError,
+      );
+
+      // NaN brokerFee
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      // Infinity salesTax
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          salesTaxPercent: double.infinity,
         ),
         throwsArgumentError,
       );


### PR DESCRIPTION
## Summary
Adds a margin calculator for EVE Online trading with support for broker fees and sales tax.

## Files
- lib/features/market/calculators/margin_calculator.dart
- test/features/market/calculators/margin_calculator_test.dart