### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,165 @@
+/// Value object holding all calculated margin fields for a trade.
+///
+/// All fields are immutable [double] values returned by
+/// [TradeCalculator.calculateMargin].
+class TradeMargin {
+  /// Price at which the item was bought.
+  final double buyPrice;
+
+  /// Price at which the item was sold (or is expected to be sold).
+  final double sellPrice;
+
+  /// Total cost including broker fee: `buyPrice * (1 + brokerFee% / 100)`.
+  final double buyTotal;
+
+  /// Net proceeds after broker fee and sales tax:
+  /// `sellPrice * (1 - brokerFee% / 100 - salesTax% / 100)`.
+  final double sellNet;
+
+  /// Profit (or loss): `sellNet - buyTotal`.
+  final double profit;
+
+  /// Margin as a percentage of buyTotal:
+  /// `(profit / buyTotal) * 100`, or `0.0` when buyTotal is zero.
+  final double marginPercent;
+
+  /// Total broker fee paid on both sides of the trade.
+  final double brokerFee;
+
+  /// Total sales tax paid when selling.
+  final double salesTax;
+
+  /// Immutable value object.
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Whether the trade generated a positive profit.
+  bool get isProfitable => profit > 0;
+}
+
+/// Stateless utility for computing trade margins and break-even prices.
+///
+/// All methods are static. Instantiation is forbidden via a private
+/// constructor.
+class TradeCalculator {
+  // coverage:ignore-line — private constructor; class has only static methods
+  const TradeCalculator._();
+
+  /// Validates that [value] is finite and non-negative.
+  ///
+  /// Throws [ArgumentError] if the value is NaN, infinite, or negative.
+  static void _validateNonNegative(double value, String paramName) {
+    if (value.isNaN || value.isInfinite || value < 0) {
+      throw ArgumentError.value(
+        value,
+        paramName,
+        'must be a finite non-negative number',
+      );
+    }
+  }
+
+  /// Calculates margin details for a trade.
+  ///
+  /// [buyPrice] and [sellPrice] are the per-unit prices.
+  /// [brokerFeePercent] defaults to 1.0%; [salesTaxPercent] defaults to 2.0%.
+  ///
+  /// Returns a [TradeMargin] with all calculated fields.
+  ///
+  /// Throws [ArgumentError] if any price or fee/tax input is invalid
+  /// (NaN, infinite, or negative), or if brokerFeePercent + salesTaxPercent
+  /// is >= 100 (which would produce zero or negative sellNet).
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateNonNegative(buyPrice, 'buyPrice');
+    _validateNonNegative(sellPrice, 'sellPrice');
+    _validateNonNegative(brokerFeePercent, 'brokerFeePercent');
+    _validateNonNegative(salesTaxPercent, 'salesTaxPercent');
+
+    final totalFeePercent = brokerFeePercent + salesTaxPercent;
+    if (totalFeePercent >= 100) {
+      throw ArgumentError.value(
+        totalFeePercent,
+        'totalFeePercent',
+        'must be less than 100',
+      );
+    }
+
+    // buyTotal = buyPrice * (1 + brokerFeePercent / 100)
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+
+    // sellNet = sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100)
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+
+    // profit = sellNet - buyTotal
+    final profit = sellNet - buyTotal;
+
+    // marginPercent = (profit / buyTotal) * 100, or 0.0 when buyTotal is zero
+    final marginPercent = buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+
+    // brokerFee = buy side + sell side
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+
+    // salesTax = sellPrice * salesTaxPercent / 100
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculates the sell price needed to break even (profit = 0).
+  ///
+  /// Formula: `buyPrice * (1 + brokerFeePercent / 100) /
+  ///           (1 - brokerFeePercent / 100 - salesTaxPercent / 100)`.
+  ///
+  /// [buyPrice] is the per-unit purchase price.
+  /// [brokerFeePercent] defaults to 1.0%; [salesTaxPercent] defaults to 2.0%.
+  ///
+  /// Throws [ArgumentError] if [buyPrice] is invalid (NaN, infinite, or
+  /// negative), or if brokerFeePercent + salesTaxPercent is >= 100.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateNonNegative(buyPrice, 'buyPrice');
+    _validateNonNegative(brokerFeePercent, 'brokerFeePercent');
+    _validateNonNegative(salesTaxPercent, 'salesTaxPercent');
+
+    final totalFeePercent = brokerFeePercent + salesTaxPercent;
+    if (totalFeePercent >= 100) {
+      throw ArgumentError.value(
+        totalFeePercent,
+        'totalFeePercent',
+        'must be less than 100',
+      );
+    }
+
+    // buyTotal = buyPrice * (1 + brokerFeePercent / 100)
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+
+    // breakEvenSellPrice = buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100)
+    return buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    group('calculateMargin', () {
+      /// Spec formula verification:
+      ///   buyTotal  = buyPrice  * (1 + brokerFeePercent / 100)
+      ///   sellNet   = sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100)
+      ///   profit    = sellNet - buyTotal
+      ///   margin%   = (profit / buyTotal) * 100
+      ///   brokerFee = buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100
+      ///   salesTax  = sellPrice * salesTaxPercent / 100
+      test('calculates margin correctly', () {
+        const buyPrice = 1000000.0;
+        const sellPrice = 1100000.0;
+        const brokerFeePercent = 1.0;
+        const salesTaxPercent = 2.0;
+
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: buyPrice,
+          sellPrice: sellPrice,
+          brokerFeePercent: brokerFeePercent,
+          salesTaxPercent: salesTaxPercent,
+        );
+
+        // buyTotal = 1000000 * (1 + 1/100) = 1010000
+        expect(result.buyTotal, equals(1010000.0));
+        // sellNet = 1100000 * (1 - 1/100 - 2/100) = 1100000 * 0.97 = 1067000
+        expect(result.sellNet, equals(1067000.0));
+        // profit = 1067000 - 1010000 = 57000
+        expect(result.profit, equals(57000.0));
+        // margin% = (57000 / 1010000) * 100 ≈ 5.643564356435644
+        expect(result.marginPercent, closeTo(5.643564356435644, 1e-12));
+        // brokerFee = 1000000*0.01 + 1100000*0.01 = 10000 + 11000 = 21000
+        expect(result.brokerFee, equals(21000.0));
+        // salesTax = 1100000 * 0.02 = 22000
+        expect(result.salesTax, equals(22000.0));
+        // 57000 > 0 → isProfitable
+        expect(result.isProfitable, isTrue);
+      });
+
+      test(
+        'marks unprofitable trades when net sell proceeds are below buy total',
+        () {
+          const buyPrice = 1000000.0;
+          const sellPrice = 1000000.0;
+
+          final result = TradeCalculator.calculateMargin(
+            buyPrice: buyPrice,
+            sellPrice: sellPrice,
+          );
+
+          // buyTotal = 1000000 * 1.01 = 1010000
+          // sellNet  = 1000000 * 0.97 = 970000
+          // profit   = 970000 - 1010000 = -40000
+          expect(result.profit, lessThan(0));
+          expect(result.isProfitable, isFalse);
+        },
+      );
+
+      test(
+        'zero buy and sell prices return zero totals without NaN margin',
+        () {
+          final result = TradeCalculator.calculateMargin(
+            buyPrice: 0,
+            sellPrice: 0,
+          );
+
+          expect(result.buyPrice, equals(0.0));
+          expect(result.sellPrice, equals(0.0));
+          expect(result.buyTotal, equals(0.0));
+          expect(result.sellNet, equals(0.0));
+          expect(result.profit, equals(0.0));
+          expect(result.marginPercent, equals(0.0));
+          expect(result.marginPercent.isNaN, isFalse);
+          expect(result.brokerFee, equals(0.0));
+          expect(result.salesTax, equals(0.0));
+          expect(result.isProfitable, isFalse);
+        },
+      );
+
+      test('negative prices throw ArgumentError', () {
+        expect(
+          () => TradeCalculator.calculateMargin(buyPrice: -1, sellPrice: 100),
+          throwsArgumentError,
+        );
+        expect(
+          () => TradeCalculator.calculateMargin(buyPrice: 100, sellPrice: -1),
+          throwsArgumentError,
+        );
+      });
+
+      test('non-finite values throw ArgumentError', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: double.nan,
+            sellPrice: 100,
+          ),
+          throwsArgumentError,
+        );
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: double.infinity,
+          ),
+          throwsArgumentError,
+        );
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            brokerFeePercent: double.nan,
+          ),
+          throwsArgumentError,
+        );
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            salesTaxPercent: double.negativeInfinity,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('total fees at or above 100 percent throw ArgumentError', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            brokerFeePercent: 60,
+            salesTaxPercent: 40,
+          ),
+          throwsArgumentError,
+        );
+      });
+    });
+
+    group('breakEvenSellPrice', () {
+      /// Spec formula:
+      ///   buyTotal = buyPrice * (1 + brokerFeePercent / 100)
+      ///   breakEvenSellPrice = buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100)
+      test('calculates break-even sell price', () {
+        const buyPrice = 1000000.0;
+        const brokerFeePercent = 1.0;
+        const salesTaxPercent = 2.0;
+
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: buyPrice,
+          brokerFeePercent: brokerFeePercent,
+          salesTaxPercent: salesTaxPercent,
+        );
+
+        // buyTotal = 1000000 * 1.01 = 1010000
+        // breakEven = 1010000 / (1 - 0.01 - 0.02) = 1010000 / 0.97
+        //           ≈ 1041237.1134020619
+        expect(result, closeTo(1041237.1134020619, 1e-10));
+        // Must cover buy price + fees: > 1010000
+        expect(result, greaterThan(1010000.0));
+      });
+
+      test('negative buyPrice throws ArgumentError', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(buyPrice: -1),
+          throwsArgumentError,
+        );
+      });
+
+      test('non-finite values throw ArgumentError', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(buyPrice: double.nan),
+          throwsArgumentError,
+        );
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(buyPrice: double.infinity),
+          throwsArgumentError,
+        );
+      });
+
+      test('total fees at or above 100 percent throw ArgumentError', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            brokerFeePercent: 60,
+            salesTaxPercent: 40,
+          ),
+          throwsArgumentError,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #448

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` with:
  - `TradeCalculator` — static utility class with `calculateMargin()` and `breakEvenSellPrice()` methods
  - `TradeMargin` — immutable value object with all calculated fields and `isProfitable` getter
  - Full input validation: NaN, infinite, negative values, and total-fee-edge case (fees ≥ 100%)
- Added `test/features/market/calculators/margin_calculator_test.dart` with 10 unit tests

## How verified

```bash
flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
# No issues found! (ran in 1.5s)

flutter test test/features/market/calculators/margin_calculator_test.dart
# 00:00 +10: All tests passed!

flutter test --coverage test/features/market/calculators/margin_calculator_test.dart
# Coverage: 29/30 = 96.7% (> 90% threshold)
# 1 missed line: private constructor on static-only utility class (documented)

flutter test
# 00:00 +18: All tests passed! (no regressions)
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) — ✓ addressed in `TradeCalculator.calculateMargin()` and `TradeCalculator.breakEvenSellPrice()` (lib/features/market/calculators/margin_calculator.dart)
- AC 2: All named tests pass the verification command — ✓ addressed in all 10 tests in `test/features/market/calculators/margin_calculator_test.dart`
- AC 3: No dependencies added unless absolutely required — ✓ no pubspec.yaml or pubspec.lock changes; only Dart stdlib and flutter_test used

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — ✓ diff touches exactly the 2 expected files
- Do NOT add third-party dependencies unless required by the task body — ✓ zero dependency changes
- Do NOT refactor unrelated code in the touched files — ✓ both files are new; no refactoring performed

## Notes

- Spec sections addressed: Market Module Specification > Price Calculations > TradeCalculator / TradeMargin margin and break-even formulas
- The single uncovered line (line 54) is `const TradeCalculator._()` — a private constructor on a class with only static methods. It exists to prevent instantiation, which is by design.
- Test conventions follow existing patterns from `test/core/utils/formatters_test.dart`: `group()`/`test()` structure, `expect()` with matchers, descriptive test names.

### Coverage

- AC 1 (verbatim): ✓ addressed in TradeCalculator.calculateMargin() and breakEvenSellPrice() (margin_calculator.dart lines 69-147)
- AC 2 (verbatim): ✓ addressed in test/features/market/calculators/margin_calculator_test.dart (10 tests, all passing)
- AC 3 (verbatim): ✓ addressed — no pubspec.yaml or pubspec.lock modifications