### PR TITLE
feat(market): add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,3 +1,5 @@
+import 'package:mimir/core/logging/logger.dart';
+
 /// Pure station-trading margin calculator.
 ///
 /// Provides the core arithmetic for evaluating market buy/sell profitability,
@@ -21,6 +23,7 @@ class TradeCalculator {
     double brokerFeePercent = 1.0,
     double salesTaxPercent = 2.0,
   }) {
+    Log.d('CALC', 'calculateMargin entry (buyPrice=$buyPrice, sellPrice=$sellPrice, brokerFee=$brokerFeePercent%, salesTax=$salesTaxPercent%)');
     _validatePrice(buyPrice, 'buyPrice');
     _validatePrice(sellPrice, 'sellPrice');
     _validateFeePercent(brokerFeePercent, 'brokerFeePercent');
@@ -36,6 +39,7 @@ class TradeCalculator {
         buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
     final salesTax = sellPrice * salesTaxPercent / 100;
 
+    Log.d('CALC', 'calculateMargin success (profit=$profit, margin=$marginPercent%)');
     return TradeMargin(
       buyPrice: buyPrice,
       sellPrice: sellPrice,
@@ -58,6 +62,7 @@ class TradeCalculator {
     double brokerFeePercent = 1.0,
     double salesTaxPercent = 2.0,
   }) {
+    Log.d('CALC', 'breakEvenSellPrice entry (buyPrice=$buyPrice, brokerFee=$brokerFeePercent%, salesTax=$salesTaxPercent%)');
     _validatePrice(buyPrice, 'buyPrice');
     _validateFeePercent(brokerFeePercent, 'brokerFeePercent');
     _validateFeePercent(salesTaxPercent, 'salesTaxPercent');
@@ -65,9 +70,14 @@ class TradeCalculator {
 
     final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
     final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
-    return buyTotal / denominator;
+    final result = buyTotal / denominator;
+    Log.d('CALC', 'breakEvenSellPrice success (result=$result)');
+    return result;
   }
 
+  /// Validates that [value] is finite and non-negative.
+  ///
+  /// Throws [ArgumentError] if [value] is NaN, infinite, or less than zero.
   static void _validatePrice(double value, String name) {
     if (!value.isFinite) {
       throw ArgumentError.value(
@@ -85,23 +95,16 @@ class TradeCalculator {
     }
   }
 
+  /// Validates that [value] is a finite, non-negative fee percentage.
+  ///
+  /// Throws [ArgumentError] if [value] is NaN, infinite, or less than zero.
   static void _validateFeePercent(double value, String name) {
-    if (!value.isFinite) {
-      throw ArgumentError.value(
-        value,
-        name,
-        'expected finite, got $value',
-      );
-    }
-    if (value < 0) {
-      throw ArgumentError.value(
-        value,
-        name,
-        'expected >= 0, got $value',
-      );
-    }
+    _validatePrice(value, name);
   }
 
+  /// Ensures the combined sell-side fees are below 100%.
+  ///
+  /// Throws [ArgumentError] if [brokerFeePercent + salesTaxPercent] >= 100.
   static void _validateTotalSellFee(
     double brokerFeePercent,
     double salesTaxPercent,

--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,147 @@
+/// Pure station-trading margin calculator.
+///
+/// Provides the core arithmetic for evaluating market buy/sell profitability,
+/// computing margin percentages, and determining break-even sell prices.
+///
+/// Uses standard EVE Online station trading formulas:
+/// - Broker fee applied to both buy and sell sides
+/// - Sales tax applied to sell side only
+///
+/// All percentages are expressed as doubles (e.g., 1.0 = 1%).
+class TradeCalculator {
+  /// Calculates the full margin breakdown for a buy-sell pair.
+  ///
+  /// Returns an immutable [TradeMargin] with computed fields.
+  ///
+  /// Throws [ArgumentError] if any input is negative, non-finite, or
+  /// the combined sell-side fees (broker + sales tax) reach 100% or above.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice(buyPrice, 'buyPrice');
+    _validatePrice(sellPrice, 'sellPrice');
+    _validateFeePercent(brokerFeePercent, 'brokerFeePercent');
+    _validateFeePercent(salesTaxPercent, 'salesTaxPercent');
+    _validateTotalSellFee(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = buyTotal == 0 ? 0.0 : (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Computes the minimum sell price needed to break even after fees.
+  ///
+  /// Throws [ArgumentError] if [buyPrice], [brokerFeePercent], or
+  /// [salesTaxPercent] are invalid, or if the combined sell-side
+  /// fees reach 100% or above (making break-even impossible).
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice(buyPrice, 'buyPrice');
+    _validateFeePercent(brokerFeePercent, 'brokerFeePercent');
+    _validateFeePercent(salesTaxPercent, 'salesTaxPercent');
+    _validateTotalSellFee(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    return buyTotal / denominator;
+  }
+
+  static void _validatePrice(double value, String name) {
+    if (!value.isFinite) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'expected finite, got $value',
+      );
+    }
+    if (value < 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'expected >= 0, got $value',
+      );
+    }
+  }
+
+  static void _validateFeePercent(double value, String name) {
+    if (!value.isFinite) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'expected finite, got $value',
+      );
+    }
+    if (value < 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'expected >= 0, got $value',
+      );
+    }
+  }
+
+  static void _validateTotalSellFee(
+    double brokerFeePercent,
+    double salesTaxPercent,
+  ) {
+    final total = brokerFeePercent + salesTaxPercent;
+    if (total >= 100) {
+      throw ArgumentError.value(
+        total,
+        'brokerFeePercent + salesTaxPercent',
+        'expected < 100, got $total',
+      );
+    }
+  }
+}
+
+/// Immutable result of a margin calculation.
+///
+/// All fields are final doubles; [isProfitable] is a derived getter
+/// returning `true` when [profit] is strictly positive.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Whether this trade produces a positive profit.
+  bool get isProfitable => profit > 0;
+}

--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,5 +1,3 @@
-import 'package:mimir/core/logging/logger.dart';
-
 /// Pure station-trading margin calculator.
 ///
 /// Provides the core arithmetic for evaluating market buy/sell profitability,
@@ -23,7 +21,6 @@ class TradeCalculator {
     double brokerFeePercent = 1.0,
     double salesTaxPercent = 2.0,
   }) {
-    Log.d('CALC', 'calculateMargin entry (buyPrice=$buyPrice, sellPrice=$sellPrice, brokerFee=$brokerFeePercent%, salesTax=$salesTaxPercent%)');
     _validatePrice(buyPrice, 'buyPrice');
     _validatePrice(sellPrice, 'sellPrice');
     _validateFeePercent(brokerFeePercent, 'brokerFeePercent');
@@ -39,7 +36,6 @@ class TradeCalculator {
         buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
     final salesTax = sellPrice * salesTaxPercent / 100;
 
-    Log.d('CALC', 'calculateMargin success (profit=$profit, margin=$marginPercent%)');
     return TradeMargin(
       buyPrice: buyPrice,
       sellPrice: sellPrice,
@@ -62,7 +58,6 @@ class TradeCalculator {
     double brokerFeePercent = 1.0,
     double salesTaxPercent = 2.0,
   }) {
-    Log.d('CALC', 'breakEvenSellPrice entry (buyPrice=$buyPrice, brokerFee=$brokerFeePercent%, salesTax=$salesTaxPercent%)');
     _validatePrice(buyPrice, 'buyPrice');
     _validateFeePercent(brokerFeePercent, 'brokerFeePercent');
     _validateFeePercent(salesTaxPercent, 'salesTaxPercent');
@@ -71,7 +66,6 @@ class TradeCalculator {
     final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
     final denominator = 1 - brokerFeePercent / 100 - salesTaxPercent / 100;
     final result = buyTotal / denominator;
-    Log.d('CALC', 'breakEvenSellPrice success (result=$result)');
     return result;
   }
 

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -3,7 +3,7 @@ import 'package:mimir/features/market/calculators/margin_calculator.dart';
 
 void main() {
   group('TradeCalculator.calculateMargin', () {
-    test('calculates default station trading margin from blueprint formula',
+    test('calculates margin correctly',
         () {
       final result = TradeCalculator.calculateMargin(
         buyPrice: 100.0,

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -163,6 +163,13 @@ void main() {
       expect(result, closeTo(214.73684210526315, 1e-10));
     });
 
+    test('returns zero break-even sell price for zero buy price', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 0.0,
+      );
+      expect(result, 0.0);
+    });
+
     test('throws ArgumentError when sell-side fees make denominator invalid',
         () {
       // broker + salesTax = 100
@@ -182,6 +189,44 @@ void main() {
           brokerFeePercent: 60.0,
           salesTaxPercent: 50.0,
         ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws ArgumentError for negative or non-finite inputs', () {
+      // Negative buyPrice
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: -1.0),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Negative brokerFeePercent
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: -0.5,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Negative salesTaxPercent
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          salesTaxPercent: -0.5,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // NaN buyPrice
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: double.nan),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Infinite buyPrice
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: double.infinity),
         throwsA(isA<ArgumentError>()),
       );
     });

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator.calculateMargin', () {
+    test('calculates default station trading margin from blueprint formula',
+        () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 120.0,
+      );
+
+      expect(result.buyPrice, 100.0);
+      expect(result.sellPrice, 120.0);
+      expect(result.buyTotal, closeTo(101.0, 1e-10));
+      expect(result.sellNet, closeTo(116.4, 1e-10));
+      expect(result.profit, closeTo(15.4, 1e-10));
+      expect(result.marginPercent, closeTo(15.247524752475248, 1e-10));
+      expect(result.brokerFee, closeTo(2.2, 1e-10));
+      expect(result.salesTax, closeTo(2.4, 1e-10));
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('calculates loss-making trade as not profitable', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 95.0,
+      );
+
+      expect(result.profit, lessThan(0));
+      expect(result.isProfitable, isFalse);
+    });
+
+    test('uses custom broker fee and sales tax percentages', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 200.0,
+        sellPrice: 250.0,
+        brokerFeePercent: 2.5,
+        salesTaxPercent: 3.5,
+      );
+
+      // buyTotal = 200 * (1 + 2.5/100) = 200 * 1.025 = 205
+      expect(result.buyTotal, closeTo(205.0, 1e-10));
+      // sellNet = 250 * (1 - 2.5/100 - 3.5/100) = 250 * 0.94 = 235
+      expect(result.sellNet, closeTo(235.0, 1e-10));
+      // profit = 235 - 205 = 30
+      expect(result.profit, closeTo(30.0, 1e-10));
+      // marginPercent = (30/205) * 100 ≈ 14.634...
+      expect(result.marginPercent, closeTo(14.634146341463415, 1e-10));
+      // brokerFee = 200*2.5/100 + 250*2.5/100 = 5 + 6.25 = 11.25
+      expect(result.brokerFee, closeTo(11.25, 1e-10));
+      // salesTax = 250 * 3.5/100 = 8.75
+      expect(result.salesTax, closeTo(8.75, 1e-10));
+      expect(result.isProfitable, isTrue);
+    });
+
+    test('returns zero margin percent for zero buy total', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 0.0,
+        sellPrice: 0.0,
+      );
+
+      expect(result.buyTotal, 0.0);
+      expect(result.marginPercent, 0.0);
+      expect(result.marginPercent.isNaN, isFalse);
+      expect(result.isProfitable, isFalse);
+    });
+
+    test('throws ArgumentError for negative or non-finite price and fee inputs',
+        () {
+      // Negative buyPrice
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: -1.0,
+          sellPrice: 120.0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Negative sellPrice
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: -1.0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Negative fee
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: -0.5,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // NaN
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.nan,
+          sellPrice: 120.0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Infinite
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.infinity,
+          sellPrice: 120.0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Sell-side fees >= 100
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: 60.0,
+          salesTaxPercent: 40.0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Sell-side fees > 100
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: 60.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('TradeCalculator.breakEvenSellPrice', () {
+    test('calculates default break-even sell price', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 100.0,
+      );
+
+      // buyTotal = 100 * 1.01 = 101
+      // denominator = 1 - 0.01 - 0.02 = 0.97
+      // result = 101 / 0.97 ≈ 104.1237...
+      expect(result, closeTo(104.12371134020619, 1e-10));
+    });
+
+    test('calculates break-even with custom fees', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 200.0,
+        brokerFeePercent: 2.0,
+        salesTaxPercent: 3.0,
+      );
+
+      // buyTotal = 200 * 1.02 = 204
+      // denominator = 1 - 0.02 - 0.03 = 0.95
+      // result = 204 / 0.95 ≈ 214.7368...
+      expect(result, closeTo(214.73684210526315, 1e-10));
+    });
+
+    test('throws ArgumentError when sell-side fees make denominator invalid',
+        () {
+      // broker + salesTax = 100
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 60.0,
+          salesTaxPercent: 40.0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // broker + salesTax > 100
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 60.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('TradeMargin', () {
+    test('isProfitable is true only for positive profit', () {
+      const profitable = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 120,
+        buyTotal: 101,
+        sellNet: 116.4,
+        profit: 15.4,
+        marginPercent: 15.2475,
+        brokerFee: 2.2,
+        salesTax: 2.4,
+      );
+      expect(profitable.isProfitable, isTrue);
+
+      const breakeven = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 103.09,
+        buyTotal: 101,
+        sellNet: 101,
+        profit: 0,
+        marginPercent: 0,
+        brokerFee: 2.03,
+        salesTax: 2.06,
+      );
+      expect(breakeven.isProfitable, isFalse);
+
+      const loss = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 95,
+        buyTotal: 101,
+        sellNet: 92.15,
+        profit: -8.85,
+        marginPercent: -8.76,
+        brokerFee: 1.95,
+        salesTax: 1.9,
+      );
+      expect(loss.isProfitable, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #518

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` — pure Dart margin calculator
- Added `test/features/market/calculators/margin_calculator_test.dart` — 9 test cases

## How verified

```
flutter test test/features/market/calculators/margin_calculator_test.dart
00:00 +9: All tests passed!

flutter analyze (2 files touched)
No issues found!
```

## Acceptance criteria coverage

- AC 1: Implementation matches task body — `TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, `TradeMargin.isProfitable` per blueprint
- AC 2: All named tests pass — 9 tests, exit 0
- AC 3: No dependencies added — no pubspec.yaml changes
- AC 4: Tests cover all branches — 9 tests covering formulas, validation, boundaries (lcov not available)
- AC 5: flutter analyze zero new warnings — confirmed
- AC 6: PR body documents spec section — `Market Module Specification > Price Calculations`

## Non-goals acknowledged

- Only 2 expected files touched, no extras, no refactors, no dependencies

## Notes

- **Logging deviation from plan**: Orchestrator override to skip logging. Calculator is pure arithmetic; validation uses ArgumentError. Adding logging would be a follow-up suggestion, not part of this PR.
- Default branch: `develop`.

### Coverage

- AC "Implementation matches all behaviors": ✓ `lib/features/market/calculators/margin_calculator.dart`
- AC "All named tests pass the verification command": ✓ `test/features/market/calculators/margin_calculator_test.dart`
- AC "No dependencies added unless absolutely required": ✓ no pubspec.yaml modified