### PR TITLE
feat(market): add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,145 @@
+/// Trade calculator for margin and profit calculations.
+class TradeCalculator {
+  /// Calculates the margin and profit for a trade.
+  ///
+  /// [buyPrice] is the price at which the item was bought.
+  /// [sellPrice] is the price at which the item was sold.
+  /// [brokerFeePercent] is the percentage fee charged by the broker (default: 1.0).
+  /// [salesTaxPercent] is the percentage sales tax (default: 2.0).
+  ///
+  /// Returns a [TradeMargin] object containing all calculated values.
+  ///
+  /// Throws [ArgumentError] if any of the parameters are invalid.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    // Validate inputs
+    if (buyPrice < 0) {
+      throw ArgumentError('buyPrice must be non-negative, got $buyPrice');
+    }
+    if (sellPrice < 0) {
+      throw ArgumentError('sellPrice must be non-negative, got $sellPrice');
+    }
+    if (brokerFeePercent < 0) {
+      throw ArgumentError('brokerFeePercent must be non-negative, got $brokerFeePercent');
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError('salesTaxPercent must be non-negative, got $salesTaxPercent');
+    }
+    if (brokerFeePercent + salesTaxPercent >= 100) {
+      throw ArgumentError(
+          'Total fees and taxes must be less than 100%, got ${brokerFeePercent + salesTaxPercent}%');
+    }
+
+    // Calculate buy total (including broker fee)
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+
+    // Calculate sell net (after broker fee and sales tax)
+    final sellNet = sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+
+    // Calculate profit (sell net minus buy total)
+    final profit = sellNet - buyTotal;
+
+    // Calculate margin percentage (profit as percentage of buy total)
+    final marginPercent = buyTotal > 0 ? (profit / buyTotal) * 100 : 0.0;
+
+    // Calculate fees and taxes
+    final brokerFee = buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculates the break-even sell price needed to achieve zero profit/loss.
+  ///
+  /// [buyPrice] is the price at which the item was bought.
+  /// [brokerFeePercent] is the percentage fee charged by the broker (default: 1.0).
+  /// [salesTaxPercent] is the percentage sales tax (default: 2.0).
+  ///
+  /// Returns the sell price needed to break even.
+  ///
+  /// Throws [ArgumentError] if any of the parameters are invalid.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    // Validate inputs
+    if (buyPrice < 0) {
+      throw ArgumentError('buyPrice must be non-negative, got $buyPrice');
+    }
+    if (brokerFeePercent < 0) {
+      throw ArgumentError('brokerFeePercent must be non-negative, got $brokerFeePercent');
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError('salesTaxPercent must be non-negative, got $salesTaxPercent');
+    }
+    if (brokerFeePercent + salesTaxPercent >= 100) {
+      throw ArgumentError(
+          'Total fees and taxes must be less than 100%, got ${brokerFeePercent + salesTaxPercent}%');
+    }
+
+    // Calculate buy total (including broker fee)
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+
+    // Calculate net sell multiplier (1 - broker_fee_percent / 100 - sales_tax_percent / 100)
+    final netSellMultiplier = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    // Return break-even sell price
+    return buyTotal / netSellMultiplier;
+  }
+}
+
+/// Result class for trade margin calculations.
+class TradeMargin {
+  /// The price at which the item was bought.
+  final double buyPrice;
+
+  /// The price at which the item was sold.
+  final double sellPrice;
+
+  /// The total buy price including broker fee.
+  final double buyTotal;
+
+  /// The net sell price after removing fees and taxes.
+  final double sellNet;
+
+  /// The absolute profit or loss from the trade.
+  final double profit;
+
+  /// The margin percentage as a percentage of the buy total.
+  final double marginPercent;
+
+  /// The total broker fee paid (calculated on both buy and sell prices).
+  final double brokerFee;
+
+  /// The sales tax paid on the sell price.
+  final double salesTax;
+
+  /// Whether the trade is profitable (profit > 0).
+  bool get isProfitable => profit > 0;
+
+  /// Creates a new [TradeMargin] instance.
+  TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    group('calculateMargin', () {
+      test('calculates margin correctly', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result.buyTotal, equals(1010000));
+        expect(result.sellNet, closeTo(1067000, 0.0001));
+        expect(result.profit, closeTo(57000, 0.0001));
+        expect(result.marginPercent, closeTo(5.6435643564, 0.0001));
+        expect(result.brokerFee, equals(21000));
+        expect(result.salesTax, equals(22000));
+        expect(result.isProfitable, isTrue);
+      });
+
+      test('calculates break-even sell price', () {
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result, greaterThan(1010000));
+        expect(result, closeTo(1041237.1134, 0.0001));
+      });
+
+      test('marks losing trades as not profitable', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000, // Selling at break-even price - should lose due to fees
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result.profit, lessThan(0));
+        expect(result.marginPercent, lessThan(0));
+        expect(result.isProfitable, isFalse);
+      });
+
+      test('supports zero prices without producing NaN for totals', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 0,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result.buyTotal, equals(0));
+        expect(result.sellNet, equals(0));
+        expect(result.profit, equals(0));
+        expect(result.marginPercent, equals(0));
+        expect(result.brokerFee, equals(0));
+        expect(result.salesTax, equals(0));
+        expect(result.isProfitable, isFalse);
+      });
+
+      test('throws ArgumentError for invalid prices and fee percentages', () {
+        // Test negative buy price
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: -1,
+            sellPrice: 100,
+            brokerFeePercent: 1.0,
+            salesTaxPercent: 2.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('buyPrice'))),
+        );
+
+        // Test negative sell price
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: -1,
+            brokerFeePercent: 1.0,
+            salesTaxPercent: 2.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('sellPrice'))),
+        );
+
+        // Test negative broker fee
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            brokerFeePercent: -1.0,
+            salesTaxPercent: 2.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('brokerFeePercent'))),
+        );
+
+        // Test negative sales tax
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            brokerFeePercent: 1.0,
+            salesTaxPercent: -1.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('salesTaxPercent'))),
+        );
+
+        // Test total fees and taxes >= 100%
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            brokerFeePercent: 50.0,
+            salesTaxPercent: 50.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('Total fees and taxes'))),
+        );
+
+        // Test breakEvenSellPrice negative buy price
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: -1,
+            brokerFeePercent: 1.0,
+            salesTaxPercent: 2.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('buyPrice'))),
+        );
+
+        // Test breakEvenSellPrice negative broker fee
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            brokerFeePercent: -1.0,
+            salesTaxPercent: 2.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('brokerFeePercent'))),
+        );
+
+        // Test breakEvenSellPrice negative sales tax
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            brokerFeePercent: 1.0,
+            salesTaxPercent: -1.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('salesTaxPercent'))),
+        );
+
+        // Test breakEvenSellPrice total fees and taxes >= 100%
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            brokerFeePercent: 50.0,
+            salesTaxPercent: 50.0,
+          ),
+          throwsA(predicate((e) => e is ArgumentError && e.message.contains('Total fees and taxes'))),
+        );
+      });
+    });
+
+    group('breakEvenSellPrice', () {
+      test('calculates correct break-even price', () {
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result, greaterThan(1010000));
+        expect(result, closeTo(1041237.1134, 0.0001));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #444

## What changed

- Added TradeCalculator class with calculateMargin and breakEvenSellPrice static methods
- Added TradeMargin immutable result class with all calculated values
- Added comprehensive tests covering the spec requirements and edge cases
- Implementation matches the **Price Calculations** section from market spec

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
00:00 +0: TradeCalculator calculateMargin calculates margin correctly
00:00 +1: TradeCalculator calculateMargin calculates break-even sell price
00:00 +2: TradeCalculator calculateMargin marks losing trades as not profitable
00:00 +3: TradeCalculator calculateMargin supports zero prices without producing NaN for totals
00:00 +4: TradeCalculator calculateMargin throws ArgumentError for invalid prices and fee percentages
00:00 +5: TradeCalculator breakEvenSellPrice calculates correct break-even price
00:00 +6: All tests passed!

flutter analyze
Analyzing lib/features/market/calculators/margin_calculator.dart...                            
No issues found! (ran in 0.7s)
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) - ✓ addressed in lib/features/market/calculators/margin_calculator.dart
- AC 2: All named tests pass the verification command - ✓ addressed in test/features/market/calculators/margin_calculator_test.dart  
- AC 3: No dependencies added unless absolutely required - ✓ addressed, no new dependencies

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated
- Do NOT add third-party dependencies unless required by the task body: not violated  
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

Implementation addresses the **Price Calculations** section from the market spec with:
- TradeCalculator.calculateMargin: Implements exact formulas for buyTotal, sellNet, profit, marginPercent, brokerFee, salesTax
- TradeCalculator.breakEvenSellPrice: Implements inverse formula for break-even price calculation  
- TradeMargin result class with isProfitable getter
- Comprehensive validation for all input parameters
- Full test coverage including edge cases and error conditions

### Coverage

- AC 1 (verbatim): ✓ addressed in lib/features/market/calculators/margin_calculator.dart and test/features/market/calculators/margin_calculator_test.dart
- AC 2 (verbatim): ✓ addressed in lib/features/market/calculators/margin_calculator.dart and test/features/market/calculators/margin_calculator_test.dart
- AC 3 (verbatim): ✓ addressed in lib/features/market/calculators/margin_calculator.dart