### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,144 @@
+/// Pure Dart margin calculator for EVE Online market trade profit/margin analysis.
+///
+/// Provides [calculateMargin] which computes gross costs, revenue, fees, taxes,
+/// and net profit, returning a typed [MarginCalculationResult] with derived
+/// percentage getters.
+library;
+
+/// Result of a margin calculation for a single trade.
+///
+/// All fields are immutable. Percentages returned by getters are in percentage
+/// units (e.g., 20 means 20%, not 0.20). Fee rates in [calculateMargin] are
+/// decimal rates (e.g., 0.05 means 5%).
+class MarginCalculationResult {
+  /// Buy price per unit (ISK).
+  final double buyPrice;
+
+  /// Sell price per unit (ISK).
+  final double sellPrice;
+
+  /// Number of units traded.
+  final int quantity;
+
+  /// Broker fee as a decimal rate (0–1).
+  final double brokerFeeRate;
+
+  /// Sales tax as a decimal rate (0–1).
+  final double salesTaxRate;
+
+  /// Total ISK from selling: [sellPrice] × [quantity].
+  final double grossRevenue;
+
+  /// Total ISK spent buying: [buyPrice] × [quantity].
+  final double grossCost;
+
+  /// Broker fee in ISK: [grossRevenue] × [brokerFeeRate].
+  final double brokerFee;
+
+  /// Sales tax in ISK: [grossRevenue] × [salesTaxRate].
+  final double salesTax;
+
+  /// Net profit in ISK: [grossRevenue] − [grossCost] − [brokerFee] − [salesTax].
+  final double netProfit;
+
+  const MarginCalculationResult({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.quantity,
+    required this.brokerFeeRate,
+    required this.salesTaxRate,
+    required this.grossRevenue,
+    required this.grossCost,
+    required this.brokerFee,
+    required this.salesTax,
+    required this.netProfit,
+  });
+
+  /// Profit margin as a percentage of gross revenue.
+  ///
+  /// Returns 0 when [grossRevenue] is 0 (no division by zero).
+  double get profitMarginPercent =>
+      grossRevenue == 0 ? 0 : (netProfit / grossRevenue) * 100;
+
+  /// Return on investment as a percentage of gross cost.
+  ///
+  /// Returns 0 when [grossCost] is 0 (no division by zero).
+  double get returnOnInvestmentPercent =>
+      grossCost == 0 ? 0 : (netProfit / grossCost) * 100;
+
+  /// True when [netProfit] is strictly positive.
+  bool get isProfitable => netProfit > 0;
+}
+
+/// Computes the margin for an EVE Online market trade.
+///
+/// All fee and tax rates are decimal fractions: 0.05 means 5%. The returned
+/// [MarginCalculationResult] provides percentage getters ([profitMarginPercent],
+/// [returnOnInvestmentPercent]) that return values like 20 (meaning 20%).
+///
+/// Throws [ArgumentError] for any invalid input:
+/// - [buyPrice] or [sellPrice] negative
+/// - [quantity] less than 1
+/// - [brokerFeeRate] or [salesTaxRate] outside [0, 1]
+MarginCalculationResult calculateMargin({
+  required double buyPrice,
+  required double sellPrice,
+  int quantity = 1,
+  double brokerFeeRate = 0,
+  double salesTaxRate = 0,
+}) {
+  if (buyPrice < 0) {
+    throw ArgumentError.value(
+      buyPrice,
+      'buyPrice',
+      'Must be greater than or equal to 0',
+    );
+  }
+  if (sellPrice < 0) {
+    throw ArgumentError.value(
+      sellPrice,
+      'sellPrice',
+      'Must be greater than or equal to 0',
+    );
+  }
+  if (quantity < 1) {
+    throw ArgumentError.value(
+      quantity,
+      'quantity',
+      'Must be greater than or equal to 1',
+    );
+  }
+  if (brokerFeeRate < 0 || brokerFeeRate > 1) {
+    throw ArgumentError.value(
+      brokerFeeRate,
+      'brokerFeeRate',
+      'Must be between 0 and 1 inclusive',
+    );
+  }
+  if (salesTaxRate < 0 || salesTaxRate > 1) {
+    throw ArgumentError.value(
+      salesTaxRate,
+      'salesTaxRate',
+      'Must be between 0 and 1 inclusive',
+    );
+  }
+
+  final grossCost = buyPrice * quantity;
+  final grossRevenue = sellPrice * quantity;
+  final brokerFee = grossRevenue * brokerFeeRate;
+  final salesTax = grossRevenue * salesTaxRate;
+  final netProfit = grossRevenue - grossCost - brokerFee - salesTax;
+
+  return MarginCalculationResult(
+    buyPrice: buyPrice,
+    sellPrice: sellPrice,
+    quantity: quantity,
+    brokerFeeRate: brokerFeeRate,
+    salesTaxRate: salesTaxRate,
+    grossRevenue: grossRevenue,
+    grossCost: grossCost,
+    brokerFee: brokerFee,
+    salesTax: salesTax,
+    netProfit: netProfit,
+  );
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('calculateMargin', () {
+    test('calculates profitable trade without fees', () {
+      final result = calculateMargin(
+        buyPrice: 100,
+        sellPrice: 125,
+        quantity: 10,
+      );
+
+      expect(result.grossCost, 1000);
+      expect(result.grossRevenue, 1250);
+      expect(result.brokerFee, 0);
+      expect(result.salesTax, 0);
+      expect(result.netProfit, 250);
+      expect(result.profitMarginPercent, 20);
+      expect(result.returnOnInvestmentPercent, 25);
+      expect(result.isProfitable, true);
+    });
+
+    test('subtracts broker fee and sales tax from profit', () {
+      final result = calculateMargin(
+        buyPrice: 100,
+        sellPrice: 120,
+        quantity: 5,
+        brokerFeeRate: 0.03,
+        salesTaxRate: 0.02,
+      );
+
+      expect(result.grossCost, 500);
+      expect(result.grossRevenue, 600);
+      expect(result.brokerFee, 18);
+      expect(result.salesTax, 12);
+      expect(result.netProfit, 70);
+      expect(result.profitMarginPercent, closeTo(11.6666666667, 0.000001));
+      expect(result.returnOnInvestmentPercent, closeTo(14, 0.000001));
+      expect(result.isProfitable, true);
+    });
+
+    test('identifies losing trade', () {
+      final result = calculateMargin(
+        buyPrice: 100,
+        sellPrice: 90,
+        quantity: 3,
+      );
+
+      expect(result.netProfit, -30);
+      expect(result.profitMarginPercent, closeTo(-11.1111111111, 0.000001));
+      expect(result.returnOnInvestmentPercent, -10);
+      expect(result.isProfitable, false);
+    });
+
+    test('returns zero percentages when revenue and cost are zero', () {
+      final result = calculateMargin(
+        buyPrice: 0,
+        sellPrice: 0,
+      );
+
+      expect(result.grossCost, 0);
+      expect(result.grossRevenue, 0);
+      expect(result.netProfit, 0);
+      expect(result.profitMarginPercent, 0);
+      expect(result.returnOnInvestmentPercent, 0);
+      expect(result.isProfitable, false);
+    });
+
+    test('throws ArgumentError for invalid numeric inputs', () {
+      expect(
+        () => calculateMargin(buyPrice: -1, sellPrice: 100),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculateMargin(buyPrice: 100, sellPrice: -1),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculateMargin(buyPrice: 100, sellPrice: 100, quantity: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          brokerFeeRate: -0.1,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          brokerFeeRate: 1.1,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          salesTaxRate: -0.1,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => calculateMargin(
+          buyPrice: 100,
+          sellPrice: 100,
+          salesTaxRate: 1.1,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #477

## What changed

- Added `MarginCalculationResult` — an immutable value class holding buy/sell prices, quantity, fee/tax rates, gross cost/revenue, fees, and net profit
- Added derived getters: `profitMarginPercent`, `returnOnInvestmentPercent`, `isProfitable`
- Added `calculateMargin()` — a pure Dart function computing EVE Online market trade margin with fee and tax effects
- Added comprehensive test file covering profitable trades, fee/tax deductions, losing trades, zero boundaries, and all input validation failures

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
# 5 tests, all passed

flutter analyze
# 1 pre-existing info-level lint (dangling_library_doc_comments in lib/core/utils/formatters.dart — not our file)

dart analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
# No issues found

flutter test
# 18 tests (13 existing + 5 new), all passed

flutter test --coverage
# Coverage on lib/features/market/calculators/margin_calculator.dart: 100% (23/23 lines)
```

## Acceptance criteria coverage

- AC 1: Capability "Margin calculator" is implemented per spec — `calculateMargin()` computes gross cost, gross revenue, broker fee, sales tax, net profit, and returns a typed `MarginCalculationResult` with margin/ROI percentage getters, implementing the Trade Calculator: Margin and profit analysis capability from the Market Module spec
- AC 2: Tests cover the new capability with ≥ 90% line coverage on touched files — 100% line coverage on `margin_calculator.dart` (23/23 instrumented lines); tests cover happy path, fee/tax, losing trade, zero boundary, and all validation error paths
- AC 3: No dependencies added unless absolutely required — zero changes to `pubspec.yaml` or `pubspec.lock`; implementation uses only Dart SDK and Flutter SDK types
- AC 4: `flutter analyze` reports zero new warnings — `dart analyze` on the two touched files returns "No issues found!"
- AC 5: PR body documents which spec sections are addressed — see Spec sections coverage below

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `margin_calculator.dart` and `margin_calculator_test.dart` created
- Do NOT add third-party dependencies unless required by the task body: not violated — no dependencies added
- Do NOT refactor unrelated code in the touched files: not violated — both files are new

## Notes

- The default branch for this repo is `develop`, not `main`; branch was created from `origin/develop` to produce a clean diff
- Both expected files and their parent directories (`lib/features/market/calculators/`, `test/features/market/calculators/`) were created fresh — none existed before
- No barrel files, providers, UI, or module scaffolding added — kept within the two expected files per scope discipline

### Spec sections coverage

| Spec Section | Coverage |
|---|---|
| Overview / User Value — Station Trader: margin analysis | `calculateMargin()` computes net profit, margin %, and ROI % for station traders to analyze trade profitability |
| Key Features — Trade Calculator: Margin and profit analysis | `MarginCalculationResult` with `profitMarginPercent`, `returnOnInvestmentPercent`, `isProfitable` getters provides the trade calculator capability |
| Price Calculations | Pure calculation logic for gross cost, gross revenue, broker fee, sales tax, and net profit with explicit input validation on all parameters |

### Coverage

- AC 1: ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `calculateMargin()` and `MarginCalculationResult`
- AC 2: ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — 5 test cases, 100% line coverage
- AC 3: ✓ no dependencies added
- AC 4: ✓ `dart analyze` clean on touched files
- AC 5: ✓ PR body Spec sections coverage table above
- AC 6: ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `calculateMargin()` and `MarginCalculationResult` (acceptance criteria from structured card field)