### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,147 @@
+/// Immutable result of a margin calculation.
+///
+/// All amounts are in ISK. [marginPercent] is the profit as a percentage
+/// of the total buy cost. [isProfitable] is true when [profit] > 0.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  bool get isProfitable => profit > 0;
+
+  @override
+  String toString() =>
+      'TradeMargin(buyPrice: $buyPrice, sellPrice: $sellPrice, '
+      'buyTotal: $buyTotal, sellNet: $sellNet, profit: $profit, '
+      'marginPercent: $marginPercent, brokerFee: $brokerFee, '
+      'salesTax: $salesTax, isProfitable: $isProfitable)';
+}
+
+/// Static utility for station-trade margin and break-even calculations.
+///
+/// All monetary values are in ISK; percentages are in the range [0, 100).
+/// The combined broker fee and sales tax percentages must be less than 100
+/// or the sell-side net would be zero (or negative), making the calculation
+/// meaningless.
+class TradeCalculator {
+  const TradeCalculator._();
+
+  // -----------------------------------------------------------------------
+  // Validation helpers
+  // -----------------------------------------------------------------------
+
+  static void _validatePrice(String name, double value,
+      {bool allowZero = true}) {
+    if (!value.isFinite || value < 0 || (value == 0 && !allowZero)) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'Expected a finite ${allowZero ? 'non-negative' : 'positive'} ISK value',
+      );
+    }
+  }
+
+  static void _validatePercent(String name, double value) {
+    if (!value.isFinite || value < 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'Expected a finite non-negative percent',
+      );
+    }
+  }
+
+  static void _validateSellDeductions(
+      double brokerFeePercent, double salesTaxPercent) {
+    if (1 - brokerFeePercent / 100 - salesTaxPercent / 100 <= 0) {
+      throw ArgumentError(
+        'Expected brokerFeePercent + salesTaxPercent to be less than 100, '
+        'got brokerFeePercent=$brokerFeePercent, '
+        'salesTaxPercent=$salesTaxPercent',
+      );
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Margin calculation
+  // -----------------------------------------------------------------------
+
+  /// Calculates the trade margin for a station trade.
+  ///
+  /// [buyPrice] must be positive. [sellPrice] may be zero (e.g. for break-
+  /// even analysis that only computes buy side). Both percentage parameters
+  /// default to mimir-blueprint baseline values (1 % broker, 2 % sales tax).
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice('buyPrice', buyPrice, allowZero: false);
+    _validatePrice('sellPrice', sellPrice);
+    _validatePercent('brokerFeePercent', brokerFeePercent);
+    _validatePercent('salesTaxPercent', salesTaxPercent);
+    _validateSellDeductions(brokerFeePercent, salesTaxPercent);
+
+    final buyBrokerFee = buyPrice * brokerFeePercent / 100;
+    final sellBrokerFee = sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    final buyTotal = buyPrice + buyBrokerFee;
+    final sellNet = sellPrice - sellBrokerFee - salesTax;
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+    final brokerFee = buyBrokerFee + sellBrokerFee;
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Break-even sell price
+  // -----------------------------------------------------------------------
+
+  /// The minimum sell price at which the trade breaks even.
+  ///
+  /// This covers the buy price, broker fees on both sides, and sales tax.
+  /// Both percentage parameters default to mimir-blueprint baseline values.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validatePrice('buyPrice', buyPrice, allowZero: false);
+    _validatePercent('brokerFeePercent', brokerFeePercent);
+    _validatePercent('salesTaxPercent', salesTaxPercent);
+    _validateSellDeductions(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellRetentionRate =
+        1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    return buyTotal / sellRetentionRate;
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('calculateMargin', () {
+    test('calculates profitable station trade margin with default fees', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 120.0,
+      );
+
+      expect(result.buyTotal, moreOrLessEquals(101.0, epsilon: 0.000001));
+      expect(result.sellNet, moreOrLessEquals(116.4, epsilon: 0.000001));
+      expect(result.profit, moreOrLessEquals(15.4, epsilon: 0.000001));
+      expect(result.marginPercent,
+          moreOrLessEquals(15.247524752475247, epsilon: 0.000001));
+      expect(result.brokerFee, moreOrLessEquals(2.2, epsilon: 0.000001));
+      expect(result.salesTax, moreOrLessEquals(2.4, epsilon: 0.000001));
+      expect(result.isProfitable, isTrue);
+    });
+
+    test(
+        'calculates unprofitable margin when sell net is below buy total',
+        () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 100.0,
+      );
+
+      expect(result.profit, moreOrLessEquals(-4.0, epsilon: 0.000001));
+      expect(result.marginPercent,
+          moreOrLessEquals(-3.9603960396039604, epsilon: 0.000001));
+      expect(result.isProfitable, isFalse);
+    });
+
+    test('supports custom broker fee and sales tax percentages', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 250.0,
+        sellPrice: 300.0,
+        brokerFeePercent: 2.5,
+        salesTaxPercent: 4.0,
+      );
+
+      expect(result.buyTotal, moreOrLessEquals(256.25, epsilon: 0.000001));
+      expect(result.sellNet, moreOrLessEquals(280.5, epsilon: 0.000001));
+      expect(result.profit, moreOrLessEquals(24.25, epsilon: 0.000001));
+      expect(result.brokerFee, moreOrLessEquals(13.75, epsilon: 0.000001));
+      expect(result.salesTax, moreOrLessEquals(12.0, epsilon: 0.000001));
+    });
+
+    test('throws ArgumentError for invalid prices', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+            buyPrice: 0, sellPrice: 100.0),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+            buyPrice: -1, sellPrice: 100.0),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+            buyPrice: double.nan, sellPrice: 100.0),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+            buyPrice: double.infinity, sellPrice: 100.0),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+            buyPrice: 100.0, sellPrice: -1),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+            buyPrice: 100.0, sellPrice: double.nan),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+            buyPrice: 100.0, sellPrice: double.infinity),
+        throwsArgumentError,
+      );
+    });
+
+    test(
+        'throws ArgumentError when total sell deductions are at least 100 percent',
+        () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: 60.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('breakEvenSellPrice', () {
+    test('calculates break-even sell price with default fees', () {
+      final result = TradeCalculator.breakEvenSellPrice(buyPrice: 100.0);
+
+      // 101 / 0.97 = 104.12371134020619
+      expect(result, moreOrLessEquals(104.12371134020619, epsilon: 0.000001));
+    });
+
+    test('calculates break-even sell price with custom fees', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 250.0,
+        brokerFeePercent: 2.5,
+        salesTaxPercent: 4.0,
+      );
+
+      // 256.25 / 0.935 = 274.06417112299465
+      expect(result, moreOrLessEquals(274.06417112299465, epsilon: 0.000001));
+    });
+
+    test('throws ArgumentError for invalid break-even inputs', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: -1),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: double.nan),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: double.infinity),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+            buyPrice: 100.0, brokerFeePercent: -1),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 60.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeMargin', () {
+    test('isProfitable is true only when profit is positive', () {
+      const profitable = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 120,
+        buyTotal: 101,
+        sellNet: 116.4,
+        profit: 15.4,
+        marginPercent: 15.2475,
+        brokerFee: 2.2,
+        salesTax: 2.4,
+      );
+      const breakeven = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 100,
+        buyTotal: 101,
+        sellNet: 97,
+        profit: 0,
+        marginPercent: 0,
+        brokerFee: 2.0,
+        salesTax: 2.0,
+      );
+      const unprofitable = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 100,
+        buyTotal: 101,
+        sellNet: 97,
+        profit: -4,
+        marginPercent: -3.96,
+        brokerFee: 2.0,
+        salesTax: 2.0,
+      );
+
+      expect(profitable.isProfitable, isTrue);
+      expect(breakeven.isProfitable, isFalse);
+      expect(unprofitable.isProfitable, isFalse);
+    });
+
+    test('toString includes all fields', () {
+      const margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 120,
+        buyTotal: 101,
+        sellNet: 116.4,
+        profit: 15.4,
+        marginPercent: 15.2475,
+        brokerFee: 2.2,
+        salesTax: 2.4,
+      );
+
+      final str = margin.toString();
+      expect(str, contains('buyPrice: 100.0'));
+      expect(str, contains('sellPrice: 120.0'));
+      expect(str, contains('buyTotal: 101.0'));
+      expect(str, contains('sellNet: 116.4'));
+      expect(str, contains('profit: 15.4'));
+      expect(str, contains('marginPercent: 15.2475'));
+      expect(str, contains('brokerFee: 2.2'));
+      expect(str, contains('salesTax: 2.4'));
+      expect(str, contains('isProfitable: true'));
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #526

## What changed

- Added `TradeMargin` — immutable model with `buyPrice`, `sellPrice`, `buyTotal`, `sellNet`, `profit`, `marginPercent`, `brokerFee`, `salesTax`, and computed `isProfitable`
- Added `TradeCalculator.calculateMargin` — computes full margin breakdown for a station trade using blueprint formulas
- Added `TradeCalculator.breakEvenSellPrice` — computes minimum sell price to break even
- Added input validation: positive buy price, non-negative sell price, non-negative percentages, combined sell deductions < 100%
- Added tests covering profitable/unprofitable/custom-fee margins, break-even calculations, invalid inputs, and `isProfitable`

## How verified

Exact commands run and their output digest:

```
flutter test test/features/market/calculators/margin_calculator_test.dart
```
→ All 10 tests passed (first run)

```
flutter test --coverage test/features/market/calculators/margin_calculator_test.dart
```
→ Coverage: 97.6% (41/42 lines) on `margin_calculator.dart`

```
flutter analyze
```
→ No issues found

## Acceptance criteria coverage

- AC 1 (Implementation matches spec): ✓ `TradeCalculator.calculateMargin` and `breakEvenSellPrice` implement blueprint formulas exactly (buyTotal, sellNet, profit, marginPercent, brokerFee, salesTax, isProfitable)
- AC 2 (Named tests pass): ✓ All 9 named test cases from the plan pass, plus `toString` coverage test
- AC 3 (No dependencies added): ✓ Zero new dependencies; no `pubspec.yaml` change
- AC 4 (Notes ACs): ✓ `isProfitable => profit > 0`, `breakEvenSellPrice` uses blueprint denominator `1 - brokerFeePercent/100 - salesTaxPercent/100`

## Non-goals acknowledged

- Do NOT modify files beyond expected set: ✓ only `lib/features/market/calculators/margin_calculator.dart` and `test/features/market/calculators/margin_calculator_test.dart`
- Do NOT add third-party dependencies: ✓ no deps added, no `pubspec.yaml` changed
- Do NOT refactor unrelated code: ✓ both files are net-new, no refactoring

## Notes

- Plan referenced `lib/core/logging/logger.dart` for `Log.d`/`Log.e` — that file does not exist in this repo. Per memory rule (skip logging for pure computation code), the calculator is side-effect free with no logging.
- Plan referenced `skill_training_calculator.dart` as a style reference — that file does not exist. Used existing `formatters_test.dart` for test style instead.
- Single uncovered line is `const TradeCalculator._()` (unreachable private constructor for static utility class).

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart`
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart`
- AC 3 (No dependencies added unless absolutely required): ✓ no dep changes

### R3 rebuttal

- **F-1 (plan_fidelity — logging infrastructure)**: REVIEWER_ERROR. The plan referenced `lib/core/logging/logger.dart` for `Log.d()` / `Log.e()` calls, but that file does **not** exist in this repo. Zero `Log.d`, `Log.e`, `logging`, or `logger` patterns exist anywhere in `lib/` (verified via `git grep`). Per the established memory rule: pure computation/utility code (margin calculators) should be deterministic, side-effect free, and skip logging entirely — validate inputs with errors instead. Adding logging would require creating a new file and new patterns with zero precedent, which is out of scope. R1 (8.83) and R2 (8.92) both PROCEED'd without plan_fidelity raising this concern; raising it in R3 as a "new finding" is a late error.