### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,165 @@
+/// Immutable result of a margin trade calculation.
+///
+/// All amounts are in ISK except [marginPercent] which is a percentage value.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Whether the trade is profitable (profit > 0).
+  bool get isProfitable => profit > 0;
+}
+
+/// Margin calculator for EVE Online market trades.
+///
+/// Computes trade margin, profit, and break-even sell price using
+/// broker fees and sales tax as configurable percentages.
+class MarginCalculator {
+  const MarginCalculator._();
+
+  // ── Validation helpers ────────────────────────────────────────────────
+
+  static void _validatePositive(String name, double value) {
+    if (!value.isFinite || value <= 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'must be a finite positive ISK amount',
+      );
+    }
+  }
+
+  static void _validatePercent(String name, double value) {
+    if (!value.isFinite || value < 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'must be a finite percentage greater than or equal to 0',
+      );
+    }
+  }
+
+  static void _validateSellDeductions(
+    double brokerFeePercent,
+    double salesTaxPercent,
+  ) {
+    final sum = brokerFeePercent + salesTaxPercent;
+    if (sum >= 100) {
+      throw ArgumentError.value(
+        sum,
+        'brokerFeePercent + salesTaxPercent',
+        'must be less than 100 so sell net and break-even price are defined',
+      );
+    }
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────
+
+  /// Calculates the complete margin analysis for a trade.
+  ///
+  /// [buyPrice] and [sellPrice] are the ISK amounts per unit.
+  /// [brokerFeePercent] defaults to 1.0% (applied to both buy and sell).
+  /// [salesTaxPercent] defaults to 2.0% (applied to sell price only).
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePositive('buyPrice', buyPrice);
+    _validatePositive('sellPrice', sellPrice);
+    _validatePercent('brokerFeePercent', brokerFeePercent);
+    _validatePercent('salesTaxPercent', salesTaxPercent);
+    _validateSellDeductions(brokerFeePercent, salesTaxPercent);
+
+    final buyBrokerFee = buyPrice * brokerFeePercent / 100;
+    final sellBrokerFee = sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    final buyTotal = buyPrice + buyBrokerFee;
+    final sellNet = sellPrice - sellBrokerFee - salesTax;
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+    final brokerFee = buyBrokerFee + sellBrokerFee;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Returns the sell price at which profit is exactly zero.
+  ///
+  /// The formula accounts for the same broker fee and sales tax
+  /// percentages as [calculateMargin].
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePositive('buyPrice', buyPrice);
+    _validatePercent('brokerFeePercent', brokerFeePercent);
+    _validatePercent('salesTaxPercent', salesTaxPercent);
+    _validateSellDeductions(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    return buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+  }
+}
+
+/// Compatibility facade that forwards to [MarginCalculator].
+///
+/// Preserves the method names from the original specification's
+/// `TradeCalculator` class while keeping all formula logic in
+/// [MarginCalculator].
+class TradeCalculator {
+  const TradeCalculator._();
+
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    return MarginCalculator.calculateMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+  }
+
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    return MarginCalculator.breakEvenSellPrice(
+      buyPrice: buyPrice,
+      brokerFeePercent: brokerFeePercent,
+      salesTaxPercent: salesTaxPercent,
+    );
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+/// Shorter alias for readability.
+Matcher closeToDouble(double expected) => closeTo(expected, 0.000001);
+
+void main() {
+  group('MarginCalculator.calculateMargin', () {
+    test('applies default broker fee and sales tax', () {
+      const buyPrice = 100.0;
+      const sellPrice = 150.0;
+
+      final result = MarginCalculator.calculateMargin(
+        buyPrice: buyPrice,
+        sellPrice: sellPrice,
+      );
+
+      expect(result.buyPrice, buyPrice);
+      expect(result.sellPrice, sellPrice);
+      expect(result.buyTotal, closeToDouble(101.0));
+      expect(result.sellNet, closeToDouble(145.5));
+      expect(result.profit, closeToDouble(44.5));
+      expect(result.marginPercent, closeToDouble(44.05940594059406));
+      expect(result.brokerFee, closeToDouble(2.5));
+      expect(result.salesTax, closeToDouble(3.0));
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('reports unprofitable trade', () {
+      const buyPrice = 100.0;
+      const sellPrice = 90.0;
+
+      final result = MarginCalculator.calculateMargin(
+        buyPrice: buyPrice,
+        sellPrice: sellPrice,
+      );
+
+      expect(result.profit, lessThan(0));
+      expect(result.marginPercent, lessThan(0));
+      expect(result.isProfitable, isFalse);
+    });
+
+    test('uses custom fee percentages', () {
+      const buyPrice = 200.0;
+      const sellPrice = 260.0;
+      const brokerFeePercent = 2.5;
+      const salesTaxPercent = 4.0;
+
+      final result = MarginCalculator.calculateMargin(
+        buyPrice: buyPrice,
+        sellPrice: sellPrice,
+        brokerFeePercent: brokerFeePercent,
+        salesTaxPercent: salesTaxPercent,
+      );
+
+      expect(result.buyTotal, closeToDouble(205.0));
+      expect(result.sellNet, closeToDouble(243.1));
+      expect(result.profit, closeToDouble(38.1));
+      expect(result.brokerFee, closeToDouble(11.5));
+      expect(result.salesTax, closeToDouble(10.4));
+      expect(result.marginPercent, closeToDouble(18.585365853658537));
+      expect(result.isProfitable, isTrue);
+    });
+  });
+
+  group('MarginCalculator.breakEvenSellPrice', () {
+    test('returns sell price that makes profit zero with default fees', () {
+      const buyPrice = 100.0;
+
+      final breakEven = MarginCalculator.breakEvenSellPrice(buyPrice: buyPrice);
+
+      expect(breakEven, closeToDouble(104.12371134020619));
+
+      // Verify that using this sell price yields zero profit.
+      final margin = MarginCalculator.calculateMargin(
+        buyPrice: buyPrice,
+        sellPrice: breakEven,
+      );
+      expect(margin.profit, closeToDouble(0.0));
+    });
+
+    test('uses custom fee percentages', () {
+      const buyPrice = 200.0;
+      const brokerFeePercent = 2.5;
+      const salesTaxPercent = 4.0;
+
+      final breakEven = MarginCalculator.breakEvenSellPrice(
+        buyPrice: buyPrice,
+        brokerFeePercent: brokerFeePercent,
+        salesTaxPercent: salesTaxPercent,
+      );
+
+      expect(breakEven, closeToDouble(219.25133689839572));
+
+      // Verify round-trip: using break-even price yields ~zero profit.
+      final margin = MarginCalculator.calculateMargin(
+        buyPrice: buyPrice,
+        sellPrice: breakEven,
+        brokerFeePercent: brokerFeePercent,
+        salesTaxPercent: salesTaxPercent,
+      );
+      expect(margin.profit, closeToDouble(0.0));
+    });
+  });
+
+  group('validation', () {
+    test('calculateMargin rejects non-positive prices', () {
+      expect(
+        () => MarginCalculator.calculateMargin(buyPrice: 0.0, sellPrice: 100.0),
+        throwsArgumentError,
+      );
+
+      expect(
+        () =>
+            MarginCalculator.calculateMargin(buyPrice: 100.0, sellPrice: -1.0),
+        throwsArgumentError,
+      );
+    });
+
+    test('calculators reject invalid fee percentages', () {
+      // Negative brokerFeePercent.
+      expect(
+        () => MarginCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 150.0,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      // brokerFeePercent + salesTaxPercent >= 100 for calculateMargin.
+      expect(
+        () => MarginCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 150.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+
+      // brokerFeePercent + salesTaxPercent >= 100 for breakEvenSellPrice.
+      expect(
+        () => MarginCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('calculators reject non-finite inputs', () {
+      // NaN price.
+      expect(
+        () => MarginCalculator.calculateMargin(
+          buyPrice: double.nan,
+          sellPrice: 100.0,
+        ),
+        throwsArgumentError,
+      );
+
+      // Infinity price.
+      expect(
+        () => MarginCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      // NaN fee percent.
+      expect(
+        () => MarginCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      // Infinity fee percent.
+      expect(
+        () => MarginCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          salesTaxPercent: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeCalculator facade', () {
+    test('matches MarginCalculator results', () {
+      const buyPrice = 100.0;
+      const sellPrice = 150.0;
+      const brokerFeePercent = 1.5;
+      const salesTaxPercent = 3.0;
+
+      final marginMargin = MarginCalculator.calculateMargin(
+        buyPrice: buyPrice,
+        sellPrice: sellPrice,
+        brokerFeePercent: brokerFeePercent,
+        salesTaxPercent: salesTaxPercent,
+      );
+
+      final tradeMargin = TradeCalculator.calculateMargin(
+        buyPrice: buyPrice,
+        sellPrice: sellPrice,
+        brokerFeePercent: brokerFeePercent,
+        salesTaxPercent: salesTaxPercent,
+      );
+
+      expect(tradeMargin.profit, marginMargin.profit);
+      expect(tradeMargin.marginPercent, marginMargin.marginPercent);
+      expect(tradeMargin.brokerFee, marginMargin.brokerFee);
+      expect(tradeMargin.salesTax, marginMargin.salesTax);
+      expect(tradeMargin.buyTotal, marginMargin.buyTotal);
+      expect(tradeMargin.sellNet, marginMargin.sellNet);
+      expect(tradeMargin.isProfitable, marginMargin.isProfitable);
+
+      final marginBreakEven = MarginCalculator.breakEvenSellPrice(
+        buyPrice: buyPrice,
+        brokerFeePercent: brokerFeePercent,
+        salesTaxPercent: salesTaxPercent,
+      );
+
+      final tradeBreakEven = TradeCalculator.breakEvenSellPrice(
+        buyPrice: buyPrice,
+        brokerFeePercent: brokerFeePercent,
+        salesTaxPercent: salesTaxPercent,
+      );
+
+      expect(tradeBreakEven, closeToDouble(marginBreakEven));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #485

## What changed

- Created `lib/features/market/calculators/margin_calculator.dart` with:
  - `TradeMargin` immutable value class with `isProfitable` getter
  - `MarginCalculator.calculateMargin()` — computes buyTotal, sellNet, profit, marginPercent, brokerFee, salesTax
  - `MarginCalculator.breakEvenSellPrice()` — returns sell price where profit ≈ 0
  - `TradeCalculator` compatibility facade forwarding to `MarginCalculator`
  - Input validation for non-positive prices, non-finite inputs, and invalid fee combinations
- Created `test/features/market/calculators/margin_calculator_test.dart` with 9 test cases covering profitable/unprofitable trades, custom fees, break-even round-trip, validation errors, non-finite inputs, and facade equivalence

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
flutter test test/features/market/calculators/margin_calculator_test.dart --coverage
flutter analyze
```

**Test results:** 9/9 passed (2.7s)
- calculateMargin: default fees ✓, unprofitable ✓, custom fees ✓
- breakEvenSellPrice: default fees round-trip ✓, custom fees round-trip ✓
- validation: non-positive prices ✓, invalid fee percentages ✓, non-finite inputs ✓
- TradeCalculator facade: equivalence ✓

**Coverage:** 95% (38/40 lines) on `lib/features/market/calculators/margin_calculator.dart`. The 2 uncovered lines are private constructors on static-only utility classes (`MarginCalculator._()`, `TradeCalculator._()`).

**Analyzer:** Zero warnings on touched files. Pre-existing `dangling_library_doc_comments` on `lib/core/utils/formatters.dart` — out of scope.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `TradeMargin` fields match the spec, `calculateMargin` computes all named variables (buyTotal, sellNet, profit, marginPercent, brokerFee, salesTax), `breakEvenSellPrice` uses the blueprint formula, `isProfitable` returns `profit > 0`, and `TradeCalculator` facade preserves spec method names.
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — 9 named tests all pass `flutter test`.
- AC 3 (No dependencies added unless absolutely required): ✓ no new dependencies; `pubspec.yaml` and `pubspec.lock` are unchanged from `origin/develop`.

### Coverage

- AC 1 (verbatim: "Implementation matches all behaviors described in the task body (see Notes)"): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart`
- AC 2 (verbatim: "All named tests pass the verification command"): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart`
- AC 3 (verbatim: "No dependencies added unless absolutely required"): ✓ verified — pubspec.yaml unchanged
- Task-body AC 1 (Capability "Margin calculator" is implemented per spec): ✓ addressed in `MarginCalculator` + `TradeMargin` classes
- Task-body AC 2 (Tests cover with ≥ 90% line coverage): ✓ 95% coverage on touched file
- Task-body AC 3 (flutter analyze reports zero new warnings): ✓ zero warnings on touched files
- Task-body AC 4 (PR body documents spec sections): ✓ addressed below

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — diff touches only the 2 expected files
- Do NOT add third-party dependencies: not violated — no new dependencies
- Do NOT refactor unrelated code in the touched files: not violated — both files are new, no unrelated changes

## Notes

**Spec sections addressed:** Market Module Specification > Price Calculations; capability: Trade Calculator: Margin and profit analysis / pending Margin calculator.

**Branch base:** The repo default branch is `develop` (not `main` as assumed in the plan). PR is correctly targeted at `develop`.

**Uncovered lines:** 2/40 lines uncovered (95% coverage) — both are private constructors (`const MarginCalculator._()` and `const TradeCalculator._()`) on classes that expose only static methods. No behavioral code paths are untested.