### PR TITLE
feat(market): add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,138 @@
+/// Immutable result of a margin calculation.
+///
+/// All fields are final doubles representing the trade's financials
+/// in ISK (or whatever the caller uses).
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// True when the trade yields a positive profit.
+  bool get isProfitable => profit > 0;
+}
+
+/// Pure market margin calculator matching the market module
+/// specification's [TradeCalculator] behavior.
+///
+/// All public methods are static; this class is not meant to be
+/// instantiated.
+class TradeCalculator {
+  // Private constructor — this class is only used statically.
+  TradeCalculator._();
+
+  /// Returns the margin breakdown for a trade with the given
+  /// [buyPrice] and [sellPrice].
+  ///
+  /// Defaults: 1.0% broker fee, 2.0% sales tax.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice(buyPrice, 'buyPrice');
+    _validatePrice(sellPrice, 'sellPrice');
+    _validateFeePercent(brokerFeePercent, 'brokerFeePercent');
+    _validateFeePercent(salesTaxPercent, 'salesTaxPercent');
+    _validateCombinedFees(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+
+    // Broker fee is charged on both sides.
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Returns the sell price at which profit is exactly zero for the
+  /// given [buyPrice], after accounting for broker fees and sales tax.
+  ///
+  /// Defaults: 1.0% broker fee, 2.0% sales tax.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice(buyPrice, 'buyPrice');
+    _validateFeePercent(brokerFeePercent, 'brokerFeePercent');
+    _validateFeePercent(salesTaxPercent, 'salesTaxPercent');
+    _validateCombinedFees(brokerFeePercent, salesTaxPercent);
+
+    // Break-even: buyTotal == sellNet
+    // buyPrice * (1 + bf/100) = sellPrice * (1 - bf/100 - st/100)
+    // sellPrice = buyPrice * (1 + bf/100) / (1 - bf/100 - st/100)
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    return buyTotal / denominator;
+  }
+
+  // --- Validators -------------------------------------------------
+
+  static void _validatePrice(double value, String name) {
+    if (value <= 0 || value.isNaN || value.isInfinite) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'must be a finite positive number',
+      );
+    }
+  }
+
+  static void _validateFeePercent(double value, String name) {
+    if (value < 0 || value.isNaN || value.isInfinite) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'must be a finite non-negative percent (0-100)',
+      );
+    }
+  }
+
+  static void _validateCombinedFees(
+    double brokerFeePercent,
+    double salesTaxPercent,
+  ) {
+    final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    if (denominator <= 0) {
+      throw ArgumentError.value(
+        brokerFeePercent + salesTaxPercent,
+        'brokerFeePercent + salesTaxPercent',
+        'combined broker fee and sales tax must be less than 100% '
+            '(got $brokerFeePercent% + $salesTaxPercent% = '
+            '${brokerFeePercent + salesTaxPercent}%)',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,245 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    test('calculates margin correctly', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1100000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.buyPrice, equals(1000000));
+      expect(result.sellPrice, equals(1100000));
+      expect(result.buyTotal, equals(1010000));
+      expect(result.sellNet, closeTo(1067000, 0.001));
+      expect(result.profit, closeTo(57000, 0.001));
+      expect(result.marginPercent, closeTo(5.6435643564, 0.000001));
+      expect(result.brokerFee, equals(21000));
+      expect(result.salesTax, equals(22000));
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('calculates break-even sell price', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result, closeTo(1041237.1134, 0.0001));
+      expect(result, greaterThan(1010000));
+    });
+
+    test('identifies unprofitable trades', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(result.profit, lessThan(0));
+      expect(result.marginPercent, lessThan(0));
+      expect(result.isProfitable, isFalse);
+    });
+
+    test('uses default broker fee and sales tax percentages', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1100000,
+      );
+
+      // With default 1% broker fee, 2% sales tax
+      expect(result.buyTotal, equals(1010000));
+      expect(result.sellNet, closeTo(1067000, 0.001));
+      expect(result.profit, closeTo(57000, 0.001));
+      expect(result.brokerFee, equals(21000));
+      expect(result.salesTax, equals(22000));
+    });
+
+    test('rejects non-positive prices', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 1000000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: -100,
+          sellPrice: 1000000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: -100,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: 0),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: -100),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects NaN prices', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.nan,
+          sellPrice: 1000000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: double.nan,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: double.nan),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects infinite prices', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.infinity,
+          sellPrice: 1000000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: double.infinity,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: double.infinity),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects invalid fee percentages', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+          brokerFeePercent: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+          salesTaxPercent: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          salesTaxPercent: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects NaN fee percentages', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+          brokerFeePercent: double.nan,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+          salesTaxPercent: double.nan,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects infinite fee percentages', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+          brokerFeePercent: double.infinity,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+          salesTaxPercent: double.infinity,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects combined fees at 100% or more', () {
+      // brokerFeePercent + salesTaxPercent >= 100 means sellNet denominator <= 0
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+          brokerFeePercent: 50,
+          salesTaxPercent: 50,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1000000,
+          brokerFeePercent: 60,
+          salesTaxPercent: 40,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 50,
+          salesTaxPercent: 50,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #470

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` — pure Dart `TradeCalculator` class with static `calculateMargin()` and `breakEvenSellPrice()` methods, plus immutable `TradeMargin` result type
- Added `test/features/market/calculators/margin_calculator_test.dart` — 11 tests covering margin calculation, break-even, unprofitable trades, defaults, and all validation error paths

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
flutter test test/features/market/calculators/margin_calculator_test.dart --coverage
flutter analyze
```

**Output digest:** All 11 tests passed. `dart analyze` reports zero issues.
Coverage on `margin_calculator.dart`: 97.3% (36/37 lines; the one uncovered line is `TradeCalculator._()` — the private constructor that prevents instantiation, intentionally untestable).

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — ✓ addressed by `TradeCalculator.calculateMargin()` and `TradeCalculator.breakEvenSellPrice()` using the exact spec formulas for buyTotal, sellNet, profit, marginPercent, brokerFee, and salesTax
- AC 2: All named tests pass the verification command — ✓ addressed by `calculates margin correctly` and `calculates break-even sell price` tests in `margin_calculator_test.dart`, plus 9 additional edge/error tests
- AC 3: No dependencies added unless absolutely required — ✓ no changes to `pubspec.yaml` or `pubspec.lock`; implementation uses only core Dart

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `lib/features/market/calculators/margin_calculator.dart` and `test/features/market/calculators/margin_calculator_test.dart` changed
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependency changes
- Do NOT refactor unrelated code in the touched files: not violated — both files are new

## Notes

This PR addresses the market spec sections: Overview key feature "Trade Calculator: Margin and profit analysis," Price Calculations (`TradeCalculator.calculateMargin`, `breakEvenSellPrice`, `TradeMargin`), and Testing Strategy named tests for margin and break-even calculations.

### Coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) — ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` (TradeCalculator, TradeMargin)
- AC 2: All named tests pass the verification command — ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart`
- AC 3: No dependencies added unless absolutely required — ✓ verified; no pubspec.yaml/lock changes