### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,158 @@
+/// Immutable margin calculation utilities for the Market feature.
+///
+/// Implements the mimir-blueprint Market Module Specification
+/// section "Price Calculations", specifically:
+///   - TradeCalculator.calculateMargin
+///   - TradeCalculator.breakEvenSellPrice
+///   - TradeMargin.isProfitable
+library;
+
+import 'package:flutter/foundation.dart';
+import 'package:mimir/core/logging/logger.dart';
+
+/// Immutable result for margin calculations.
+class TradeMargin {
+  final double buyPrice;
+  final double sellPrice;
+  final double buyTotal;
+  final double sellNet;
+  final double profit;
+  final double marginPercent;
+  final double brokerFee;
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  bool get isProfitable => profit > 0;
+}
+
+/// Immutable trade margin and break-even calculator.
+///
+/// All methods are static and pure — no side effects, no state.
+class TradeCalculator {
+  TradeCalculator._();
+
+  /// Calculates margin analysis for a trade given buy/sell prices and fees.
+  ///
+  /// [buyPrice] must be greater than 0.
+  /// [sellPrice] must be greater than or equal to 0.
+  /// [brokerFeePercent] and [salesTaxPercent] must be >= 0.
+  /// Total sell fees ([brokerFeePercent] + [salesTaxPercent]) must be < 100.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateBuyPrice(buyPrice);
+    _validateSellPrice(sellPrice);
+    _validateFees(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    if (kDebugMode) {
+      Log.d(
+          'MARKET',
+          'calculateMargin: buy=$buyPrice sell=$sellPrice '
+              'profit=${profit.toStringAsFixed(2)} '
+              'margin=${marginPercent.toStringAsFixed(2)}%');
+    }
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculates the minimum sell price needed to break even (profit = 0).
+  ///
+  /// [buyPrice] must be greater than 0.
+  /// [brokerFeePercent] and [salesTaxPercent] must be >= 0 and sum < 100.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateBuyPrice(buyPrice);
+    _validateFees(brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final result =
+        buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+
+    if (kDebugMode) {
+      Log.d('MARKET',
+          'breakEvenSellPrice: buy=$buyPrice => ${result.toStringAsFixed(2)}');
+    }
+
+    return result;
+  }
+
+  // --- Private validators ---
+
+  static void _validateBuyPrice(double buyPrice) {
+    if (buyPrice <= 0) {
+      throw ArgumentError.value(
+        buyPrice,
+        'buyPrice',
+        'must be greater than 0 to calculate trade margin',
+      );
+    }
+  }
+
+  static void _validateSellPrice(double sellPrice) {
+    if (sellPrice < 0) {
+      throw ArgumentError.value(
+        sellPrice,
+        'sellPrice',
+        'must be greater than or equal to 0',
+      );
+    }
+  }
+
+  static void _validateFees(double brokerFeePercent, double salesTaxPercent) {
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'must be greater than or equal to 0',
+      );
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'must be greater than or equal to 0',
+      );
+    }
+    if (brokerFeePercent + salesTaxPercent >= 100) {
+      throw ArgumentError.value(
+        brokerFeePercent + salesTaxPercent,
+        'totalSellFeesPercent',
+        'must be less than 100',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator.calculateMargin', () {
+    test('calculates profitable default-fee margin', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 120.0,
+      );
+
+      expect(result.buyPrice, 100.0);
+      expect(result.sellPrice, 120.0);
+      expect(result.buyTotal, 101.0);
+      expect(result.sellNet, closeTo(116.4, 0.000001));
+      expect(result.profit, closeTo(15.4, 0.000001));
+      expect(result.marginPercent, closeTo(15.2475247525, 0.000001));
+      expect(result.brokerFee, 2.2);
+      expect(result.salesTax, 2.4);
+      expect(result.isProfitable, true);
+    });
+
+    test('calculates loss-making margin', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 100.0,
+      );
+
+      expect(result.buyTotal, 101.0);
+      expect(result.sellNet, 97.0);
+      expect(result.profit, -4.0);
+      expect(result.marginPercent, closeTo(-3.9603960396, 0.000001));
+      expect(result.isProfitable, false);
+    });
+
+    test('uses custom broker fee and sales tax percentages', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 120.0,
+        brokerFeePercent: 2.0,
+        salesTaxPercent: 3.0,
+      );
+
+      expect(result.buyTotal, 102.0);
+      expect(result.sellNet, 114.0);
+      expect(result.profit, 12.0);
+      expect(result.brokerFee, 4.4);
+      expect(result.salesTax, 3.6);
+    });
+  });
+
+  group('TradeCalculator.breakEvenSellPrice', () {
+    test('calculates break-even sell price with default fees', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 100.0,
+      );
+
+      // 101.0 / 0.97
+      expect(result, closeTo(104.1237113402, 0.000001));
+    });
+
+    test('calculates break-even sell price with custom fees', () {
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 100.0,
+        brokerFeePercent: 2.0,
+        salesTaxPercent: 3.0,
+      );
+
+      // 102.0 / 0.95
+      expect(result, closeTo(107.3684210526, 0.000001));
+    });
+  });
+
+  group('TradeCalculator validation', () {
+    test('calculateMargin rejects non-positive buy price', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 0.0,
+          sellPrice: 120.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: -1.0,
+          sellPrice: 120.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('calculateMargin rejects negative sell price', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: -1.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('calculateMargin rejects negative fees', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          salesTaxPercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test(
+      'calculateMargin rejects total sell fees at or above 100 percent',
+      () {
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100.0,
+            sellPrice: 120.0,
+            brokerFeePercent: 50.0,
+            salesTaxPercent: 50.0,
+          ),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => TradeCalculator.calculateMargin(
+            buyPrice: 100.0,
+            sellPrice: 120.0,
+            brokerFeePercent: 60.0,
+            salesTaxPercent: 50.0,
+          ),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test('breakEvenSellPrice rejects invalid inputs', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: 0.0),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: -1.0),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          salesTaxPercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeMargin.isProfitable', () {
+    test('returns true when profit is positive', () {
+      const margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 120,
+        buyTotal: 101,
+        sellNet: 116.4,
+        profit: 15.4,
+        marginPercent: 15.25,
+        brokerFee: 2.2,
+        salesTax: 2.4,
+      );
+      expect(margin.isProfitable, true);
+    });
+
+    test('returns false when profit is zero', () {
+      const margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 100,
+        buyTotal: 101,
+        sellNet: 97,
+        profit: 0,
+        marginPercent: 0,
+        brokerFee: 2,
+        salesTax: 2,
+      );
+      expect(margin.isProfitable, false);
+    });
+
+    test('returns false when profit is negative', () {
+      const margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 80,
+        buyTotal: 101,
+        sellNet: 77.6,
+        profit: -23.4,
+        marginPercent: -23.17,
+        brokerFee: 1.8,
+        salesTax: 1.6,
+      );
+      expect(margin.isProfitable, false);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #530

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` — new file with:
  - `TradeMargin` immutable result class with `isProfitable` getter
  - `TradeCalculator` with static `calculateMargin()` and `breakEvenSellPrice()` methods
  - Input validation throwing `ArgumentError` for invalid prices and fee percentages
  - Debug logging via existing `package:mimir/core/logging/logger.dart`
- Added `test/features/market/calculators/margin_calculator_test.dart` — 13 unit tests covering:
  - Profitable default-fee margin calculation
  - Loss-making margin calculation
  - Custom broker fee and sales tax percentages
  - Break-even sell price with default and custom fees
  - All validation branches (non-positive buy price, negative sell price, negative fees, total fees >= 100%)
  - `isProfitable` getter (positive, zero, and negative profit)

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
flutter test --coverage test/features/market/calculators/margin_calculator_test.dart
flutter analyze
```

Test output: 13/13 passed.
Coverage: 97.37% (37/38 lines) on `lib/features/market/calculators/margin_calculator.dart` — well above the 90% threshold. The single uncovered line is the private `TradeCalculator._()` constructor (class with only static methods).
Analysis: No issues found.

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` — `TradeMargin` with all required fields and `isProfitable` getter, `TradeCalculator.calculateMargin()` and `breakEvenSellPrice()` implementing the blueprint Price Calculations formulas with `buyTotal`, `sellNet`, `profit`, `marginPercent`, `brokerFee`, and `salesTax`.
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` — 13 tests covering all named test cases pass with `flutter test`.
- AC 3 (No dependencies added unless absolutely required): ✓ no new dependencies; uses existing `flutter_test` and existing `package:mimir/core/logging/logger.dart`.

### Coverage

- AC 1 (Implementation matches all behaviors described in the task body): ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` TradeMargin + TradeCalculator
- AC 2 (All named tests pass the verification command): ✓ addressed in `test/features/market/calculators/margin_calculator_test.dart` (13/13 pass)
- AC 3 (No dependencies added unless absolutely required): ✓ no new dependencies; 0 pubspec.yaml/lockfile changes

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: ✓ only `margin_calculator.dart` and `margin_calculator_test.dart` changed
- Do NOT add third-party dependencies: ✓ no dependencies added
- Do NOT refactor unrelated code: ✓ no refactoring

## Notes

- Implements mimir-blueprint Market Module Specification section "Price Calculations" — specifically `TradeCalculator.calculateMargin`, `TradeCalculator.breakEvenSellPrice`, and `TradeMargin.isProfitable`.
- The private constructor `TradeCalculator._()` (line 42) is uncovered (97.37% coverage); it exists solely for semantic completeness of a class with only static members and cannot be called from test code.
- Self-critique was attempted via `hermes chat --skill code-review` with piped stdin diff, but the hermes subprocess opened interactively instead of processing the piped input. Proceeded per the failure-handling rule.