### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,129 @@
+/// Market module — Price Calculations / Trade Calculator margin formulas.
+///
+/// Implements the station-trading margin calculator and break-even sell
+/// price formula defined in the mimir-blueprint market specification.
+///
+/// All public functions validate inputs before computing and throw
+/// [ArgumentError] on invalid money values, percentage values, or
+/// sell-side fee combinations that would produce a negative denominator.
+library;
+
+// No third-party imports — uses only Dart core.
+
+/// Private input validation helpers.
+
+void _validateMoney(String name, double value) {
+  if (!value.isFinite || value < 0) {
+    throw ArgumentError.value(value, name, 'must be a finite non-negative number');
+  }
+}
+
+void _validatePercent(String name, double value) {
+  if (!value.isFinite || value < 0) {
+    throw ArgumentError.value(value, name, 'must be a finite non-negative percentage');
+  }
+}
+
+void _validateSellCostRate(double brokerFeePercent, double salesTaxPercent) {
+  final combined = brokerFeePercent + salesTaxPercent;
+  if (combined >= 100) {
+    throw ArgumentError.value(
+      combined,
+      'brokerFeePercent + salesTaxPercent',
+      'must be less than 100 so sell net remains positive',
+    );
+  }
+}
+
+/// Station-trading margin calculator.
+///
+/// A static namespace. Not meant to be instantiated — call the public static
+/// methods directly.
+final class TradeCalculator {
+  const TradeCalculator._();
+
+  /// Calculate profit margin for station trading.
+  ///
+  /// [buyPrice] and [sellPrice] must be finite, non-negative numbers.
+  /// [brokerFeePercent] and [salesTaxPercent] must be finite, non-negative
+  /// percentages whose sum is strictly less than 100.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateMoney('buyPrice', buyPrice);
+    _validateMoney('sellPrice', sellPrice);
+    _validatePercent('brokerFeePercent', brokerFeePercent);
+    _validatePercent('salesTaxPercent', salesTaxPercent);
+    _validateSellCostRate(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet = sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+    final brokerFee = buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculate break-even sell price.
+  ///
+  /// Returns the sell price at which [calculateMargin] would yield a profit
+  /// of zero and `marginPercent` of zero (assuming the same default or
+  /// custom fee percentages are used on both sides of the trade).
+  ///
+  /// [buyPrice] must be a finite, non-negative number.
+  /// [brokerFeePercent] and [salesTaxPercent] share the same validation as
+  /// in [calculateMargin].
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateMoney('buyPrice', buyPrice);
+    _validatePercent('brokerFeePercent', brokerFeePercent);
+    _validatePercent('salesTaxPercent', salesTaxPercent);
+    _validateSellCostRate(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    return buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+  }
+}
+
+/// Result model returned by [TradeCalculator.calculateMargin].
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Whether the trade is profitable (profit > 0).
+  bool get isProfitable => profit > 0;
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,223 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator.calculateMargin', () {
+    test('calculates profitable station trade with default fees', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 150.0,
+      );
+
+      expect(result.buyPrice, 100.0);
+      expect(result.sellPrice, 150.0);
+      expect(result.buyTotal, closeTo(101.0, 0.000001));
+      expect(result.sellNet, closeTo(145.5, 0.000001));
+      expect(result.profit, closeTo(44.5, 0.000001));
+      expect(result.marginPercent, closeTo(44.05940594059406, 0.000001));
+      expect(result.brokerFee, closeTo(2.5, 0.000001));
+      expect(result.salesTax, closeTo(3.0, 0.000001));
+      expect(result.isProfitable, true);
+    });
+
+    test('calculates loss-making trade as not profitable', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 90.0,
+      );
+
+      expect(result.profit, closeTo(-13.7, 0.000001));
+      expect(result.isProfitable, false);
+    });
+
+    test('supports custom broker fee and sales tax percentages', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 200.0,
+        sellPrice: 250.0,
+        brokerFeePercent: 2.0,
+        salesTaxPercent: 1.5,
+      );
+
+      // buyTotal  = 200 * (1 + 2/100)   = 204.0
+      // sellNet   = 250 * (1 - 2/100 - 1.5/100) = 250 * 0.965 = 241.25
+      // profit    = 241.25 - 204.0 = 37.25
+      // marginPct = (37.25 / 204.0) * 100 = 18.259803921568627
+      // brokerFee = 200*2/100 + 250*2/100 = 4 + 5 = 9.0
+      // salesTax  = 250 * 1.5/100 = 3.75
+      expect(result.buyTotal, closeTo(204.0, 0.000001));
+      expect(result.sellNet, closeTo(241.25, 0.000001));
+      expect(result.profit, closeTo(37.25, 0.000001));
+      expect(result.marginPercent, closeTo(18.259803921568627, 0.000001));
+      expect(result.brokerFee, closeTo(9.0, 0.000001));
+      expect(result.salesTax, closeTo(3.75, 0.000001));
+      expect(result.isProfitable, true);
+    });
+
+    test('returns zero margin percent when buy total is zero', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 0.0,
+        sellPrice: 0.0,
+        brokerFeePercent: 0.0,
+        salesTaxPercent: 0.0,
+      );
+
+      expect(result.buyTotal, 0.0);
+      expect(result.profit, 0.0);
+      expect(result.marginPercent, 0.0);
+      expect(result.isProfitable, false);
+    });
+
+    test('rejects invalid prices and fee percentages', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.nan,
+          sellPrice: 100.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 100.0,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 100.0,
+          brokerFeePercent: 1.0,
+          salesTaxPercent: double.nan,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: -50.0,
+          sellPrice: 100.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects combined sell-side fees at or above 100 percent', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 200.0,
+          brokerFeePercent: 60.0,
+          salesTaxPercent: 40.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 200.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeCalculator.breakEvenSellPrice', () {
+    test('calculates break-even sell price with default fees', () {
+      // buyTotal = 100 * 1.01 = 101.0
+      // sellPrice = 101.0 / (1 - 0.01 - 0.02) = 101.0 / 0.97
+      final price = TradeCalculator.breakEvenSellPrice(buyPrice: 100.0);
+
+      expect(price, closeTo(104.12371134020619, 0.000001));
+    });
+
+    test('calculates break-even sell price with custom fees', () {
+      // buyTotal = 100 * (1 + 2/100) = 102.0
+      // sellPrice = 102.0 / (1 - 2/100 - 3/100) = 102.0 / 0.95
+      final price = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 100.0,
+        brokerFeePercent: 2.0,
+        salesTaxPercent: 3.0,
+      );
+
+      expect(price, closeTo(107.36842105263158, 0.000001));
+    });
+
+    test('rejects invalid inputs', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: double.nan),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 60.0,
+          salesTaxPercent: 40.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeMargin', () {
+    test('isProfitable is true only when profit is positive', () {
+      const profitable = TradeMargin(
+        buyPrice: 100.0,
+        sellPrice: 150.0,
+        buyTotal: 101.0,
+        sellNet: 145.5,
+        profit: 44.5,
+        marginPercent: 44.06,
+        brokerFee: 2.5,
+        salesTax: 3.0,
+      );
+      expect(profitable.isProfitable, true);
+
+      const breakEven = TradeMargin(
+        buyPrice: 100.0,
+        sellPrice: 104.12,
+        buyTotal: 101.0,
+        sellNet: 101.0,
+        profit: 0.0,
+        marginPercent: 0.0,
+        brokerFee: 2.04,
+        salesTax: 2.08,
+      );
+      expect(breakEven.isProfitable, false);
+
+      const loss = TradeMargin(
+        buyPrice: 100.0,
+        sellPrice: 90.0,
+        buyTotal: 101.0,
+        sellNet: 87.3,
+        profit: -13.7,
+        marginPercent: -13.56,
+        brokerFee: 1.9,
+        salesTax: 1.8,
+      );
+      expect(loss.isProfitable, false);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #497

## What changed

- **`lib/features/market/calculators/margin_calculator.dart`** (new): Implements the Market module Price Calculations / Trade Calculator margin formulas from the mimir-blueprint spec. Contains:
  - `TradeCalculator` final class with private constructor — static namespace for the two public formulas
  - `TradeCalculator.calculateMargin()` — computes `TradeMargin` with all spec fields (`buyTotal`, `sellNet`, `profit`, `marginPercent`, `brokerFee`, `salesTax`)
  - `TradeCalculator.breakEvenSellPrice()` — computes the sell price that yields zero profit
  - `TradeMargin` — immutable result model with `isProfitable => profit > 0` getter
  - Private validation helpers for money values, percentage values, and sell-side fee rate safety

- **`test/features/market/calculators/margin_calculator_test.dart`** (new): 10 tests covering all public formulas, validation paths, and edge cases. Uses `group()/test()` pattern matching existing conventions, `closeTo()` for floating-point assertions, and `throwsArgumentError` for validation failures.

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
# 00:00 +10: All tests passed!

flutter analyze
# Only pre-existing info in lib/core/utils/formatters.dart (dangling_library_doc_comments) — zero new warnings from touched files.

flutter test --coverage test/features/market/calculators/margin_calculator_test.dart
# lcov reports 32/33 instrumented lines hit (97.0%) on margin_calculator.dart
# The 1 missed line is the class declaration line (not executable code)
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body (see Notes) — ✓ All spec formulas, fields, and the `isProfitable` getter implemented exactly as described; validated against the spec excerpt's code block
- AC 2: All named tests pass the verification command — ✓ 10/10 tests pass on first run (profitable, loss, custom fees, zero buy total, invalid inputs, fee enforcement, break-even, isProfitable)
- AC 3: No dependencies added unless absolutely required — ✓ No imports in source file, test file uses existing `flutter_test` only; pubspec.yaml unchanged, pubspec.lock reverted to origin/main

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below — ✓ Only the two files listed; diff shows exactly 2 files
- Do NOT add third-party dependencies unless required by the task body — ✓ Zero new dependencies
- Do NOT refactor unrelated code in the touched files — ✓ Both files are new, no existing code was touched

## Notes

- Spec section addressed: **Market Module Specification → Price Calculations → TradeCalculator / TradeMargin**
- The `lib/features/` and `test/features/` directories did not exist; created as necessary scaffolding per the approved plan
- Coverage on touched file: 97% (32/33 lines hit; the sole missed "line" is the class declaration which Dart's lcov doesn't count as executable)
- Pre-existing analyzer info (`dangling_library_doc_comments` in `lib/core/utils/formatters.dart`) is not addressed — it's outside the touched fileset

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `calculateMargin`, `breakEvenSellPrice`, `TradeMargin`, `isProfitable`
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — 10 tests, all passing
- AC 3 (No dependencies added unless absolutely required): ✓ zero new deps, pubspec.lock reverted