### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,159 @@
+// Market module margin calculator.
+//
+// Provides [TradeCalculator] for margin and break-even price
+// computations, plus the [TradeMargin] value object.
+
+/// Immutable result of a margin calculation.
+class TradeMargin {
+  /// Creates a [TradeMargin].
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Original buy price.
+  final double buyPrice;
+
+  /// Original sell price.
+  final double sellPrice;
+
+  /// Total cost to buy (price + broker fee).
+  final double buyTotal;
+
+  /// Net proceeds from selling (price minus fees and tax).
+  final double sellNet;
+
+  /// Absolute profit in ISK.
+  final double profit;
+
+  /// Profit as a percentage of [buyTotal].
+  final double marginPercent;
+
+  /// Total broker fee for both sides of the trade.
+  final double brokerFee;
+
+  /// Sales tax on the sell price.
+  final double salesTax;
+
+  /// Whether this trade yields a positive profit.
+  bool get isProfitable => profit > 0;
+}
+
+/// Stateless helper for trade calculations.
+class TradeCalculator {
+  TradeCalculator._();
+
+  /// Validates numeric inputs common to both methods.
+  static void _validateCommon({
+    required double buyPrice,
+    required double brokerFeePercent,
+    required double salesTaxPercent,
+  }) {
+    if (!buyPrice.isFinite) {
+      throw ArgumentError.value(buyPrice, 'buyPrice', 'must be finite');
+    }
+    if (buyPrice < 0) {
+      throw ArgumentError.value(buyPrice, 'buyPrice', 'must not be negative');
+    }
+    if (!brokerFeePercent.isFinite) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must be finite',
+      );
+    }
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must not be negative',
+      );
+    }
+    if (!salesTaxPercent.isFinite) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must be finite',
+      );
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must not be negative',
+      );
+    }
+    if ((brokerFeePercent + salesTaxPercent) >= 100) {
+      throw ArgumentError(
+        'Combined sell-side fees must be below 100% '
+        '(got brokerFeePercent=$brokerFeePercent, '
+        'salesTaxPercent=$salesTaxPercent)',
+      );
+    }
+  }
+
+  /// Calculates the margin for a buy-and-sell trade.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateCommon(
+      buyPrice: buyPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+
+    if (!sellPrice.isFinite) {
+      throw ArgumentError.value(sellPrice, 'sellPrice', 'must be finite');
+    }
+    if (sellPrice < 0) {
+      throw ArgumentError.value(sellPrice, 'sellPrice', 'must not be negative');
+    }
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Computes the break-even sell price for a given buy price and fees.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateCommon(
+      buyPrice: buyPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellFeeMultiplier =
+        1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    return buyTotal / sellFeeMultiplier;
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,286 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator.calculateMargin', () {
+    test('calculates margin correctly', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1100000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(margin.buyPrice, 1000000);
+      expect(margin.sellPrice, 1100000);
+      expect(margin.buyTotal, 1010000);
+      expect(margin.sellNet, 1067000);
+      expect(margin.profit, 57000);
+      expect(margin.marginPercent, closeTo(5.643564356, 0.0000001));
+      expect(margin.brokerFee, 21000);
+      expect(margin.salesTax, 22000);
+      expect(margin.isProfitable, isTrue);
+    });
+
+    test('identifies an unprofitable trade', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1000000,
+      );
+
+      expect(margin.buyTotal, 1010000);
+      expect(margin.sellNet, 970000);
+      expect(margin.profit, -40000);
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('returns zero values for zero buy and sell prices', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 0,
+        sellPrice: 0,
+      );
+
+      expect(margin.buyTotal, 0);
+      expect(margin.sellNet, 0);
+      expect(margin.profit, 0);
+      expect(margin.marginPercent, 0);
+      expect(margin.brokerFee, 0);
+      expect(margin.salesTax, 0);
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('throws ArgumentError for invalid margin inputs', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: -1,
+          sellPrice: 100,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.nan,
+          sellPrice: 100,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.infinity,
+          sellPrice: 100,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: -1,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          brokerFeePercent: -1,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          brokerFeePercent: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          brokerFeePercent: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          salesTaxPercent: -1,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          salesTaxPercent: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          salesTaxPercent: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          brokerFeePercent: 100.0,
+          salesTaxPercent: 0.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeCalculator.breakEvenSellPrice', () {
+    test('calculates break-even sell price', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result, closeTo(1041237.1134020619, 0.0000001));
+      expect(result, greaterThan(1010000));
+    });
+
+    test('returns zero when buy price is zero', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 0,
+      );
+
+      expect(result, 0);
+    });
+
+    test('throws ArgumentError for invalid break-even inputs', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: -1,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: -1,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          salesTaxPercent: -1,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          salesTaxPercent: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          salesTaxPercent: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: 100.0,
+          salesTaxPercent: 0.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #449

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` containing:
  - `TradeCalculator` — stateless helper with private constructor, static methods `calculateMargin(...)` and `breakEvenSellPrice(...)`
  - `TradeMargin` — immutable const value object with fields `buyPrice`, `sellPrice`, `buyTotal`, `sellNet`, `profit`, `marginPercent`, `brokerFee`, `salesTax`, and `isProfitable` getter
- Added `test/features/market/calculators/margin_calculator_test.dart` with 7 tests covering profitable, unprofitable, zero-price, break-even, and invalid-input branches

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart --coverage
flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
```

Output digest:
- All 7 tests passed
- 97.22% line coverage on `lib/features/market/calculators/margin_calculator.dart`
- Zero analyzer warnings on touched files

## Acceptance criteria coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ covered in `lib/features/market/calculators/margin_calculator.dart`
- All named tests pass the verification command: ✓ `flutter test` → 7/7 passed
- No dependencies added unless absolutely required: ✓ no pubspec.yaml changes
- Capability 'Margin calculator' is implemented per spec: ✓ `TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, and `TradeMargin.isProfitable` implemented per Market Module Specification §7 Price Calculations
- Tests cover the new capability with ≥ 90% line coverage on touched files: ✓ 97.22% on `margin_calculator.dart`
- `flutter analyze` reports zero new warnings: ✓ no warnings on touched files
- PR body documents which spec sections are addressed: ✓ this section references Market Module Specification §7 Price Calculations

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/features/market/calculators/margin_calculator.dart` and `test/features/market/calculators/margin_calculator_test.dart` were created
- Do NOT add third-party dependencies unless required by the task body: not violated — no pubspec.yaml or pubspec.lock changes
- Do NOT refactor unrelated code in the touched files: not violated — both files are new and contain only margin calculator code

## Notes

- The spec-exact formula output for `breakEvenSellPrice(1000000, 1.0, 2.0)` is `1041237.1134020619` (`1010000 / 0.97`), confirmed by test
- The `marginPercent` formula handles `buyTotal == 0` with explicit `0.0` branch to avoid division-by-zero, confirmed by zero-price test
- Non-finite value checks (`NaN`, `infinity`) are covered by tests; one uncovered line is the `TradeCalculator._()` private constructor (line 50), which is by design and unreachable from tests