### PR TITLE
feat(market): add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,202 @@
+import 'package:mimir/core/logging/logger.dart';
+
+/// Immutable result of a trade margin calculation.
+///
+/// All fields are [double] and final. No JSON serialization or code
+/// generation is included — this is a pure value object.
+class TradeMargin {
+  /// Original buy price.
+  final double buyPrice;
+
+  /// Original sell price.
+  final double sellPrice;
+
+  /// Total cost to buy, including broker fee: `buyPrice * (1 + brokerFee / 100)`.
+  final double buyTotal;
+
+  /// Net proceeds from selling, after broker fee and sales tax:
+  /// `sellPrice * (1 - brokerFee / 100 - salesTax / 100)`.
+  final double sellNet;
+
+  /// Profit (positive) or loss (negative): `sellNet - buyTotal`.
+  final double profit;
+
+  /// Margin as a percentage of buyTotal. Zero when buyTotal is zero.
+  final double marginPercent;
+
+  /// Total broker fee paid: `brokerFee on buy + brokerFee on sell`.
+  final double brokerFee;
+
+  /// Sales tax paid on the sell side: `sellPrice * salesTax / 100`.
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Whether this trade is profitable (profit > 0).
+  bool get isProfitable => profit > 0;
+}
+
+/// Pure calculator for EVE Online trade margins.
+///
+/// Static methods accept input values and return either a [TradeMargin]
+/// or a break-even sell price.  All public methods validate inputs and
+/// throw [ArgumentError] with context when values are invalid.
+class TradeCalculator {
+  static const double _defaultBrokerFeePercent = 1.0;
+  static const double _defaultSalesTaxPercent = 2.0;
+  static const String _tag = 'MARKET';
+
+  // -----------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------
+
+  /// Calculate the trade margin for a buy/sell pair.
+  ///
+  /// [buyPrice] and [sellPrice] must be >= 0.
+  /// [brokerFeePercent] and [salesTaxPercent] must be >= 0 and,
+  /// together, must be < 100 (otherwise sell net proceeds would be
+  /// zero or negative).
+  ///
+  /// Defaults: [brokerFeePercent] = 1.0, [salesTaxPercent] = 2.0
+  /// (EVE Online standard NPC station rates).
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = _defaultBrokerFeePercent,
+    double salesTaxPercent = _defaultSalesTaxPercent,
+  }) {
+    _validatePrice('buyPrice', buyPrice, allowZero: true);
+    _validatePrice('sellPrice', sellPrice, allowZero: true);
+    _validateFeePercentages(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    final result = TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+
+    Log.d(
+      _tag,
+      'Margin calc: buy=$buyPrice sell=$sellPrice '
+      'bf=$brokerFeePercent% st=$salesTaxPercent% '
+      'profit=$profit margin=$marginPercent%',
+    );
+
+    return result;
+  }
+
+  /// Calculate the break-even sell price for a given buy price and fee
+  /// rates so that profit = 0.
+  ///
+  /// [buyPrice] must be >= 0.
+  /// [brokerFeePercent] and [salesTaxPercent] must be >= 0 and,
+  /// together, must be < 100.
+  ///
+  /// Defaults: [brokerFeePercent] = 1.0, [salesTaxPercent] = 2.0.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = _defaultBrokerFeePercent,
+    double salesTaxPercent = _defaultSalesTaxPercent,
+  }) {
+    _validatePrice('buyPrice', buyPrice, allowZero: true);
+    _validateFeePercentages(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    final breakEven = buyTotal / denominator;
+
+    Log.d(
+      _tag,
+      'Break-even: buy=$buyPrice bf=$brokerFeePercent% '
+      'st=$salesTaxPercent% → $breakEven',
+    );
+
+    return breakEven;
+  }
+
+  // -----------------------------------------------------------------
+  // Validation helpers
+  // -----------------------------------------------------------------
+
+  /// Validate that [value] is a finite number >= 0.
+  static void _validatePrice(
+    String name,
+    double value, {
+    required bool allowZero,
+  }) {
+    if (value.isNaN || value.isInfinite) {
+      throw ArgumentError.value(value, name, 'must be a finite number');
+    }
+    final lower = allowZero ? 0.0 : 0.0;
+    if (value < lower) {
+      throw ArgumentError.value(value, name, 'must be >= 0, got $value');
+    }
+  }
+
+  /// Validate that fee percentages are non-negative and their sum
+  /// is < 100.
+  static void _validateFeePercentages(
+    double brokerFeePercent,
+    double salesTaxPercent,
+  ) {
+    if (brokerFeePercent.isNaN || brokerFeePercent.isInfinite) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must be a finite number',
+      );
+    }
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must be >= 0, got $brokerFeePercent',
+      );
+    }
+    if (salesTaxPercent.isNaN || salesTaxPercent.isInfinite) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must be a finite number',
+      );
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must be >= 0, got $salesTaxPercent',
+      );
+    }
+    if (brokerFeePercent + salesTaxPercent >= 100) {
+      throw ArgumentError.value(
+        brokerFeePercent + salesTaxPercent,
+        'brokerFeePercent + salesTaxPercent',
+        'must be < 100 (would produce zero or negative sell proceeds). '
+            'brokerFeePercent=$brokerFeePercent, salesTaxPercent=$salesTaxPercent',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator', () {
+    // ---------------------------------------------------------------
+    // Success-path tests
+    // ---------------------------------------------------------------
+
+    test('calculates margin correctly', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1100000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(margin.buyPrice, 1000000);
+      expect(margin.sellPrice, 1100000);
+      expect(margin.buyTotal, 1010000);
+      expect(margin.sellNet, 1067000);
+      expect(margin.profit, 57000);
+      expect(margin.marginPercent, closeTo(5.6435643564, 1e-8));
+      expect(margin.brokerFee, 21000);
+      expect(margin.salesTax, 22000);
+      expect(margin.isProfitable, isTrue);
+    });
+
+    test('calculates break-even sell price', () {
+      final breakEven = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000,
+        brokerFeePercent: 1.0,
+        salesTaxPercent: 2.0,
+      );
+
+      expect(breakEven, greaterThan(1010000));
+      expect(breakEven, closeTo(1041237.1134, 1e-4));
+    });
+
+    test('uses default broker fee and sales tax percentages', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000,
+        sellPrice: 1100,
+      );
+
+      // With 1% broker fee, 2% sales tax:
+      // buyTotal  = 1000 * 1.01 = 1010
+      // sellNet   = 1100 * 0.97 = 1067
+      // profit    = 1067 - 1010 = 57
+      // brokerFee = 1000*0.01 + 1100*0.01 = 21
+      // salesTax  = 1100 * 0.02 = 22
+      expect(margin.buyPrice, 1000);
+      expect(margin.sellPrice, 1100);
+      expect(margin.buyTotal, 1010);
+      expect(margin.sellNet, 1067);
+      expect(margin.profit, 57);
+      expect(margin.brokerFee, 21);
+      expect(margin.salesTax, 22);
+    });
+
+    test('marks negative profit as not profitable', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 1000000,
+        sellPrice: 1000000,
+      );
+
+      expect(margin.profit, lessThan(0));
+      expect(margin.marginPercent, lessThan(0));
+      expect(margin.isProfitable, isFalse);
+    });
+
+    // ---------------------------------------------------------------
+    // Boundary tests
+    // ---------------------------------------------------------------
+
+    test('returns zero margin percent for zero buy total', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 0,
+        sellPrice: 0,
+        brokerFeePercent: 0,
+        salesTaxPercent: 0,
+      );
+
+      expect(margin.buyTotal, 0);
+      expect(margin.profit, 0);
+      expect(margin.marginPercent, 0);
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('break-even sell price is zero for zero buy price', () {
+      final breakEven = TradeCalculator.breakEvenSellPrice(buyPrice: 0);
+
+      expect(breakEven, 0);
+    });
+
+    // ---------------------------------------------------------------
+    // Error-path tests
+    // ---------------------------------------------------------------
+
+    test('throws ArgumentError for negative prices', () {
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: -1, sellPrice: 100),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: 100, sellPrice: -1),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: -1),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws ArgumentError for invalid fee percentages', () {
+      // Negative brokerFeePercent
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 200,
+          brokerFeePercent: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Negative salesTaxPercent
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 200,
+          salesTaxPercent: -1,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Sum >= 100 — calculateMargin
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 200,
+          brokerFeePercent: 50,
+          salesTaxPercent: 50,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Sum >= 100 — breakEvenSellPrice
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: 50,
+          salesTaxPercent: 50,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the **Margin calculator** capability from the mimir-blueprint
market module **Price Calculations** section.

### What's implemented

| Symbol | Description |
|--------|-------------|
| `TradeMargin` | Immutable value object: `buyPrice` / `sellPrice` / `buyTotal` / `sellNet` / `profit` / `marginPercent` / `brokerFee` / `salesTax` |
| `TradeMargin.isProfitable` | `profit > 0` |
| `TradeCalculator.calculateMargin` | Full margin analysis with input validation |
| `TradeCalculator.breakEvenSellPrice` | Exact break-even formula from blueprint |

### Formulas (per blueprint spec)

- `buyTotal = buyPrice * (1 + brokerFeePercent / 100)`
- `sellNet = sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100)`
- `profit = sellNet - buyTotal`
- `marginPercent = buyTotal == 0 ? 0 : (profit / buyTotal) * 100`
- `brokerFee = buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100`
- `salesTax = sellPrice * salesTaxPercent / 100`
- `breakEven = buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100)`

### Input validation

- Prices must be finite and >= 0
- Fee percentages must be finite and >= 0
- Sum of brokerFeePercent + salesTaxPercent must be < 100
- All violations throw `ArgumentError` with parameter-specific context
- NaN / Infinity inputs are explicitly rejected

### Default values

- Broker fee: 1.0% (EVE NPC station rate)
- Sales tax: 2.0% (EVE NPC station rate)

## Test Results

```
flutter test test/features/market/calculators/margin_calculator_test.dart
# 00:00 +8: All tests passed!
```

### Tests (8 total)

| Test | Status |
|------|--------|
| calculates margin correctly | ✅ PASS |
| calculates break-even sell price | ✅ PASS |
| uses default broker fee and sales tax percentages | ✅ PASS |
| marks negative profit as not profitable | ✅ PASS |
| returns zero margin percent for zero buy total | ✅ PASS |
| break-even sell price is zero for zero buy price | ✅ PASS |
| throws ArgumentError for negative prices | ✅ PASS |
| throws ArgumentError for invalid fee percentages | ✅ PASS |

## Analyzer

```
flutter analyze — zero warnings from lib/features/market/calculators/margin_calculator.dart
                    zero warnings from test/features/market/calculators/margin_calculator_test.dart
```

Pre-existing warnings exist elsewhere in the codebase — none originate from these two files.

## Files changed

- `lib/features/market/calculators/margin_calculator.dart`
- `test/features/market/calculators/margin_calculator_test.dart`

No other files modified. No new dependencies added.

## Spec sections addressed

- Market blueprint: **Price Calculations** section
- Implements: `TradeCalculator`, `TradeMargin`, `calculateMargin`, `breakEvenSellPrice`, `isProfitable`

Closes #508

## Benchmark Verification

The card (`[BENCH t01 deepseek-v4-pro-c]`) specifies a benchmark verification step.
This step references a benchmark harness / tooling that is **not available** in this
repository's existing test infrastructure. The existing `flutter test` command was
used and all 8 tests pass, but the benchmark-specific DoD step could not be executed.

The margin calculator itself is fully implemented, all unit tests pass, and
`flutter analyze` reports zero new warnings. The benchmark run (task id: `t01`)
remains as a follow-up to be executed when the benchmark harness is available.