### PR TITLE
[BENCH t03] feat(market): Add price checking (all regions)

### DIFF
--- a/lib/features/market/data/repositories/price_repository.dart
+++ b/lib/features/market/data/repositories/price_repository.dart
@@ -1,0 +1,439 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Default region ID for single-region lookups (The Forge).
+const defaultMarketRegionId = 10000002;
+
+/// A single market order quote from ESI or a fake fetcher.
+class MarketOrderQuote {
+  final double price;
+  final int volumeRemain;
+  final bool isBuyOrder;
+
+  const MarketOrderQuote({
+    required this.price,
+    required this.volumeRemain,
+    required this.isBuyOrder,
+  });
+}
+
+/// Aggregated market price data for a single type in a single region.
+class MarketPrice {
+  final int typeId;
+  final String typeName;
+  final double? buyMax;
+  final double? sellMin;
+  final double? buyAvg;
+  final double? sellAvg;
+  final int buyVolume;
+  final int sellVolume;
+  final int regionId;
+  final DateTime updatedAt;
+
+  const MarketPrice({
+    required this.typeId,
+    required this.typeName,
+    this.buyMax,
+    this.sellMin,
+    this.buyAvg,
+    this.sellAvg,
+    this.buyVolume = 0,
+    this.sellVolume = 0,
+    required this.regionId,
+    required this.updatedAt,
+  });
+
+  /// The absolute spread: sellMin - buyMax. Returns `null` if either
+  /// side is unavailable.
+  double? get spread =>
+      (buyMax != null && sellMin != null) ? sellMin! - buyMax! : null;
+
+  /// Spread as a percentage of buyMax. Returns `null` if spread cannot
+  /// be computed or buyMax is 0.
+  double? get spreadPercent {
+    final s = spread;
+    if (s == null || buyMax == null || buyMax == 0) return null;
+    return (s / buyMax!) * 100;
+  }
+
+  /// Margin: sellMin * 0.99 - buyMax * 1.01 (broker-fee approximation).
+  /// Returns `null` if either side is unavailable.
+  double? get margin {
+    if (buyMax == null || sellMin == null) return null;
+    return sellMin! * 0.99 - buyMax! * 1.01;
+  }
+}
+
+/// A price result for a single region, used by all-regions queries.
+class MarketRegionPrice {
+  final int regionId;
+  final String regionName;
+  final MarketPrice price;
+
+  const MarketRegionPrice({
+    required this.regionId,
+    required this.regionName,
+    required this.price,
+  });
+}
+
+/// Exception raised when price operations fail.
+class PriceRepositoryException implements Exception {
+  final String message;
+
+  const PriceRepositoryException(this.message);
+
+  @override
+  String toString() => 'PriceRepositoryException: $message';
+}
+
+/// Signature for a function that fetches market order quotes for a given
+/// type in a given region.
+typedef MarketOrderFetcher = Future<List<MarketOrderQuote>> Function(
+  int typeId,
+  int regionId,
+);
+
+/// The authoritative catalog of known-space EVE market regions.
+///
+/// Excludes non-market / Jove / pseudo regions:
+///   10000004 (UUA-F4), 10000017 (J174102), 10000019 (A821-A),
+///   10000024 (J200727), 10000026 (AD0006).
+const Map<int, String> eveMarketRegions = <int, String>{
+  10000001: 'Derelik',
+  10000002: 'The Forge',
+  10000003: 'Vale of the Silent',
+  10000005: 'Detorid',
+  10000006: 'Wicked Creek',
+  10000007: 'Cache',
+  10000008: 'Scalding Pass',
+  10000009: 'Insmother',
+  10000010: 'Tribute',
+  10000011: 'Great Wildlands',
+  10000012: 'Curse',
+  10000013: 'Malpais',
+  10000014: 'Catch',
+  10000015: 'Venal',
+  10000016: 'Lonetrek',
+  10000018: 'The Spire',
+  10000020: 'Tash-Murkon',
+  10000021: 'Outer Passage',
+  10000022: 'Stain',
+  10000023: 'Pure Blind',
+  10000025: 'Immensea',
+  10000027: 'Etherium Reach',
+  10000028: 'Molden Heath',
+  10000029: 'Geminate',
+  10000030: 'Heimatar',
+  10000031: 'Impass',
+  10000032: 'Sinq Laison',
+  10000033: 'The Citadel',
+  10000034: 'The Kalevala Expanse',
+  10000035: 'Deklein',
+  10000036: 'Devoid',
+  10000037: 'Everyshore',
+  10000038: 'The Bleak Lands',
+  10000039: 'Esoteria',
+  10000040: 'Oasa',
+  10000041: 'Syndicate',
+  10000042: 'Metropolis',
+  10000043: 'Domain',
+  10000044: 'Solitude',
+  10000045: 'Tenal',
+  10000046: 'Fade',
+  10000047: 'Providence',
+  10000048: 'Placid',
+  10000049: 'Khanid',
+  10000050: 'Querious',
+  10000051: 'Cloud Ring',
+  10000052: 'Kador',
+  10000053: 'Cobalt Edge',
+  10000054: 'Aridia',
+  10000055: 'Branch',
+  10000056: 'Feythabolis',
+  10000057: 'Outer Ring',
+  10000058: 'Fountain',
+  10000059: 'Paragon Soul',
+  10000060: 'Delve',
+  10000061: 'Tenerifis',
+  10000062: 'Omist',
+  10000063: 'Period Basis',
+  10000064: 'Essence',
+  10000065: 'Kor-Azor',
+  10000066: 'Perrigen Falls',
+  10000067: 'Genesis',
+  10000068: 'Verge Vendor',
+  10000069: 'Black Rise',
+  10000070: 'Pochven',
+};
+
+/// Repository for fetching and aggregating EVE market price data.
+///
+/// Supports single-region and all-regions price lookups with injectable
+/// order fetching for testability.
+class PriceRepository {
+  final Dio _dio;
+  final MarketOrderFetcher? _orderFetcher;
+  final Map<int, String> _marketRegions;
+  final DateTime Function() _clock;
+
+  PriceRepository({
+    Dio? dio,
+    MarketOrderFetcher? orderFetcher,
+    Map<int, String>? marketRegions,
+    DateTime Function()? clock,
+  })  : _dio = dio ?? Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest')),
+        _orderFetcher = orderFetcher,
+        _marketRegions = marketRegions ?? eveMarketRegions,
+        _clock = clock ?? (() => DateTime.now());
+
+  /// Returns the configured market-region catalog.
+  Map<int, String> get marketRegions => Map.unmodifiable(_marketRegions);
+
+  /// The Dio instance used for ESI calls (exposed for testing).
+  Dio get dio => _dio;
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  /// Fetches and aggregates market prices for a single type in a single
+  /// region.
+  Future<MarketPrice> getPrice(
+    int typeId,
+    int regionId, {
+    String? typeName,
+  }) async {
+    if (typeId <= 0) {
+      throw ArgumentError.value(
+        typeId,
+        'typeId',
+        'expected positive EVE type id',
+      );
+    }
+    if (!_marketRegions.containsKey(regionId)) {
+      throw ArgumentError.value(
+        regionId,
+        'regionId',
+        'expected known market region id',
+      );
+    }
+
+    final orders = await (_orderFetcher?.call(typeId, regionId) ??
+        _fetchWithDio(typeId, regionId));
+    return _aggregate(orders, typeId, regionId, typeName);
+  }
+
+  /// Fetches and aggregates market prices for a single type across every
+  /// configured region.
+  ///
+  /// Returns one [MarketRegionPrice] per region in [marketRegions]
+  /// insertion order. Throws [PriceRepositoryException] if any region
+  /// fetch fails — partial results are never returned.
+  Future<List<MarketRegionPrice>> getPricesAcrossAllRegions(
+    int typeId, {
+    String? typeName,
+  }) async {
+    if (typeId <= 0) {
+      throw ArgumentError.value(
+        typeId,
+        'typeId',
+        'expected positive EVE type id',
+      );
+    }
+
+    final results = <MarketRegionPrice>[];
+    for (final entry in _marketRegions.entries) {
+      try {
+        final price = await getPrice(typeId, entry.key, typeName: typeName);
+        results.add(MarketRegionPrice(
+          regionId: entry.key,
+          regionName: entry.value,
+          price: price,
+        ));
+      } catch (e) {
+        throw PriceRepositoryException(
+          'Failed to fetch prices for region ${entry.key} (${entry.value}): $e',
+        );
+      }
+    }
+    return results;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  MarketPrice _aggregate(
+    List<MarketOrderQuote> orders,
+    int typeId,
+    int regionId,
+    String? typeName,
+  ) {
+    final buys = orders.where((o) => o.isBuyOrder).toList();
+    final sells = orders.where((o) => !o.isBuyOrder).toList();
+
+    final buyMax = buys.isEmpty
+        ? null
+        : buys.map((o) => o.price).reduce((a, b) => a > b ? a : b);
+    final sellMin = sells.isEmpty
+        ? null
+        : sells.map((o) => o.price).reduce((a, b) => a < b ? a : b);
+    final buyAvg = buys.isEmpty
+        ? null
+        : buys.map((o) => o.price).reduce((a, b) => a + b) / buys.length;
+    final sellAvg = sells.isEmpty
+        ? null
+        : sells.map((o) => o.price).reduce((a, b) => a + b) / sells.length;
+    final buyVolume = buys.fold<int>(0, (sum, o) => sum + o.volumeRemain);
+    final sellVolume = sells.fold<int>(0, (sum, o) => sum + o.volumeRemain);
+
+    return MarketPrice(
+      typeId: typeId,
+      typeName: typeName ?? 'Type $typeId',
+      buyMax: buyMax,
+      sellMin: sellMin,
+      buyAvg: buyAvg,
+      sellAvg: sellAvg,
+      buyVolume: buyVolume,
+      sellVolume: sellVolume,
+      regionId: regionId,
+      updatedAt: _clock(),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Default ESI fetcher
+  // ---------------------------------------------------------------------------
+
+  /// The default ESI order fetching path. Uses [dio] to request every page
+  /// of `/markets/{region_id}/orders/` with `type_id`, `order_type=all`,
+  /// and `datasource=tranquility`.
+  ///
+  /// Exposed as a public method so tests can verify pagination via a fake
+  /// Dio adapter injected into the [dio] field.
+  Future<List<MarketOrderQuote>> _fetchWithDio(
+    int typeId,
+    int regionId,
+  ) async {
+    return _fetchAllPages(_dio, typeId, regionId);
+  }
+
+  static Future<List<MarketOrderQuote>> _fetchAllPages(
+    Dio dio,
+    int typeId,
+    int regionId,
+  ) async {
+    final allOrders = <MarketOrderQuote>[];
+    int totalPages = 1;
+
+    // Page 1 — also reads X-Pages header.
+    final page1Response = await _fetchSinglePage(dio, typeId, regionId, 1);
+    final headerValue = page1Response.headers.value('x-pages');
+    if (headerValue != null) {
+      final parsed = int.tryParse(headerValue);
+      if (parsed == null || parsed <= 0) {
+        throw PriceRepositoryException(
+          'Invalid X-Pages header for typeId=$typeId regionId=$regionId '
+          'page=1: "$headerValue"',
+        );
+      }
+      totalPages = parsed;
+    }
+
+    allOrders.addAll(page1Response.data as List<MarketOrderQuote>);
+
+    // Remaining pages 2..totalPages.
+    for (int page = 2; page <= totalPages; page++) {
+      final response = await _fetchSinglePage(dio, typeId, regionId, page);
+      allOrders.addAll(response.data as List<MarketOrderQuote>);
+    }
+
+    return allOrders;
+  }
+
+  static Future<Response<List<MarketOrderQuote>>> _fetchSinglePage(
+    Dio dio,
+    int typeId,
+    int regionId,
+    int page,
+  ) async {
+    try {
+      final response = await dio.get(
+        '/markets/$regionId/orders/',
+        queryParameters: {
+          'type_id': typeId,
+          'order_type': 'all',
+          'datasource': 'tranquility',
+          'page': page,
+        },
+      );
+
+      final body = response.data;
+      if (body is! List) {
+        throw PriceRepositoryException(
+          'Expected JSON array from /markets/$regionId/orders/ page=$page, '
+          'got ${body.runtimeType}',
+        );
+      }
+
+      final orders = <MarketOrderQuote>[];
+      for (int i = 0; i < body.length; i++) {
+        final item = body[i];
+        if (item is! Map<String, dynamic>) {
+          throw PriceRepositoryException(
+            'Invalid order entry at index $i page=$page region=$regionId: '
+            'expected Map, got ${item.runtimeType}',
+          );
+        }
+        final price = item['price'];
+        final volumeRemain = item['volume_remain'];
+        final isBuyOrder = item['is_buy_order'];
+
+        if (price is! num) {
+          throw PriceRepositoryException(
+            'Missing or invalid "price" at index $i page=$page '
+            'region=$regionId: got ${price.runtimeType}',
+          );
+        }
+        if (volumeRemain is! int) {
+          throw PriceRepositoryException(
+            'Missing or invalid "volume_remain" at index $i page=$page '
+            'region=$regionId: got ${volumeRemain.runtimeType}',
+          );
+        }
+        if (isBuyOrder is! bool) {
+          throw PriceRepositoryException(
+            'Missing or invalid "is_buy_order" at index $i page=$page '
+            'region=$regionId: got ${isBuyOrder.runtimeType}',
+          );
+        }
+
+        orders.add(MarketOrderQuote(
+          price: price.toDouble(),
+          volumeRemain: volumeRemain,
+          isBuyOrder: isBuyOrder,
+        ));
+      }
+
+      return Response(
+        data: orders,
+        statusCode: response.statusCode,
+        requestOptions: response.requestOptions,
+        headers: response.headers,
+      );
+    } on PriceRepositoryException {
+      rethrow;
+    } catch (e) {
+      throw PriceRepositoryException(
+        'Failed to fetch /markets/$regionId/orders/ page=$page for '
+        'typeId=$typeId: $e',
+      );
+    }
+  }
+}
+
+/// Riverpod provider for [PriceRepository].
+final priceRepositoryProvider = Provider<PriceRepository>(
+  (ref) => PriceRepository(),
+);

--- a/lib/features/market/presentation/price_check_screen.dart
+++ b/lib/features/market/presentation/price_check_screen.dart
@@ -129,6 +129,7 @@ class _PriceCheckScreenState extends ConsumerState<PriceCheckScreen> {
       if (_showAllRegions) {
         final results =
             await repo.getPricesAcrossAllRegions(parsed, typeName: typeName);
+        _sortPricesBySellMin(results);
         setState(() => _prices = AsyncData(results));
       } else {
         final price =
@@ -147,6 +148,17 @@ class _PriceCheckScreenState extends ConsumerState<PriceCheckScreen> {
     } catch (e) {
       setState(() => _prices = AsyncError(e, StackTrace.current));
     }
+  }
+
+  void _sortPricesBySellMin(List<MarketRegionPrice> prices) {
+    prices.sort((a, b) {
+      final sa = a.price.sellMin;
+      final sb = b.price.sellMin;
+      if (sa != null && sb != null) return sa.compareTo(sb);
+      if (sa != null) return -1;
+      if (sb != null) return 1;
+      return a.regionName.compareTo(b.regionName);
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -237,18 +249,8 @@ class _PriceResultsList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Sort a copy for display without mutating repository order.
-    final sorted = List<MarketRegionPrice>.from(prices)..sort((a, b) {
-      final sa = a.price.sellMin;
-      final sb = b.price.sellMin;
-      if (sa != null && sb != null) return sa.compareTo(sb);
-      if (sa != null) return -1;
-      if (sb != null) return 1;
-      return a.regionName.compareTo(b.regionName);
-    });
-
     return Column(
-      children: sorted
+      children: prices
           .map((rp) => _PriceResultTile(regionPrice: rp))
           .toList(),
     );

--- a/lib/features/market/presentation/price_check_screen.dart
+++ b/lib/features/market/presentation/price_check_screen.dart
@@ -130,11 +130,13 @@ class _PriceCheckScreenState extends ConsumerState<PriceCheckScreen> {
         final results =
             await repo.getPricesAcrossAllRegions(parsed, typeName: typeName);
         _sortPricesBySellMin(results);
+        if (!mounted) return;
         setState(() => _prices = AsyncData(results));
       } else {
         final price =
             await repo.getPrice(parsed, _selectedRegionId, typeName: typeName);
         final name = repo.marketRegions[_selectedRegionId]!;
+        if (!mounted) return;
         setState(() {
           _prices = AsyncData([
             MarketRegionPrice(
@@ -146,6 +148,7 @@ class _PriceCheckScreenState extends ConsumerState<PriceCheckScreen> {
         });
       }
     } catch (e) {
+      if (!mounted) return;
       setState(() => _prices = AsyncError(e, StackTrace.current));
     }
   }

--- a/lib/features/market/presentation/price_check_screen.dart
+++ b/lib/features/market/presentation/price_check_screen.dart
@@ -1,0 +1,366 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/utils/formatters.dart';
+import '../../../core/widgets/eve_type_icon.dart';
+import '../data/repositories/price_repository.dart';
+
+/// A self-contained, accessible price-checker screen for EVE market data.
+///
+/// Supports single-region and all-regions lookups with screen-reader
+/// announcements for dynamic state transitions.
+class PriceCheckScreen extends ConsumerStatefulWidget {
+  const PriceCheckScreen({super.key});
+
+  @override
+  ConsumerState<PriceCheckScreen> createState() => _PriceCheckScreenState();
+}
+
+class _PriceCheckScreenState extends ConsumerState<PriceCheckScreen> {
+  final _typeIdController = TextEditingController();
+  final _typeNameController = TextEditingController();
+  int _selectedRegionId = defaultMarketRegionId;
+  bool _showAllRegions = true;
+  String? _validationError;
+  AsyncValue<List<MarketRegionPrice>>? _prices;
+
+  @override
+  void dispose() {
+    _typeIdController.dispose();
+    _typeNameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Price Checker')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // --- Type ID input ---
+            TextField(
+              controller: _typeIdController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: 'Type ID'),
+            ),
+            const SizedBox(height: 12),
+
+            // --- Optional type name ---
+            TextField(
+              controller: _typeNameController,
+              decoration: const InputDecoration(labelText: 'Type name (optional)'),
+            ),
+            const SizedBox(height: 12),
+
+            // --- All-regions toggle ---
+            SwitchListTile(
+              title: const Text('Check all regions'),
+              value: _showAllRegions,
+              onChanged: (v) => setState(() => _showAllRegions = v),
+            ),
+            const SizedBox(height: 4),
+
+            // --- Single-region dropdown ---
+            _RegionDropdown(
+              selectedRegionId: _selectedRegionId,
+              enabled: !_showAllRegions,
+              regions: ref.read(priceRepositoryProvider).marketRegions,
+              onChanged: (id) => setState(() => _selectedRegionId = id),
+            ),
+            const SizedBox(height: 16),
+
+            // --- Validation error ---
+            if (_validationError != null) ...[
+              Semantics(
+                liveRegion: true,
+                label: 'Invalid Type ID: $_validationError',
+                child: Text(
+                  _validationError!,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ),
+              const SizedBox(height: 16),
+            ],
+
+            // --- Action button ---
+            FilledButton(
+              onPressed: _checkPrices,
+              child: const Text('Check Prices'),
+            ),
+            const SizedBox(height: 16),
+
+            // --- Results ---
+            if (_prices != null) _buildResults(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Price fetching
+  // ---------------------------------------------------------------------------
+
+  Future<void> _checkPrices() async {
+    final raw = _typeIdController.text.trim();
+    final parsed = int.tryParse(raw);
+    if (parsed == null || parsed <= 0) {
+      setState(() {
+        _validationError = 'Enter a positive EVE Type ID.';
+        _prices = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _validationError = null;
+      _prices = const AsyncLoading();
+    });
+
+    final repo = ref.read(priceRepositoryProvider);
+    final typeName = _typeNameController.text.trim().isEmpty
+        ? null
+        : _typeNameController.text.trim();
+
+    try {
+      if (_showAllRegions) {
+        final results =
+            await repo.getPricesAcrossAllRegions(parsed, typeName: typeName);
+        setState(() => _prices = AsyncData(results));
+      } else {
+        final price =
+            await repo.getPrice(parsed, _selectedRegionId, typeName: typeName);
+        final name = repo.marketRegions[_selectedRegionId]!;
+        setState(() {
+          _prices = AsyncData([
+            MarketRegionPrice(
+              regionId: _selectedRegionId,
+              regionName: name,
+              price: price,
+            ),
+          ]);
+        });
+      }
+    } catch (e) {
+      setState(() => _prices = AsyncError(e, StackTrace.current));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Results rendering
+  // ---------------------------------------------------------------------------
+
+  Widget _buildResults() {
+    return _prices!.when(
+      loading: () => Semantics(
+        liveRegion: true,
+        label: 'Loading market prices',
+        child: const Column(
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 8),
+            Text('Loading prices...'),
+          ],
+        ),
+      ),
+      error: (err, _) => Semantics(
+        liveRegion: true,
+        label: 'Failed to load market prices: $err',
+        child: Text(
+          'Failed to load prices: $err',
+          style: TextStyle(color: Theme.of(context).colorScheme.error),
+        ),
+      ),
+      data: (prices) {
+        if (prices.isEmpty) {
+          return Semantics(
+            liveRegion: true,
+            label: 'No market regions returned',
+            child: const Text('No market regions returned'),
+          );
+        }
+        return Semantics(
+          liveRegion: true,
+          label: 'Market price results loaded',
+          child: _PriceResultsList(prices: prices),
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Region dropdown
+// ---------------------------------------------------------------------------
+
+class _RegionDropdown extends StatelessWidget {
+  final int selectedRegionId;
+  final bool enabled;
+  final Map<int, String> regions;
+  final ValueChanged<int> onChanged;
+
+  const _RegionDropdown({
+    required this.selectedRegionId,
+    required this.enabled,
+    required this.regions,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final items = regions.entries
+        .map((e) => DropdownMenuItem(value: e.key, child: Text(e.value)))
+        .toList();
+
+    return DropdownButtonFormField<int>(
+      initialValue: items.any((i) => i.value == selectedRegionId)
+          ? selectedRegionId
+          : null,
+      items: items,
+      onChanged: enabled ? (v) => onChanged(v!) : null,
+      decoration: const InputDecoration(labelText: 'Region'),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Results list
+// ---------------------------------------------------------------------------
+
+class _PriceResultsList extends StatelessWidget {
+  final List<MarketRegionPrice> prices;
+
+  const _PriceResultsList({required this.prices});
+
+  @override
+  Widget build(BuildContext context) {
+    // Sort a copy for display without mutating repository order.
+    final sorted = List<MarketRegionPrice>.from(prices)..sort((a, b) {
+      final sa = a.price.sellMin;
+      final sb = b.price.sellMin;
+      if (sa != null && sb != null) return sa.compareTo(sb);
+      if (sa != null) return -1;
+      if (sb != null) return 1;
+      return a.regionName.compareTo(b.regionName);
+    });
+
+    return Column(
+      children: sorted
+          .map((rp) => _PriceResultTile(regionPrice: rp))
+          .toList(),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single result tile
+// ---------------------------------------------------------------------------
+
+class _PriceResultTile extends StatelessWidget {
+  final MarketRegionPrice regionPrice;
+
+  const _PriceResultTile({required this.regionPrice});
+
+  @override
+  Widget build(BuildContext context) {
+    final p = regionPrice.price;
+    final theme = Theme.of(context);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            // Decorative item icon.
+            ExcludeSemantics(
+              child: EveTypeIcon(typeId: p.typeId, size: 48),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    regionPrice.regionName,
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 4),
+                  _PriceMetric(
+                    label: 'Buy',
+                    value: p.buyMax != null ? formatIskCompact(p.buyMax!) : 'No buy orders',
+                  ),
+                  _PriceMetric(
+                    label: 'Sell',
+                    value: p.sellMin != null ? formatIskCompact(p.sellMin!) : 'No sell orders',
+                  ),
+                  if (p.spread != null)
+                    _PriceMetric(
+                      label: 'Spread',
+                      value: formatIskCompact(p.spread!),
+                    ),
+                  if (p.margin != null)
+                    _PriceMetric(
+                      label: 'Margin',
+                      value: formatIskCompact(p.margin!),
+                    ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _PriceMetric(
+                          label: 'Buy vol',
+                          value: '${p.buyVolume}',
+                        ),
+                      ),
+                      Expanded(
+                        child: _PriceMetric(
+                          label: 'Sell vol',
+                          value: '${p.sellVolume}',
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A compact row showing a label and value.
+class _PriceMetric extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _PriceMetric({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 60,
+            child: Text(
+              label,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                fontSize: 12,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(value, style: const TextStyle(fontSize: 12)),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/market/data/repositories/price_repository_test.dart
+++ b/test/features/market/data/repositories/price_repository_test.dart
@@ -1,0 +1,940 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/data/repositories/price_repository.dart';
+import 'package:mimir/features/market/presentation/price_check_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Fake order fetcher (records calls, returns canned results)
+// ---------------------------------------------------------------------------
+
+class FakeOrderFetcher {
+  final List<({int typeId, int regionId})> calls = [];
+  Future<List<MarketOrderQuote>> Function(int typeId, int regionId)? onFetch;
+
+  Future<List<MarketOrderQuote>> call(int typeId, int regionId) async {
+    calls.add((typeId: typeId, regionId: regionId));
+    if (onFetch != null) return onFetch!(typeId, regionId);
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fake Dio HttpClientAdapter for pagination tests
+// ---------------------------------------------------------------------------
+
+class FakeHttpClientAdapter implements HttpClientAdapter {
+  final List<({int statusCode, Map<String, List<String>> headers, Object body})>
+      responses;
+  final List<({String path, Map<String, dynamic> queryParameters})> requests =
+      [];
+
+  FakeHttpClientAdapter(this.responses);
+
+  int _callCount = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions requestOptions,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add((
+      path: requestOptions.path,
+      queryParameters: requestOptions.queryParameters,
+    ));
+
+    final resp = responses[_callCount < responses.length
+        ? _callCount
+        : responses.length - 1];
+    _callCount++;
+
+    final bodyBytes = utf8.encode(jsonEncode(resp.body));
+    return ResponseBody.fromBytes(
+      bodyBytes,
+      resp.statusCode,
+      headers: resp.headers,
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+MarketOrderQuote _buy(double price, [int volume = 1000]) =>
+    MarketOrderQuote(price: price, volumeRemain: volume, isBuyOrder: true);
+
+MarketOrderQuote _sell(double price, [int volume = 1000]) =>
+    MarketOrderQuote(price: price, volumeRemain: volume, isBuyOrder: false);
+
+PriceRepository _repoWithFetcher(
+  FakeOrderFetcher fetcher, {
+  Map<int, String>? regions,
+}) {
+  return PriceRepository(
+    orderFetcher: fetcher.call,
+    marketRegions: regions ?? eveMarketRegions,
+    clock: () => DateTime.utc(2025, 1, 1, 12, 0, 0),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Repository unit tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // getPrice
+  // ---------------------------------------------------------------------------
+
+  group('getPrice', () {
+    test('aggregates buy and sell orders for one region', () async {
+      final fetcher = FakeOrderFetcher();
+      fetcher.onFetch = (typeId, regionId) async => [
+            _buy(100.0, 10), // buyMax candidate
+            _buy(90.0, 5),
+            _sell(120.0, 8), // sellMin candidate
+            _sell(130.0, 7),
+          ];
+
+      final repo = _repoWithFetcher(fetcher);
+
+      final result = await repo.getPrice(34, 10000002);
+
+      expect(result.typeId, 34);
+      expect(result.regionId, 10000002);
+      expect(result.typeName, 'Type 34');
+      expect(result.buyMax, 100.0);
+      expect(result.sellMin, 120.0);
+      expect(result.buyAvg, (100.0 + 90.0) / 2);
+      expect(result.sellAvg, (120.0 + 130.0) / 2);
+      expect(result.buyVolume, 15);
+      expect(result.sellVolume, 15);
+      expect(result.spread, 20.0);
+      expect(result.spreadPercent, 20.0);
+      expect(result.margin, closeTo(120.0 * 0.99 - 100.0 * 1.01, 0.001));
+      expect(result.updatedAt, DateTime.utc(2025, 1, 1, 12, 0, 0));
+    });
+
+    test('returns null prices and zero volumes for an empty successful region response', () async {
+      final fetcher = FakeOrderFetcher();
+      fetcher.onFetch = (typeId, regionId) async => [];
+
+      final repo = _repoWithFetcher(fetcher);
+      final result = await repo.getPrice(34, 10000002);
+
+      expect(result.buyMax, isNull);
+      expect(result.sellMin, isNull);
+      expect(result.buyAvg, isNull);
+      expect(result.sellAvg, isNull);
+      expect(result.buyVolume, 0);
+      expect(result.sellVolume, 0);
+    });
+
+    test('validates positive type id', () async {
+      final fetcher = FakeOrderFetcher();
+      final repo = _repoWithFetcher(fetcher);
+
+      expect(
+        () => repo.getPrice(0, 10000002),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          contains('expected positive EVE type id'),
+        )),
+      );
+      expect(
+        () => repo.getPrice(-1, 10000002),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(fetcher.calls, isEmpty);
+    });
+
+    test('validates known region id', () async {
+      final fetcher = FakeOrderFetcher();
+      final repo = _repoWithFetcher(fetcher);
+
+      expect(
+        () => repo.getPrice(34, 99999999),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          contains('expected known market region id'),
+        )),
+      );
+      expect(fetcher.calls, isEmpty);
+    });
+
+    test('does not call fetcher when region is not in injected marketRegions', () async {
+      final fetcher = FakeOrderFetcher();
+      // Use an explicit two-region map so 10000002 is NOT in it.
+      final smallRegions = <int, String>{10000030: 'Heimatar'};
+      final repo = PriceRepository(
+        orderFetcher: fetcher.call,
+        marketRegions: smallRegions,
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      expect(
+        () => repo.getPrice(34, 10000002),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(fetcher.calls, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // MarketRegionPrice / eveMarketRegions
+  // ---------------------------------------------------------------------------
+
+  test('marketRegions matches the configured all-region catalog', () {
+    expect(eveMarketRegions, <int, String>{
+      10000001: 'Derelik',
+      10000002: 'The Forge',
+      10000003: 'Vale of the Silent',
+      10000005: 'Detorid',
+      10000006: 'Wicked Creek',
+      10000007: 'Cache',
+      10000008: 'Scalding Pass',
+      10000009: 'Insmother',
+      10000010: 'Tribute',
+      10000011: 'Great Wildlands',
+      10000012: 'Curse',
+      10000013: 'Malpais',
+      10000014: 'Catch',
+      10000015: 'Venal',
+      10000016: 'Lonetrek',
+      10000018: 'The Spire',
+      10000020: 'Tash-Murkon',
+      10000021: 'Outer Passage',
+      10000022: 'Stain',
+      10000023: 'Pure Blind',
+      10000025: 'Immensea',
+      10000027: 'Etherium Reach',
+      10000028: 'Molden Heath',
+      10000029: 'Geminate',
+      10000030: 'Heimatar',
+      10000031: 'Impass',
+      10000032: 'Sinq Laison',
+      10000033: 'The Citadel',
+      10000034: 'The Kalevala Expanse',
+      10000035: 'Deklein',
+      10000036: 'Devoid',
+      10000037: 'Everyshore',
+      10000038: 'The Bleak Lands',
+      10000039: 'Esoteria',
+      10000040: 'Oasa',
+      10000041: 'Syndicate',
+      10000042: 'Metropolis',
+      10000043: 'Domain',
+      10000044: 'Solitude',
+      10000045: 'Tenal',
+      10000046: 'Fade',
+      10000047: 'Providence',
+      10000048: 'Placid',
+      10000049: 'Khanid',
+      10000050: 'Querious',
+      10000051: 'Cloud Ring',
+      10000052: 'Kador',
+      10000053: 'Cobalt Edge',
+      10000054: 'Aridia',
+      10000055: 'Branch',
+      10000056: 'Feythabolis',
+      10000057: 'Outer Ring',
+      10000058: 'Fountain',
+      10000059: 'Paragon Soul',
+      10000060: 'Delve',
+      10000061: 'Tenerifis',
+      10000062: 'Omist',
+      10000063: 'Period Basis',
+      10000064: 'Essence',
+      10000065: 'Kor-Azor',
+      10000066: 'Perrigen Falls',
+      10000067: 'Genesis',
+      10000068: 'Verge Vendor',
+      10000069: 'Black Rise',
+      10000070: 'Pochven',
+    });
+  });
+
+  test('getPricesAcrossAllRegions queries every configured region in the full catalog', () async {
+    final fetcher = FakeOrderFetcher();
+    fetcher.onFetch = (typeId, regionId) async => [];
+
+    final repo = PriceRepository(
+      orderFetcher: fetcher.call,
+      marketRegions: eveMarketRegions,
+      clock: () => DateTime.utc(2025, 1, 1),
+    );
+
+    final results = await repo.getPricesAcrossAllRegions(34);
+
+    expect(results.length, eveMarketRegions.length);
+    final calledRegionIds = fetcher.calls.map((c) => c.regionId).toList();
+    expect(calledRegionIds, eveMarketRegions.keys.toList());
+  });
+
+  test('getPricesAcrossAllRegions queries every configured region and preserves configured names', () async {
+    final fetcher = FakeOrderFetcher();
+    fetcher.onFetch = (typeId, regionId) async => [
+          _buy(50.0),
+          _sell(60.0),
+        ];
+
+    const smallRegions = <int, String>{
+      10000002: 'The Forge',
+      10000030: 'Heimatar',
+      10000042: 'Metropolis',
+    };
+
+    final repo = PriceRepository(
+      orderFetcher: fetcher.call,
+      marketRegions: smallRegions,
+      clock: () => DateTime.utc(2025, 1, 1),
+    );
+
+    final results = await repo.getPricesAcrossAllRegions(34);
+
+    expect(results.length, 3);
+    expect(results[0].regionId, 10000002);
+    expect(results[0].regionName, 'The Forge');
+    expect(results[1].regionId, 10000030);
+    expect(results[1].regionName, 'Heimatar');
+    expect(results[2].regionId, 10000042);
+    expect(results[2].regionName, 'Metropolis');
+
+    final calledRegionIds = fetcher.calls.map((c) => c.regionId).toList();
+    expect(calledRegionIds, [10000002, 10000030, 10000042]);
+    final calledTypeIds = fetcher.calls.map((c) => c.typeId).toList();
+    expect(calledTypeIds, [34, 34, 34]);
+  });
+
+  test('getPricesAcrossAllRegions fails instead of skipping when one region fetch fails', () async {
+    final fetcher = FakeOrderFetcher();
+    var callCount = 0;
+    fetcher.onFetch = (typeId, regionId) async {
+      callCount++;
+      if (callCount == 2) {
+        throw Exception('Network error');
+      }
+      return [_buy(50.0), _sell(60.0)];
+    };
+
+    const smallRegions = <int, String>{
+      10000002: 'The Forge',
+      10000030: 'Heimatar',
+      10000042: 'Metropolis',
+    };
+
+    final repo = PriceRepository(
+      orderFetcher: fetcher.call,
+      marketRegions: smallRegions,
+      clock: () => DateTime.utc(2025, 1, 1),
+    );
+
+    expect(
+      () => repo.getPricesAcrossAllRegions(34),
+      throwsA(isA<PriceRepositoryException>().having(
+        (e) => e.message,
+        'message',
+        allOf(
+          contains('10000030'),
+          contains('Heimatar'),
+        ),
+      )),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Default ESI fetcher — pagination tests (Dio fake adapter)
+  // ---------------------------------------------------------------------------
+
+  group('default ESI fetcher', () {
+    test('combines paginated market order responses', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 200,
+          headers: {
+            'x-pages': ['2'],
+            'content-type': ['application/json'],
+          },
+          body: [
+            {'price': 100.0, 'volume_remain': 100, 'is_buy_order': true},
+          ],
+        ),
+        (
+          statusCode: 200,
+          headers: <String, List<String>>{
+            'content-type': ['application/json'],
+          },
+          body: [
+            {'price': 50.0, 'volume_remain': 200, 'is_buy_order': false},
+          ],
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      final result = await repo.getPrice(34, 10000002);
+
+      // Both pages should be queried.
+      expect(adapter.requests.length, 2);
+
+      // Page 1 with filters.
+      expect(adapter.requests[0].path, '/markets/10000002/orders/');
+      expect(adapter.requests[0].queryParameters['type_id'], 34);
+      expect(adapter.requests[0].queryParameters['order_type'], 'all');
+      expect(adapter.requests[0].queryParameters['datasource'], 'tranquility');
+      expect(adapter.requests[0].queryParameters['page'], 1);
+
+      // Page 2 with same filters.
+      expect(adapter.requests[1].path, '/markets/10000002/orders/');
+      expect(adapter.requests[1].queryParameters['type_id'], 34);
+      expect(adapter.requests[1].queryParameters['order_type'], 'all');
+      expect(adapter.requests[1].queryParameters['datasource'], 'tranquility');
+      expect(adapter.requests[1].queryParameters['page'], 2);
+
+      // Aggregation from both pages.
+      expect(result.buyMax, 100.0);
+      expect(result.sellMin, 50.0);
+      expect(result.buyVolume, 100);
+      expect(result.sellVolume, 200);
+    });
+
+    test('fails on invalid X-Pages header', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 200,
+          headers: {
+            'x-pages': ['not-a-number'],
+            'content-type': ['application/json'],
+          },
+          body: [
+            {'price': 100.0, 'volume_remain': 100, 'is_buy_order': true},
+          ],
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      expect(
+        () => repo.getPrice(34, 10000002),
+        throwsA(isA<PriceRepositoryException>().having(
+          (e) => e.message,
+          'message',
+          allOf(
+            contains('X-Pages'),
+            contains('not-a-number'),
+          ),
+        )),
+      );
+    });
+
+    test('handles absent X-Pages header as single page', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 200,
+          headers: <String, List<String>>{
+            'content-type': ['application/json'],
+          },
+          body: [
+            {'price': 150.0, 'volume_remain': 300, 'is_buy_order': false},
+          ],
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      final result = await repo.getPrice(34, 10000002);
+
+      expect(adapter.requests.length, 1);
+      expect(result.sellMin, 150.0);
+    });
+
+    test('fails when response body is not a JSON array', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 200,
+          headers: {
+            'content-type': ['application/json'],
+          },
+          body: {'not': 'a list'},
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      expect(
+        () => repo.getPrice(34, 10000002),
+        throwsA(isA<PriceRepositoryException>().having(
+          (e) => e.message,
+          'message',
+          contains('Expected JSON array'),
+        )),
+      );
+    });
+
+    test('fails when an order entry is not a Map', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 200,
+          headers: {
+            'content-type': ['application/json'],
+          },
+          body: ['not a map'],
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      expect(
+        () => repo.getPrice(34, 10000002),
+        throwsA(isA<PriceRepositoryException>().having(
+          (e) => e.message,
+          'message',
+          allOf(contains('Invalid order entry'), contains('expected Map')),
+        )),
+      );
+    });
+
+    test('fails when price field is missing or invalid', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 200,
+          headers: {
+            'content-type': ['application/json'],
+          },
+          body: [
+            {'price': 'not-a-number', 'volume_remain': 100, 'is_buy_order': true},
+          ],
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      expect(
+        () => repo.getPrice(34, 10000002),
+        throwsA(isA<PriceRepositoryException>().having(
+          (e) => e.message,
+          'message',
+          contains('price'),
+        )),
+      );
+    });
+
+    test('fails when volume_remain is not an int', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 200,
+          headers: {
+            'content-type': ['application/json'],
+          },
+          body: [
+            {'price': 100.0, 'volume_remain': 'not-int', 'is_buy_order': true},
+          ],
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      expect(
+        () => repo.getPrice(34, 10000002),
+        throwsA(isA<PriceRepositoryException>().having(
+          (e) => e.message,
+          'message',
+          contains('volume_remain'),
+        )),
+      );
+    });
+
+    test('fails when is_buy_order is not a bool', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 200,
+          headers: {
+            'content-type': ['application/json'],
+          },
+          body: [
+            {'price': 100.0, 'volume_remain': 100, 'is_buy_order': 'true'},
+          ],
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      expect(
+        () => repo.getPrice(34, 10000002),
+        throwsA(isA<PriceRepositoryException>().having(
+          (e) => e.message,
+          'message',
+          contains('is_buy_order'),
+        )),
+      );
+    });
+
+    test('handles non-PriceRepositoryException Dio errors gracefully', () async {
+      final adapter = FakeHttpClientAdapter([
+        (
+          statusCode: 500,
+          headers: {'content-type': ['text/plain']},
+          body: 'Internal Server Error',
+        ),
+      ]);
+
+      final dio = Dio(BaseOptions(baseUrl: 'https://esi.evetech.net/latest'))
+        ..httpClientAdapter = adapter;
+
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      // A 500 with non-JSON body causes Dio's transformer to fail, which
+      // hits the general catch → PriceRepositoryException.
+      expect(
+        () => repo.getPrice(34, 10000002),
+        throwsA(isA<PriceRepositoryException>().having(
+          (e) => e.message,
+          'message',
+          contains('Failed to fetch'),
+        )),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Constructor defaults
+  // ---------------------------------------------------------------------------
+
+  group('constructor defaults', () {
+    test('default clock returns DateTime.now-ish', () {
+      final repo = PriceRepository(
+        marketRegions: const {10000002: 'The Forge'},
+      );
+      // We can't test the exact time, but we can check it doesn't throw.
+      expect(repo.marketRegions, isNotEmpty);
+    });
+
+    test('default clock produces a usable DateTime when fetching', () async {
+      // Prove the default clock fallback (line 188) works by fetching
+      // without injecting a clock.
+      final fetcher = FakeOrderFetcher();
+      fetcher.onFetch = (typeId, regionId) async => [
+            _buy(50.0),
+          ];
+      final repo = PriceRepository(
+        orderFetcher: fetcher.call,
+        marketRegions: const {10000002: 'The Forge'},
+        // No clock injected — exercises the ?? fallback.
+      );
+      final result = await repo.getPrice(34, 10000002);
+      expect(result.updatedAt, isNotNull);
+      // Should be within the last minute.
+      expect(
+        DateTime.now().difference(result.updatedAt).inSeconds.abs(),
+        lessThan(60),
+      );
+    });
+
+    test('default regions fall back to eveMarketRegions', () {
+      final repo = PriceRepository();
+      expect(repo.marketRegions.length, eveMarketRegions.length);
+      expect(repo.marketRegions[10000002], 'The Forge');
+    });
+
+    test('exposes dio field for testing', () {
+      final dio = Dio(BaseOptions(baseUrl: 'https://test.example.com'));
+      final repo = PriceRepository(
+        dio: dio,
+        marketRegions: const {10000002: 'The Forge'},
+      );
+      expect(repo.dio.options.baseUrl, 'https://test.example.com');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPricesAcrossAllRegions validation
+  // ---------------------------------------------------------------------------
+
+  group('getPricesAcrossAllRegions validation', () {
+    test('validates positive type id', () async {
+      final repo = PriceRepository(
+        marketRegions: const {10000002: 'The Forge'},
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      expect(
+        () => repo.getPricesAcrossAllRegions(0),
+        throwsA(isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          contains('expected positive EVE type id'),
+        )),
+      );
+
+      expect(
+        () => repo.getPricesAcrossAllRegions(-5),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // priceRepositoryProvider
+  // ---------------------------------------------------------------------------
+
+  group('priceRepositoryProvider', () {
+    test('provider creates a PriceRepository with default regions', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final repo = container.read(priceRepositoryProvider);
+      expect(repo, isA<PriceRepository>());
+      expect(repo.marketRegions.length, eveMarketRegions.length);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Widget tests: PriceCheckScreen
+  // ---------------------------------------------------------------------------
+
+  group('PriceCheckScreen', () {
+    // Helper — wraps screen in ProviderScope with an overridden price repository.
+    Future<void> pumpScreen(
+      WidgetTester tester, {
+      required PriceRepository repo,
+    }) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            priceRepositoryProvider.overrideWithValue(repo),
+          ],
+          child: const MaterialApp(
+            home: PriceCheckScreen(),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('validates Type ID accessibly before repository calls',
+        (tester) async {
+      final fetcher = FakeOrderFetcher();
+      final repo = _repoWithFetcher(fetcher);
+
+      await pumpScreen(tester, repo: repo);
+
+      // Tap "Check Prices" with an empty type ID.
+      await tester.tap(find.text('Check Prices'));
+      await tester.pumpAndSettle();
+
+      // Assert visible validation error.
+      expect(find.text('Enter a positive EVE Type ID.'), findsOneWidget);
+
+      // Assert no fetcher calls.
+      expect(fetcher.calls, isEmpty);
+
+      // Enter non-positive number and try again.
+      await tester.enterText(find.byType(TextField).first, '-5');
+      await tester.tap(find.text('Check Prices'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Enter a positive EVE Type ID.'), findsOneWidget);
+      expect(fetcher.calls, isEmpty);
+    });
+
+    testWidgets('announces loading and renders all-region results',
+        (tester) async {
+      final completer = Completer<List<MarketOrderQuote>>();
+      final fetcher = FakeOrderFetcher();
+      fetcher.onFetch = (typeId, regionId) => completer.future;
+
+      const smallRegions = <int, String>{
+        10000002: 'The Forge',
+        10000030: 'Heimatar',
+      };
+
+      final repo = PriceRepository(
+        orderFetcher: fetcher.call,
+        marketRegions: smallRegions,
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      await pumpScreen(tester, repo: repo);
+
+      // Enter type ID.
+      await tester.enterText(find.byType(TextField).first, '34');
+      // Ensure all-regions toggle is on.
+      expect(find.byType(SwitchListTile), findsOneWidget);
+
+      // Tap "Check Prices".
+      await tester.tap(find.text('Check Prices'));
+      await tester.pump();
+
+      // Loading state.
+      expect(find.text('Loading prices...'), findsOneWidget);
+
+      // Complete with data.
+      completer.complete([
+        _buy(100.0, 10),
+        _sell(120.0, 8),
+        _buy(90.0, 5),
+        _sell(130.0, 7),
+      ]);
+      await tester.pumpAndSettle();
+
+      // No more loading, results visible.
+      expect(find.text('Loading prices...'), findsNothing);
+      // "The Forge" appears in both the dropdown and the result card.
+      expect(find.descendant(of: find.byType(Card), matching: find.text('The Forge')), findsOneWidget);
+      expect(find.descendant(of: find.byType(Card), matching: find.text('Heimatar')), findsOneWidget);
+
+      // No error text.
+      expect(find.textContaining('Failed to load prices'), findsNothing);
+    });
+
+    testWidgets('announces repository errors', (tester) async {
+      final fetcher = FakeOrderFetcher();
+      fetcher.onFetch = (typeId, regionId) async {
+        throw const PriceRepositoryException('Simulated ESI failure');
+      };
+
+      final repo = _repoWithFetcher(fetcher);
+
+      await pumpScreen(tester, repo: repo);
+
+      await tester.enterText(find.byType(TextField).first, '34');
+      await tester.tap(find.text('Check Prices'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Failed to load prices'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Simulated ESI failure'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows accessible empty results state', (tester) async {
+      final fetcher = FakeOrderFetcher();
+      fetcher.onFetch = (typeId, regionId) async => [];
+
+      // Use an empty map and a custom repo that bypasses the empty-map
+      // validation since getPricesAcrossAllRegions iterates _marketRegions.
+      const emptyRegions = <int, String>{};
+      final repo = PriceRepository(
+        orderFetcher: fetcher.call,
+        marketRegions: emptyRegions,
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      await pumpScreen(tester, repo: repo);
+
+      await tester.enterText(find.byType(TextField).first, '34');
+      await tester.tap(find.text('Check Prices'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No market regions returned'), findsOneWidget);
+    });
+
+    testWidgets('renders single-region results when all-regions is off',
+        (tester) async {
+      final fetcher = FakeOrderFetcher();
+      fetcher.onFetch = (typeId, regionId) async => [
+            _buy(100.0, 10),
+            _sell(120.0, 8),
+          ];
+
+      const smallRegions = <int, String>{
+        10000002: 'The Forge',
+        10000030: 'Heimatar',
+      };
+
+      final repo = PriceRepository(
+        orderFetcher: fetcher.call,
+        marketRegions: smallRegions,
+        clock: () => DateTime.utc(2025, 1, 1),
+      );
+
+      await pumpScreen(tester, repo: repo);
+
+      // Toggle off all-regions.
+      await tester.tap(find.byType(SwitchListTile));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).first, '34');
+      await tester.tap(find.text('Check Prices'));
+      await tester.pumpAndSettle();
+
+      // The Forge should appear since default is 10000002.
+      expect(find.descendant(of: find.byType(Card), matching: find.text('The Forge')), findsOneWidget);
+      expect(find.text('Heimatar'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #471

## What changed

- Add `MarketPrice`, `MarketRegionPrice`, `MarketOrderQuote` data models in `lib/features/market/data/repositories/price_repository.dart`
- Add `PriceRepository` with injectable order fetching (fake fetcher for tests, Dio for production)
- Add paginated ESI `/markets/{region_id}/orders/` integration with `X-Pages` header handling
- Add authoritative all-regions catalog (`eveMarketRegions`) with 64 known-space EVE market regions
- Add Riverpod `priceRepositoryProvider`
- Add `PriceCheckScreen` UI with accessible semantics (`Semantics(liveRegion: true)` for dynamic states)
- Add 29 tests: 21 repository unit tests (aggregation, validation, pagination, error handling, region catalog) + 5 widget tests (validation, loading, results, errors, empty state) + 3 constructor/provider tests

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter analyze lib/features/market/ test/features/market/
# No issues found!

flutter test test/features/market/data/repositories/price_repository_test.dart
# 00:02 +29: All tests passed!

flutter test --coverage test/features/market/data/repositories/price_repository_test.dart
# lib/features/market/data/repositories/price_repository.dart: 104/104 = 100.0%
# lib/features/market/presentation/price_check_screen.dart: 133/137 = 97.1%
```

## Acceptance criteria coverage

### Card ACs
- AC 1: "Implementation matches all behaviors described in the task body (see Notes)" — ✓ addressed in `price_repository.dart` (models, paginated fetching, all-regions catalog, Riverpod provider) and `price_check_screen.dart` (accessible UI with Semantics liveRegion, validation, loading/error/empty/data states)
- AC 2: "All named tests pass the verification command" — ✓ all 29 tests pass; verification commands exit 0
- AC 3: "No dependencies added unless absolutely required" — ✓ no changes to pubspec.yaml/lock; uses existing dio, riverpod, flutter_test; hand-written fakes instead of mock packages

### Body ACs
- AC 1: "Capability 'Price checking (all regions)' is implemented per spec" — ✓ `getPricesAcrossAllRegions` iterates all 64 configured regions; single-region `getPrice` with paginated ESI integration
- AC 2: "Tests cover the new capability with ≥ 90% line coverage on touched files" — ✓ 100.0% on repository, 97.1% on screen
- AC 3: "`flutter analyze` reports zero new warnings" — ✓ no issues found
- AC 4: "PR body documents which spec sections are addressed" — ✓ see Spec sections below

## Spec sections addressed

- Overview / Key Features: Price Lookup — `getPricesAcrossAllRegions` iterates all configured regions
- API Integration: `GET /markets/{region_id}/orders/` with `type_id`, `order_type=all`, `datasource=tranquility`, `X-Pages` pagination
- Riverpod Providers: `priceRepositoryProvider` in `price_repository.dart`
- UI Components: `PriceCheckScreen` with type ID/name inputs, region dropdown, all-regions toggle, accessible results
- Price Calculations: `MarketPrice.spread`, `.spreadPercent`, `.margin` computed getters
- Testing Strategy: 29 tests covering aggregation, empty responses, validation, all-region iteration, pagination, error states, widget states

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — ✓ only the 3 expected files modified
- Do NOT add third-party dependencies unless required by the task body — ✓ no new deps
- Do NOT refactor unrelated code in the touched files — ✓ all three files are new

## Notes

- The three files are created in new `lib/features/market/` and `test/features/market/` directories; all parent directories are new and contain only the expected files
- `EveTypeIcon` import works clean in the new screen file (the screen is in `lib/features/market/presentation/` so the relative path `../../../core/widgets/eve_type_icon.dart` resolves correctly)
- The `priceRepositoryProvider` is defined in `price_repository.dart` rather than a separate providers file — this is per the approved plan since only 3 files are allowed

### Coverage

- AC 1 (Implementation matches all behaviors): ✓ addressed in `price_repository.dart:1-439` and `price_check_screen.dart:1-366`
- AC 2 (All named tests pass): ✓ addressed in `price_repository_test.dart` — 29/29 pass
- AC 3 (No dependencies added): ✓ zero changes to pubspec.yaml/lock
- Body AC 1 (Price checking all regions): ✓ `getPricesAcrossAllRegions` at `price_repository.dart:233-261`
- Body AC 2 (≥90% coverage): ✓ 100.0% / 97.1%
- Body AC 3 (flutter analyze clean): ✓ no issues
- Body AC 4 (Spec sections documented): ✓ in PR body Spec sections addressed