### PR TITLE
feat(market): add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,120 @@
+/// Immutable result of a trade margin calculation.
+///
+/// All fields are final; use [isProfitable] to check whether the trade
+/// generates a positive profit.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Returns `true` when the trade yields a strictly positive profit.
+  bool get isProfitable => profit > 0;
+}
+
+/// Pure calculator for Eve Online trade margin and break-even analysis.
+///
+/// All methods are static; [TradeCalculator] cannot be instantiated.
+class TradeCalculator {
+  // Coverage: intentionally inaccessible — prevents accidental instantiation.
+  const TradeCalculator._();
+
+  /// Computes the margin for a trade given buy and sell prices plus
+  /// applicable broker fee and sales tax percentages.
+  ///
+  /// The formulas are taken from the Market module blueprint
+  /// (Price Calculations section).
+  ///
+  /// Throws [ArgumentError] if any argument is negative or if the
+  /// combined sell-side fee percentages reach 100% or more.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateNonNegative('buyPrice', buyPrice);
+    _validateNonNegative('sellPrice', sellPrice);
+    _validateNonNegative('brokerFeePercent', brokerFeePercent);
+    _validateNonNegative('salesTaxPercent', salesTaxPercent);
+    _validateTotalSellFees(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Returns the sell price at which the trade breaks even
+  /// (profit == 0), given the buy price and fee percentages.
+  ///
+  /// Throws [ArgumentError] when any argument is negative or the
+  /// combined fee percentages reach 100% or more (which would make
+  /// the sell-side multiplier zero or negative).
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateNonNegative('buyPrice', buyPrice);
+    _validateNonNegative('brokerFeePercent', brokerFeePercent);
+    _validateNonNegative('salesTaxPercent', salesTaxPercent);
+    _validateTotalSellFees(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellFeeMultiplier =
+        1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    return buyTotal / sellFeeMultiplier;
+  }
+
+  static void _validateNonNegative(String name, double value) {
+    if (value < 0) {
+      throw ArgumentError.value(value, name, 'must be non-negative');
+    }
+  }
+
+  static void _validateTotalSellFees(
+    double brokerFeePercent,
+    double salesTaxPercent,
+  ) {
+    final totalSellFeePercent = brokerFeePercent + salesTaxPercent;
+    if (totalSellFeePercent >= 100) {
+      throw ArgumentError.value(
+        totalSellFeePercent,
+        'brokerFeePercent + salesTaxPercent',
+        'total sell fees must be less than 100%',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,251 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    group('calculateMargin', () {
+      test('calculates margin correctly', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result.buyPrice, 1000000);
+        expect(result.sellPrice, 1100000);
+        expect(result.buyTotal, 1010000);
+        expect(result.sellNet, closeTo(1067000, 0.001));
+        expect(result.profit, closeTo(57000, 0.001));
+        expect(result.marginPercent, closeTo(5.643564356435644, 0.001));
+        expect(result.brokerFee, 21000);
+        expect(result.salesTax, 22000);
+        expect(result.isProfitable, isTrue);
+      });
+
+      test('marks negative profit margins as not profitable', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 900000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result.profit, lessThan(0));
+        expect(result.isProfitable, isFalse);
+        expect(result.marginPercent, lessThan(0));
+      });
+
+      test('uses default broker fee and sales tax percentages', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 1000000,
+          sellPrice: 1100000,
+        );
+
+        expect(result.buyTotal, 1010000);
+        expect(result.sellNet, closeTo(1067000, 0.001));
+        expect(result.brokerFee, 21000);
+        expect(result.salesTax, 22000);
+      });
+
+      test('handles zero buy price without dividing by zero', () {
+        final result = TradeCalculator.calculateMargin(
+          buyPrice: 0,
+          sellPrice: 1000,
+        );
+
+        expect(result.buyTotal, 0);
+        expect(result.sellNet, closeTo(970, 0.001));
+        expect(result.profit, closeTo(970, 0.001));
+        expect(result.marginPercent, 0);
+        expect(result.isProfitable, isTrue);
+      });
+
+      test('throws ArgumentError for negative buyPrice', () {
+        expect(
+          () => TradeCalculator.calculateMargin(buyPrice: -1, sellPrice: 1000),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for negative sellPrice', () {
+        expect(
+          () => TradeCalculator.calculateMargin(buyPrice: 1000, sellPrice: -1),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for negative brokerFeePercent', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 1000,
+            sellPrice: 1100,
+            brokerFeePercent: -0.1,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for negative salesTaxPercent', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 1000,
+            sellPrice: 1100,
+            salesTaxPercent: -0.1,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test(
+        'throws ArgumentError when sell fees are 100 percent or greater',
+        () {
+          expect(
+            () => TradeCalculator.calculateMargin(
+              buyPrice: 1000,
+              sellPrice: 1100,
+              brokerFeePercent: 60,
+              salesTaxPercent: 40,
+            ),
+            throwsA(isA<ArgumentError>()),
+          );
+        },
+      );
+
+      test('throws ArgumentError when sell fees exceed 100 percent', () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 1000,
+            sellPrice: 1100,
+            brokerFeePercent: 60,
+            salesTaxPercent: 50,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
+    group('breakEvenSellPrice', () {
+      test('calculates break-even sell price', () {
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: 2.0,
+        );
+
+        expect(result, greaterThan(1010000));
+        expect(result, closeTo(1041237.1134020619, 0.001));
+      });
+
+      test('uses default broker fee and sales tax percentages', () {
+        final result = TradeCalculator.breakEvenSellPrice(buyPrice: 1000000);
+
+        expect(result, closeTo(1041237.1134020619, 0.001));
+      });
+
+      test('returns buyPrice when fees are zero', () {
+        final result = TradeCalculator.breakEvenSellPrice(
+          buyPrice: 1000000,
+          brokerFeePercent: 0,
+          salesTaxPercent: 0,
+        );
+
+        expect(result, 1000000);
+      });
+
+      test('handles zero buy price', () {
+        final result = TradeCalculator.breakEvenSellPrice(buyPrice: 0);
+
+        expect(result, 0);
+      });
+
+      test('throws ArgumentError for negative buyPrice', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(buyPrice: -1),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for negative brokerFeePercent', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 1000,
+            brokerFeePercent: -0.1,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('throws ArgumentError for negative salesTaxPercent', () {
+        expect(
+          () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 1000,
+            salesTaxPercent: -0.1,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test(
+        'throws ArgumentError when sell fees are 100 percent or greater',
+        () {
+          expect(
+            () => TradeCalculator.breakEvenSellPrice(
+              buyPrice: 1000,
+              brokerFeePercent: 60,
+              salesTaxPercent: 40,
+            ),
+            throwsA(isA<ArgumentError>()),
+          );
+        },
+      );
+    });
+  });
+
+  group('TradeMargin', () {
+    test('isProfitable is true when profit is positive', () {
+      const margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 120,
+        buyTotal: 101,
+        sellNet: 116.4,
+        profit: 15.4,
+        marginPercent: 15.247,
+        brokerFee: 3.2,
+        salesTax: 2.4,
+      );
+
+      expect(margin.isProfitable, isTrue);
+    });
+
+    test('isProfitable is false when profit is negative', () {
+      const margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 80,
+        buyTotal: 101,
+        sellNet: 77.6,
+        profit: -23.4,
+        marginPercent: -23.168,
+        brokerFee: 2.8,
+        salesTax: 1.6,
+      );
+
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('isProfitable is false when profit is exactly zero', () {
+      const margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 104.1237,
+        buyTotal: 101,
+        sellNet: 101,
+        profit: 0,
+        marginPercent: 0,
+        brokerFee: 2.04,
+        salesTax: 2.08,
+      );
+
+      expect(margin.isProfitable, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #493

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` — pure Dart `TradeCalculator` with static `calculateMargin` and `breakEvenSellPrice` methods, plus immutable `TradeMargin` result type
- Added `test/features/market/calculators/margin_calculator_test.dart` — 21 tests covering profitable margin, loss margin, break-even, zero-buy-price, default fees, and all `ArgumentError` validation branches

## How verified

```bash
cd ~/workspace/infiquetra/mimir
dart format lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
dart analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
flutter test test/features/market/calculators/margin_calculator_test.dart --coverage
```

- `dart analyze`: 0 issues on touched files
- `flutter test`: 21/21 passed
- Line coverage on `margin_calculator.dart`: 96.8% (30/31 lines; uncovered line is the intentionally-inaccessible private constructor `TradeCalculator._()`)

## Acceptance criteria coverage

- AC 1: "Implementation matches all behaviors described in the task body (see Notes)" — ✓ addressed in `TradeCalculator.calculateMargin` and `TradeCalculator.breakEvenSellPrice` using exact blueprint formulas
- AC 2: "All named tests pass the verification command" — ✓ addressed; all 21 tests pass including the named spec tests "calculates margin correctly" and "calculates break-even sell price"
- AC 3: "No dependencies added unless absolutely required" — ✓ addressed; no `pubspec.yaml` changes, no new imports beyond `flutter_test`
- Notes AC 1: "Capability 'Margin calculator' is implemented per spec" — ✓ addressed in `margin_calculator.dart` per the Price Calculations section of the Market blueprint
- Notes AC 2: "Tests cover the new capability with ≥ 90% line coverage on touched files" — ✓ addressed; 96.8% line coverage on the calculator file
- Notes AC 3: "`flutter analyze` reports zero new warnings" — ✓ addressed; `dart analyze` on touched files: 0 issues
- Notes AC 4: "PR body documents which spec sections are addressed" — ✓ addressed below

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only the two expected files are changed
- Do NOT add third-party dependencies unless required by the task body: not violated — no deps added
- Do NOT refactor unrelated code in the touched files: not violated — both files are new, no existing code refactored

## Notes

- Implementation targets the **Price Calculations** section of the Market module blueprint, specifically `TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, and `TradeMargin.isProfitable`
- The spec URL (https://github.com/infiquetra/mimir-blueprint/blob/main/platform-specs/03-feature-modules/market/specification.md) returned 404; formulas were taken from the spec excerpt in the issue body and the approved plan
- Private constructor `TradeCalculator._()` is intentionally unreachable (class is a static utility) — marked with a comment explaining this is intentional

### Coverage

- AC 1 (verbatim): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, `TradeMargin.isProfitable`
- AC 2 (verbatim): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — 21 tests, all pass
- AC 3 (verbatim): ✓ addressed — no `pubspec.yaml` or dependency changes
- Notes AC "Capability 'Margin calculator' is implemented per spec": ✓ addressed in `margin_calculator.dart`
- Notes AC "Tests cover with ≥ 90% line coverage": ✓ addressed — 96.8% on touched file
- Notes AC "`flutter analyze` zero new warnings": ✓ addressed — `dart analyze` clean on touched files
- Notes AC "PR body documents spec sections": ✓ addressed — Price Calculations section documented above