### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,189 @@
+/// Market margin calculator for trade profit analysis.
+///
+/// Provides pure-Dart calculations for trade margins, break-even prices,
+/// and fee breakdowns following the mimir-blueprint Price Calculations spec.
+///
+/// All methods are static and deterministic — no side effects, no I/O.
+library;
+
+import '../../../core/logging/logger.dart';
+
+/// Immutable result model for a trade margin calculation.
+class TradeMargin {
+  /// Original buy price per unit.
+  final double buyPrice;
+
+  /// Original sell price per unit.
+  final double sellPrice;
+
+  /// Total buy cost including broker fee: `buyPrice * (1 + brokerFeePercent / 100)`.
+  final double buyTotal;
+
+  /// Net sell proceeds after fees: `sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100)`.
+  final double sellNet;
+
+  /// Profit (or loss): `sellNet - buyTotal`.
+  final double profit;
+
+  /// Profit as a percentage of buyTotal: `(profit / buyTotal) * 100`.
+  final double marginPercent;
+
+  /// Total broker fees on both sides: `buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100`.
+  final double brokerFee;
+
+  /// Sales tax on the sell side: `sellPrice * salesTaxPercent / 100`.
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Whether the trade produces a profit.
+  /// Zero profit is NOT considered profitable (exact break-even).
+  bool get isProfitable => profit > 0;
+}
+
+/// Stateless calculator for trade margins and break-even prices.
+///
+/// Non-instantiable — use the static methods directly:
+/// ```dart
+/// final margin = TradeCalculator.calculateMargin(buyPrice: 100, sellPrice: 150);
+/// final breakEven = TradeCalculator.breakEvenSellPrice(buyPrice: 100);
+/// ```
+class TradeCalculator {
+  TradeCalculator._();
+
+  /// Calculates the trade margin for a given buy/sell price pair.
+  ///
+  /// Default fees match EVE Online's typical rates:
+  /// - [brokerFeePercent] defaults to 1.0
+  /// - [salesTaxPercent] defaults to 2.0
+  ///
+  /// Throws [ArgumentError] for invalid inputs:
+  /// - buyPrice must be > 0
+  /// - sellPrice must be >= 0
+  /// - brokerFeePercent must be >= 0
+  /// - salesTaxPercent must be >= 0
+  /// - Combined sell-side fees must be < 100
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    Log.d(
+      'MARKET',
+      'calculateMargin(buyPrice: $buyPrice, sellPrice: $sellPrice, '
+          'brokerFeePercent: $brokerFeePercent, salesTaxPercent: $salesTaxPercent) - START',
+    );
+    _validateCommon(buyPrice, brokerFeePercent, salesTaxPercent);
+    if (sellPrice < 0) {
+      throw ArgumentError.value(
+        sellPrice,
+        'sellPrice',
+        'Expected sellPrice to be 0 or greater',
+      );
+    }
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellFeeMultiplier =
+        1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    final sellNet = sellPrice * sellFeeMultiplier;
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    Log.d(
+      'MARKET',
+      'calculateMargin - profit: $profit, marginPercent: $marginPercent, '
+          'isProfitable: ${profit > 0}',
+    );
+
+    return TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+  }
+
+  /// Calculates the break-even sell price where profit = 0.
+  ///
+  /// This is the minimum sell price needed to cover the buy cost
+  /// plus all fees on both sides of the transaction.
+  ///
+  /// Throws [ArgumentError] for the same invalid-input conditions
+  /// as [calculateMargin], plus the combined sell-side fees must be < 100
+  /// (otherwise the denominator collapses to zero or negative).
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    Log.d(
+      'MARKET',
+      'breakEvenSellPrice(buyPrice: $buyPrice, brokerFeePercent: $brokerFeePercent, '
+          'salesTaxPercent: $salesTaxPercent) - START',
+    );
+    _validateCommon(buyPrice, brokerFeePercent, salesTaxPercent);
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellFeeMultiplier =
+        1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+
+    final breakEvenPrice = buyTotal / sellFeeMultiplier;
+    Log.d('MARKET', 'breakEvenSellPrice - breakEvenPrice: $breakEvenPrice');
+    return breakEvenPrice;
+  }
+
+  /// Validates parameters shared by both calculation methods.
+  static void _validateCommon(
+    double buyPrice,
+    double brokerFeePercent,
+    double salesTaxPercent,
+  ) {
+    if (buyPrice <= 0) {
+      throw ArgumentError.value(
+        buyPrice,
+        'buyPrice',
+        'Expected buyPrice to be greater than 0',
+      );
+    }
+    if (brokerFeePercent < 0) {
+      throw ArgumentError.value(
+        brokerFeePercent,
+        'brokerFeePercent',
+        'Expected brokerFeePercent to be 0 or greater',
+      );
+    }
+    if (salesTaxPercent < 0) {
+      throw ArgumentError.value(
+        salesTaxPercent,
+        'salesTaxPercent',
+        'Expected salesTaxPercent to be 0 or greater',
+      );
+    }
+    final sellFeeMultiplier =
+        1 - brokerFeePercent / 100 - salesTaxPercent / 100;
+    if (sellFeeMultiplier <= 0) {
+      throw ArgumentError.value(
+        brokerFeePercent + salesTaxPercent,
+        'brokerFeePercent + salesTaxPercent',
+        'Expected combined sell-side fees to be less than 100',
+      );
+    }
+  }
+}

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,260 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator.calculateMargin', () {
+    test('calculates profitable margin with default fees', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 150.0,
+      );
+
+      // buyTotal = 100 * (1 + 1/100) = 101.0
+      expect(margin.buyTotal, closeTo(101.0, 0.000001));
+      // sellNet = 150 * (1 - 1/100 - 2/100) = 150 * 0.97 = 145.5
+      expect(margin.sellNet, closeTo(145.5, 0.000001));
+      // profit = 145.5 - 101.0 = 44.5
+      expect(margin.profit, closeTo(44.5, 0.000001));
+      // marginPercent = (44.5 / 101.0) * 100 ≈ 44.05940594059406
+      expect(margin.marginPercent, closeTo(44.05940594059406, 0.000001));
+      // brokerFee = 100 * 1/100 + 150 * 1/100 = 1.0 + 1.5 = 2.5
+      expect(margin.brokerFee, closeTo(2.5, 0.000001));
+      // salesTax = 150 * 2/100 = 3.0
+      expect(margin.salesTax, closeTo(3.0, 0.000001));
+      expect(margin.isProfitable, isTrue);
+    });
+
+    test('calculates loss margin when sell net is below buy total', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 90.0,
+      );
+
+      // buyTotal = 100 * 1.01 = 101.0
+      expect(margin.buyTotal, closeTo(101.0, 0.000001));
+      // sellNet = 90 * 0.97 = 87.3
+      expect(margin.sellNet, closeTo(87.3, 0.000001));
+      // profit = 87.3 - 101.0 = -13.7
+      expect(margin.profit, lessThan(0));
+      expect(margin.marginPercent, lessThan(0));
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('treats exact break-even profit as not profitable', () {
+      final breakEvenPrice = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 100.0,
+      );
+
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: breakEvenPrice,
+      );
+
+      expect(margin.profit, closeTo(0.0, 0.000001));
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('uses custom broker fee and sales tax percentages', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 200.0,
+        sellPrice: 300.0,
+        brokerFeePercent: 0.5,
+        salesTaxPercent: 1.5,
+      );
+
+      // buyTotal = 200 * (1 + 0.5/100) = 200 * 1.005 = 201.0
+      expect(margin.buyTotal, closeTo(201.0, 0.000001));
+      // sellNet = 300 * (1 - 0.5/100 - 1.5/100) = 300 * 0.98 = 294.0
+      expect(margin.sellNet, closeTo(294.0, 0.000001));
+      // profit = 294.0 - 201.0 = 93.0
+      expect(margin.profit, closeTo(93.0, 0.000001));
+      // brokerFee = 200 * 0.5/100 + 300 * 0.5/100 = 1.0 + 1.5 = 2.5
+      expect(margin.brokerFee, closeTo(2.5, 0.000001));
+      // salesTax = 300 * 1.5/100 = 4.5
+      expect(margin.salesTax, closeTo(4.5, 0.000001));
+    });
+
+    test('throws ArgumentError for buyPrice <= 0', () {
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: 0, sellPrice: 100),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: -50, sellPrice: 100),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for negative sellPrice', () {
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: 100, sellPrice: -10),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for negative brokerFeePercent', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 150,
+          brokerFeePercent: -1,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for negative salesTaxPercent', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 150,
+          salesTaxPercent: -3,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when combined sell-side fees >= 100', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 150,
+          brokerFeePercent: 50,
+          salesTaxPercent: 50,
+        ),
+        throwsArgumentError,
+      );
+      // Exactly 100% should also fail (sellFeeMultiplier <= 0)
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100,
+          sellPrice: 150,
+          brokerFeePercent: 100,
+          salesTaxPercent: 0,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts zero sellPrice', () {
+      final margin = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 0.0,
+      );
+
+      expect(margin.sellNet, closeTo(0.0, 0.000001));
+      expect(margin.profit, lessThan(0));
+      expect(margin.isProfitable, isFalse);
+    });
+  });
+
+  group('TradeCalculator.breakEvenSellPrice', () {
+    test('calculates break-even sell price with default fees', () {
+      final price = TradeCalculator.breakEvenSellPrice(buyPrice: 100.0);
+
+      // buyTotal = 100 * 1.01 = 101.0
+      // sellFeeMultiplier = 1 - 0.01 - 0.02 = 0.97
+      // breakEven = 101.0 / 0.97 ≈ 104.12371134020619
+      expect(price, closeTo(104.12371134020619, 0.000001));
+    });
+
+    test('calculates break-even sell price with custom fees', () {
+      final price = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 200.0,
+        brokerFeePercent: 0.5,
+        salesTaxPercent: 1.5,
+      );
+
+      // buyTotal = 200 * (1 + 0.5/100) = 200 * 1.005 = 201.0
+      // sellFeeMultiplier = 1 - 0.005 - 0.015 = 0.98
+      // breakEven = 201.0 / 0.98 ≈ 205.10204081632654
+      expect(price, closeTo(205.10204081632654, 0.000001));
+    });
+
+    test('throws ArgumentError for buyPrice <= 0', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: 0),
+        throwsArgumentError,
+      );
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(buyPrice: -10),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for negative brokerFeePercent', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: -1,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for negative salesTaxPercent', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          salesTaxPercent: -3,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when combined sell-side fees >= 100', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100,
+          brokerFeePercent: 50,
+          salesTaxPercent: 50,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeMargin.isProfitable', () {
+    test('returns true when profit is positive', () {
+      final margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 150,
+        buyTotal: 101,
+        sellNet: 145.5,
+        profit: 44.5,
+        marginPercent: 44.06,
+        brokerFee: 2.5,
+        salesTax: 3.0,
+      );
+      expect(margin.isProfitable, isTrue);
+    });
+
+    test('returns false when profit is zero', () {
+      final margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 104.12,
+        buyTotal: 101,
+        sellNet: 101,
+        profit: 0,
+        marginPercent: 0,
+        brokerFee: 2.04,
+        salesTax: 2.08,
+      );
+      expect(margin.isProfitable, isFalse);
+    });
+
+    test('returns false when profit is negative', () {
+      final margin = TradeMargin(
+        buyPrice: 100,
+        sellPrice: 80,
+        buyTotal: 101,
+        sellNet: 77.6,
+        profit: -23.4,
+        marginPercent: -23.17,
+        brokerFee: 1.8,
+        salesTax: 1.6,
+      );
+      expect(margin.isProfitable, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #543

## What changed

- Add `lib/features/market/calculators/margin_calculator.dart` with `TradeCalculator` (static `calculateMargin()` and `breakEvenSellPrice()`) and `TradeMargin` immutable result model
- Add `test/features/market/calculators/margin_calculator_test.dart` with 19 unit tests covering profit, loss, break-even, custom fees, input validation, and edge cases
- Implement price calculation formulas from mimir-blueprint Price Calculations spec
- Add `ArgumentError` validation for all invalid inputs (negative/zero buyPrice, negative sellPrice, negative fees, combined fees >= 100)
- Add `Log.d` debug logging at method entry and result per repo convention

## How verified

```bash
cd ~/workspace/infiquetra/mimir
flutter test test/features/market/calculators/margin_calculator_test.dart
# 00:01 +19: All tests passed!

dart analyze lib/features/market/calculators/margin_calculator.dart
# No issues found!

dart analyze test/features/market/calculators/margin_calculator_test.dart
# No issues found!

flutter test --coverage --exclude-tags golden,patrol test/features/market/calculators/margin_calculator_test.dart
# 97.44% line coverage on margin_calculator.dart (38/39 lines hit; line 61 = private constructor, untestable by design)
```

## Acceptance criteria coverage

- AC 1: Implementation matches all behaviors described in the task body — ✓ addressed in `lib/features/market/calculators/margin_calculator.dart` (formulas, validation, logging per spec)
- AC 2: All named tests pass the verification command — ✓ 19/19 tests pass in `test/features/market/calculators/margin_calculator_test.dart`
- AC 3: No dependencies added unless absolutely required — ✓ No new pubspec dependencies; only existing `Log` utility from `lib/core/logging/logger.dart`

## Non-goals acknowledged

- Do NOT modify files beyond the expected set below: not violated — only `margin_calculator.dart` and `margin_calculator_test.dart` changed
- Do NOT add third-party dependencies unless required by the task body: not violated
- Do NOT refactor unrelated code in the touched files: not violated

## Notes

- Added `Log.d` debug logging per approved plan step 5, matching the repo convention seen in `character_repository.dart`, `character_status_providers.dart`, etc.
- Only uncovered line is `TradeCalculator._()` private constructor (line 61) — untestable by design

### Coverage

- Implementation matches all behaviors described in the task body (see Notes): ✓ addressed in `TradeCalculator.calculateMargin()`, `TradeCalculator.breakEvenSellPrice()`, `TradeMargin.isProfitable`
- All named tests pass the verification command: ✓ 19/19 tests pass
- No dependencies added unless absolutely required: ✓ no new pubspec dependencies