### PR TITLE
[BENCH t01 deepseek-v4-pro-c] feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,137 @@
+/// Result of a trade margin calculation.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Returns true when the trade generates a profit (profit > 0).
+  bool get isProfitable => profit > 0;
+}
+
+/// Calculator for EVE Online trade margin and break-even analysis.
+///
+/// Implements the Market Module Specification → Price Calculations.
+class TradeCalculator {
+  const TradeCalculator._();
+
+  /// Calculates the trade margin for a given buy/sell scenario.
+  ///
+  /// [buyPrice] and [sellPrice] must be >= 0.
+  /// [brokerFeePercent] and [salesTaxPercent] must be >= 0 and their sum
+  /// must be less than 100.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice(buyPrice, 'buyPrice');
+    _validatePrice(sellPrice, 'sellPrice');
+    _validatePercent(brokerFeePercent, 'brokerFeePercent');
+    _validatePercent(salesTaxPercent, 'salesTaxPercent');
+    _validateDeductionSum(brokerFeePercent, salesTaxPercent);
+
+    // buyTotal = buyPrice * (1 + brokerFeePercent / 100)
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+
+    // sellNet = sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100)
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+
+    // profit = sellNet - buyTotal
+    final profit = sellNet - buyTotal;
+
+    // marginPercent = (profit / buyTotal) * 100, with zero-buy guard
+    final double marginPercent =
+        buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+
+    // brokerFee = buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100
+    final brokerFee = buyPrice * brokerFeePercent / 100 +
+        sellPrice * brokerFeePercent / 100;
+
+    // salesTax = sellPrice * salesTaxPercent / 100
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculates the minimum sell price needed to break even.
+  ///
+  /// Formula: breakEvenSellPrice = buyTotal / (1 - brokerFeePercent/100 - salesTaxPercent/100)
+  ///
+  /// [buyPrice] must be >= 0.
+  /// [brokerFeePercent] and [salesTaxPercent] must be >= 0 and their sum
+  /// must be less than 100.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice(buyPrice, 'buyPrice');
+    _validatePercent(brokerFeePercent, 'brokerFeePercent');
+    _validatePercent(salesTaxPercent, 'salesTaxPercent');
+    _validateDeductionSum(brokerFeePercent, salesTaxPercent);
+
+    if (buyPrice == 0) return 0;
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    return buyTotal / denominator;
+  }
+
+  static void _validatePrice(double value, String name) {
+    if (value < 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'must be greater than or equal to 0',
+      );
+    }
+  }
+
+  static void _validatePercent(double value, String name) {
+    if (value < 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'must be greater than or equal to 0',
+      );
+    }
+  }
+
+  static void _validateDeductionSum(
+      double brokerFeePercent, double salesTaxPercent) {
+    final sum = brokerFeePercent + salesTaxPercent;
+    if (sum >= 100) {
+      throw ArgumentError(
+        'brokerFeePercent + salesTaxPercent must be less than 100; got $sum',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    group('calculateMargin', () {
+      test('calculates margin correctly', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result.buyPrice, 1000000);
+        expect(result.sellPrice, 1100000);
+        expect(result.buyTotal, 1010000);
+        expect(result.sellNet, closeTo(1067000, 0.01));
+        expect(result.profit, closeTo(57000, 0.01));
+        expect(result.marginPercent, closeTo(5.6435643564, 0.0001));
+        expect(result.brokerFee, 21000);
+        expect(result.salesTax, 22000);
+        expect(result.isProfitable, isTrue);
+      });
+
+      test('reports unprofitable trade', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 900000,
+        );
+
+        expect(result.profit, lessThan(0));
+        expect(result.marginPercent, lessThan(0));
+        expect(result.isProfitable, isFalse);
+      });
+
+      test('handles zero buy price without dividing by zero', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 100000,
+        );
+
+        expect(result.buyTotal, 0);
+        expect(result.profit, result.sellNet);
+        expect(result.marginPercent, 0);
+        expect(result.isProfitable, isTrue);
+      });
+
+      test('throws ArgumentError for negative prices or fees', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: -1,
+            sellPrice: 100,
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: -1,
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            brokerFeePercent: -1,
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100,
+            sellPrice: 100,
+            salesTaxPercent: -1,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test(
+        'throws ArgumentError when sell-side deductions are 100 percent or more',
+        () {
+          expect(
+            () => TradeCalculator.calculateMargin(
+              buyPrice: 100,
+              sellPrice: 100,
+              brokerFeePercent: 50,
+              salesTaxPercent: 50,
+            ),
+            throwsArgumentError,
+          );
+
+          expect(
+            () => TradeCalculator.calculateMargin(
+              buyPrice: 100,
+              sellPrice: 100,
+              brokerFeePercent: 60,
+              salesTaxPercent: 50,
+            ),
+            throwsArgumentError,
+          );
+        },
+      );
+    });
+
+    group('breakEvenSellPrice', () {
+      test('calculates break-even sell price', () {
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result, greaterThan(1010000));
+        expect(result, closeTo(1041237.1134, 0.01));
+      });
+
+      test('returns zero for zero buy price', () {
+        expect(TradeCalculator.breakEvenSellPrice(buyPrice: 0), 0);
+      });
+
+      test('throws ArgumentError for invalid inputs', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(buyPrice: -1),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            brokerFeePercent: -1,
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            salesTaxPercent: -1,
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100,
+            brokerFeePercent: 50,
+            salesTaxPercent: 50,
+          ),
+          throwsArgumentError,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #465

## What changed

- **`lib/features/market/calculators/margin_calculator.dart`** (new): Pure Dart `TradeCalculator` class with static `calculateMargin()` and `breakEvenSellPrice()` methods, plus `TradeMargin` result class with `isProfitable` getter. Implements the Market Module Specification → Price Calculations section with fee-adjusted buy total, fee/tax-adjusted sell net, profit, margin percent, combined broker fee, sales tax, and break-even sell price formulas.
- **`test/features/market/calculators/margin_calculator_test.dart`** (new): 8 tests covering success paths, unprofitable trades, zero-buy guard, break-even formula, and all validation error paths (negative inputs, sell-side deductions ≥ 100%).

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
```

Output: **8/8 tests passed** on first run. **Analyzer: no issues found.** Coverage on touched production file: **36/37 lines = 97.3%** (only uncovered line is the private `const TradeCalculator._();` constructor, which is unreachable by design since all methods are static).

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — ✓ `TradeCalculator.calculateMargin()`, `TradeCalculator.breakEvenSellPrice()`, and `TradeMargin` implement the Market spec Price Calculations capability (fee-adjusted `buyTotal`, fee/tax-adjusted `sellNet`, `profit`, `marginPercent`, `brokerFee`, `salesTax`, `breakEvenSellPrice`, and `isProfitable`).
- AC 2: All named tests pass the verification command — ✓ all 8 tests pass: `calculates margin correctly`, `reports unprofitable trade`, `handles zero buy price without dividing by zero`, `throws ArgumentError for negative prices or fees`, `throws ArgumentError when sell-side deductions are 100 percent or more`, `calculates break-even sell price`, `returns zero for zero buy price`, `throws ArgumentError for invalid inputs`.
- AC 3: No dependencies added unless absolutely required — ✓ no new dependencies; production file has zero imports, test file imports only existing `flutter_test` dev dependency.
- AC 4: `flutter analyze` reports zero new warnings — ✓ analyzer clean on both touched files.
- AC 5: PR body documents which spec sections are addressed — ✓ this PR addresses Market Module Specification → **Price Calculations** (`TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, `TradeMargin`) and the Overview capability **Trade Calculator: Margin and profit analysis**.

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — diff touches only the 2 expected files.
- Do NOT add third-party dependencies unless required by the task body: not violated — no new dependencies.
- Do NOT refactor unrelated code in the touched files: not violated — both files are new, no existing code refactored.

## Notes

- The default branch for this repo is `develop`, not `main` — PR opened against `develop`.
- Pubspec.lock was regenerated by `flutter test` due to dependency resolution but was reverted before commit per scope discipline.
- The private constructor `const TradeCalculator._();` (line 31) is uncovered (0 hits) because all methods are static — this is the only uncovered line (97.3% coverage).

### Coverage

- AC 1 (verbatim): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `TradeCalculator.calculateMargin()`, `TradeCalculator.breakEvenSellPrice()`, and `TradeMargin` with `isProfitable`
- AC 2 (verbatim): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — all 8 named tests pass
- AC 3 (verbatim): ✓ addressed — no new dependencies, zero-import production file, test file uses only existing `flutter_test`
- AC 4 (verbatim): ✓ addressed — `flutter analyze` clean on both files
- AC 5 (verbatim): ✓ addressed — PR body documents Price Calculations and Trade Calculator sections