### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,119 @@
+/// Result of a trade margin calculation.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Whether the trade yields a positive profit.
+  bool get isProfitable => profit > 0;
+}
+
+/// Pure-Dart calculator for trade margin and break-even analysis.
+///
+/// Implements the [Market module spec's Price Calculations][spec] section.
+///
+/// [spec]: https://github.com/infiquetra/mimir-blueprint/blob/main/platform-specs/03-feature-modules/market/specification.md
+class TradeCalculator {
+  const TradeCalculator._();
+
+  /// Computes the margin of buying at [buyPrice] and selling at [sellPrice].
+  ///
+  /// [brokerFeePercent] and [salesTaxPercent] default to 1.0% and 2.0%
+  /// respectively, reflecting typical EVE Online broker fees and sales tax.
+  ///
+  /// Throws [ArgumentError] if any input is negative, or if the combined
+  /// sell-side deductions ([brokerFeePercent] + [salesTaxPercent]) are 100%
+  /// or greater.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice('buyPrice', buyPrice);
+    _validatePrice('sellPrice', sellPrice);
+    _validateFee('brokerFeePercent', brokerFeePercent);
+    _validateFee('salesTaxPercent', salesTaxPercent);
+    _validateCombinedDeductions(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet = sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// The sell price at which the trade breaks even (profit = 0).
+  ///
+  /// Returns zero when [buyPrice] is zero (a free item has no cost to
+  /// recover).
+  ///
+  /// Throws [ArgumentError] if [buyPrice] is negative, any fee/tax is
+  /// negative, or the combined sell-side deductions are 100% or greater.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice('buyPrice', buyPrice);
+    _validateFee('brokerFeePercent', brokerFeePercent);
+    _validateFee('salesTaxPercent', salesTaxPercent);
+    _validateCombinedDeductions(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    return buyTotal / denominator;
+  }
+
+  static void _validatePrice(String name, double value) {
+    if (value < 0) {
+      throw ArgumentError.value(value, name, 'must be >= 0');
+    }
+  }
+
+  static void _validateFee(String name, double value) {
+    if (value < 0) {
+      throw ArgumentError.value(value, name, 'must be >= 0');
+    }
+  }
+
+  static void _validateCombinedDeductions(
+      double brokerFeePercent, double salesTaxPercent) {
+    if (brokerFeePercent + salesTaxPercent >= 100) {
+      throw ArgumentError(
+        'brokerFeePercent ($brokerFeePercent) + salesTaxPercent '
+        '($salesTaxPercent) = ${brokerFeePercent + salesTaxPercent} '
+        'must be < 100',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    group('calculateMargin', () {
+      test('calculates margin correctly', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result.buyTotal, 1010000);
+        expect(result.sellNet, closeTo(1067000, 0.01));
+        expect(result.profit, closeTo(57000, 0.01));
+        expect(result.marginPercent, closeTo(5.6435643564, 0.0001));
+        expect(result.brokerFee, 21000);
+        expect(result.salesTax, 22000);
+        expect(result.isProfitable, true);
+      });
+
+      test('reports unprofitable trade', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+        );
+
+        expect(result.profit, lessThan(0));
+        expect(result.marginPercent, lessThan(0));
+        expect(result.isProfitable, false);
+      });
+
+      test('handles zero buy price without dividing by zero', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 1100000,
+        );
+
+        expect(result.buyTotal, 0);
+        expect(result.profit, result.sellNet);
+        expect(result.marginPercent, 0);
+      });
+
+      test(
+          'throws ArgumentError for negative prices or fees',
+          () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+              buyPrice: -1, sellPrice: 100),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => TradeCalculator.calculateMargin(
+              buyPrice: 100, sellPrice: -1),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => TradeCalculator.calculateMargin(
+              buyPrice: 100, sellPrice: 100, brokerFeePercent: -1),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => TradeCalculator.calculateMargin(
+              buyPrice: 100, sellPrice: 100, salesTaxPercent: -1),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test(
+          'throws ArgumentError when sell-side deductions are 100 percent or more',
+          () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+              buyPrice: 100,
+              sellPrice: 100,
+              brokerFeePercent: 50,
+              salesTaxPercent: 50),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => TradeCalculator.calculateMargin(
+              buyPrice: 100,
+              sellPrice: 100,
+              brokerFeePercent: 60,
+              salesTaxPercent: 50),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('breakEvenSellPrice', () {
+      test('calculates break-even sell price', () {
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result, greaterThan(1010000));
+        expect(result, closeTo(1041237.1134, 0.01));
+      });
+
+      test('returns zero for zero buy price', () {
+        final result = TradeCalculator.breakEvenSellPrice(buyPrice: 0);
+        expect(result, 0);
+      });
+
+      test('throws ArgumentError for invalid inputs', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(buyPrice: -1),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+              buyPrice: 100, brokerFeePercent: -1),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+              buyPrice: 100, salesTaxPercent: -1),
+          throwsA(isA<ArgumentError>()),
+        );
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+              buyPrice: 100, brokerFeePercent: 50, salesTaxPercent: 50),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #460

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` — pure-Dart `TradeCalculator` class with:
  - `static calculateMargin()` — computes fee-adjusted buy total, tax/fee-adjusted sell net, profit, margin %, broker fee, and sales tax
  - `static breakEvenSellPrice()` — the sell price that yields zero profit after fees/tax
  - `TradeMargin` result class with all computed fields and `isProfitable` getter
- Added `test/features/market/calculators/margin_calculator_test.dart` — 8 tests covering success paths, unprofitable trades, zero-buy edge case, and input validation

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
```
Output: **8/8 tests passed** on first run.

```bash
flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
```
Output: **No issues found!**

```bash
flutter test --coverage test/features/market/calculators/margin_calculator_test.dart
```
Coverage on `margin_calculator.dart`: **33/34 lines = 97.1%** (only uncovered line is the private constructor `const TradeCalculator._();` which is never instantiated — all behavior is static).

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` via `TradeCalculator.calculateMargin()`, `TradeCalculator.breakEvenSellPrice()`, and `TradeMargin` with all spec fields and `isProfitable` getter
- AC 2: All named tests pass the verification command — ✓ all 8 named tests (calculates margin correctly, reports unprofitable trade, handles zero buy price, throws for negative inputs, throws for >=100% deductions, break-even calculation, zero buy break-even, invalid input errors) pass on first invocation
- AC 3: No dependencies added unless absolutely required — ✓ zero new dependencies; production code uses only Dart arithmetic, tests use existing `flutter_test`
- AC 4: `flutter analyze` reports zero new warnings — ✓ analyzer passes with "No issues found!"
- AC 5: PR body documents which spec sections are addressed — ✓ this PR addresses Market Module Specification → **Price Calculations** (`TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, and `TradeMargin`) and the Overview's **Trade Calculator: Margin and profit analysis** capability

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — not violated: diff touches only the 2 expected files
- Do NOT add third-party dependencies unless required by the task body — not violated: no dependency changes
- Do NOT refactor unrelated code in the touched files — not violated: both files are new, no existing code touched

## Notes

No deviations from plan. The spec URL returned 404 during implementation but all formulas and test data were available in the approved plan.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` (TradeCalculator.calculateMargin, TradeCalculator.breakEvenSellPrice, TradeMargin, TradeMargin.isProfitable)
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` (8 tests, all pass first-run)
- AC 3 (No dependencies added unless absolutely required): ✓ no pubspec.yaml or lockfile changes
- AC 4 (`flutter analyze` reports zero new warnings): ✓ analyzer clean on both touched files
- AC 5 (PR body documents which spec sections are addressed): ✓ Market Module Spec → Price Calculations and Overview → Trade Calculator capability documented above