### PR TITLE
feat(market): Add margin calculator

### DIFF
--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -1,0 +1,191 @@
+/// Market margin calculator for EVE Online station trading.
+///
+/// Provides pure, static calculations for trade margin analysis and
+/// break-even price determination based on the Market Module Specification
+/// > Price Calculations section.
+library;
+
+import 'dart:developer' show log;
+
+/// Immutable result model for a trade margin calculation.
+///
+/// Contains all intermediate and final values from a margin calculation.
+/// Positive [profit] means the trade is profitable; zero or negative is not.
+class TradeMargin {
+  /// Original buy price per unit.
+  final double buyPrice;
+
+  /// Original sell price per unit.
+  final double sellPrice;
+
+  /// Total buy cost including broker fee on the buy side.
+  final double buyTotal;
+
+  /// Net sell proceeds after broker fee and sales tax on the sell side.
+  final double sellNet;
+
+  /// Profit per unit: [sellNet] minus [buyTotal].
+  final double profit;
+
+  /// Profit as a percentage of [buyTotal].
+  final double marginPercent;
+
+  /// Total broker fee across both buy and sell sides.
+  final double brokerFee;
+
+  /// Sales tax on the sell side only.
+  final double salesTax;
+
+  const TradeMargin({
+    required this.buyPrice,
+    required this.sellPrice,
+    required this.buyTotal,
+    required this.sellNet,
+    required this.profit,
+    required this.marginPercent,
+    required this.brokerFee,
+    required this.salesTax,
+  });
+
+  /// Whether this trade yields a positive profit.
+  bool get isProfitable => profit > 0;
+}
+
+/// Pure static calculator for market trade margins and break-even prices.
+///
+/// All methods are static; do not instantiate. Formulas follow the
+/// Market Module Specification > Price Calculations section.
+class TradeCalculator {
+  TradeCalculator._();
+
+  /// Calculates the trade margin for a station trade.
+  ///
+  /// [buyPrice] and [sellPrice] must be finite positive values.
+  /// [brokerFeePercent] and [salesTaxPercent] must be finite non-negative
+  /// values whose sum is strictly less than 100.
+  ///
+  /// Throws [ArgumentError] for invalid inputs.
+  static TradeMargin calculateMargin({
+    required double buyPrice,
+    required double sellPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateBuyPrice(buyPrice);
+    _validateSellPrice(sellPrice);
+    _validatePercent(brokerFeePercent, 'brokerFeePercent');
+    _validatePercent(salesTaxPercent, 'salesTaxPercent');
+    _validateDeductions(brokerFeePercent, salesTaxPercent);
+
+    log(
+      'calculateMargin() - START buy=$buyPrice sell=$sellPrice '
+      'brokerFee=$brokerFeePercent% tax=$salesTaxPercent%',
+      name: 'MARKET',
+    );
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final sellNet =
+        sellPrice * (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+    final profit = sellNet - buyTotal;
+    final marginPercent = (profit / buyTotal) * 100;
+    final brokerFee =
+        buyPrice * brokerFeePercent / 100 + sellPrice * brokerFeePercent / 100;
+    final salesTax = sellPrice * salesTaxPercent / 100;
+
+    final result = TradeMargin(
+      buyPrice: buyPrice,
+      sellPrice: sellPrice,
+      buyTotal: buyTotal,
+      sellNet: sellNet,
+      profit: profit,
+      marginPercent: marginPercent,
+      brokerFee: brokerFee,
+      salesTax: salesTax,
+    );
+
+    log(
+      'calculateMargin() - RESULT profit=$profit margin=$marginPercent%',
+      name: 'MARKET',
+    );
+
+    return result;
+  }
+
+  /// Calculates the minimum sell price that breaks even on a buy.
+  ///
+  /// Returns the sell price at which [profit] equals zero, accounting
+  /// for broker fees and sales tax on both sides of the trade.
+  ///
+  /// Throws [ArgumentError] for invalid inputs or if combined deductions
+  /// make a break-even price impossible.
+  static double breakEvenSellPrice({
+    required double buyPrice,
+    double brokerFeePercent = 1.0,
+    double salesTaxPercent = 2.0,
+  }) {
+    _validateBuyPrice(buyPrice);
+    _validatePercent(brokerFeePercent, 'brokerFeePercent');
+    _validatePercent(salesTaxPercent, 'salesTaxPercent');
+    _validateDeductions(brokerFeePercent, salesTaxPercent);
+
+    log(
+      'breakEvenSellPrice() - START buy=$buyPrice '
+      'brokerFee=$brokerFeePercent% tax=$salesTaxPercent%',
+      name: 'MARKET',
+    );
+
+    final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
+    final result =
+        buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
+
+    log('breakEvenSellPrice() - RESULT breakEven=$result', name: 'MARKET');
+
+    return result;
+  }
+
+  /// Validates that [buyPrice] is a finite positive value.
+  static void _validateBuyPrice(double buyPrice) {
+    if (!buyPrice.isFinite || buyPrice <= 0) {
+      throw ArgumentError.value(
+        buyPrice,
+        'buyPrice',
+        'Expected a finite value greater than 0 for margin calculation',
+      );
+    }
+  }
+
+  /// Validates that [sellPrice] is a finite positive value.
+  static void _validateSellPrice(double sellPrice) {
+    if (!sellPrice.isFinite || sellPrice <= 0) {
+      throw ArgumentError.value(
+        sellPrice,
+        'sellPrice',
+        'Expected a finite value greater than 0 for margin calculation',
+      );
+    }
+  }
+
+  /// Validates that a fee/tax percentage is finite and non-negative.
+  static void _validatePercent(double value, String name) {
+    if (!value.isFinite || value < 0) {
+      throw ArgumentError.value(
+        value,
+        name,
+        'Expected a finite percentage greater than or equal to 0',
+      );
+    }
+  }
+
+  /// Validates that combined selling deductions are strictly less than 100%.
+  static void _validateDeductions(
+    double brokerFeePercent,
+    double salesTaxPercent,
+  ) {
+    if (brokerFeePercent + salesTaxPercent >= 100) {
+      throw ArgumentError(
+        'Expected brokerFeePercent + salesTaxPercent to be less than 100, '
+        'got ${brokerFeePercent + salesTaxPercent}',
+      );
+    }
+  }
+}

--- a/lib/features/market/calculators/margin_calculator.dart
+++ b/lib/features/market/calculators/margin_calculator.dart
@@ -5,7 +5,7 @@
 /// > Price Calculations section.
 library;
 
-import 'dart:developer' show log;
+import 'package:mimir/core/logging/logger.dart';
 
 /// Immutable result model for a trade margin calculation.
 ///
@@ -77,10 +77,10 @@ class TradeCalculator {
     _validatePercent(salesTaxPercent, 'salesTaxPercent');
     _validateDeductions(brokerFeePercent, salesTaxPercent);
 
-    log(
+    Log.d(
+      'MARKET',
       'calculateMargin() - START buy=$buyPrice sell=$sellPrice '
       'brokerFee=$brokerFeePercent% tax=$salesTaxPercent%',
-      name: 'MARKET',
     );
 
     final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
@@ -103,9 +103,9 @@ class TradeCalculator {
       salesTax: salesTax,
     );
 
-    log(
+    Log.d(
+      'MARKET',
       'calculateMargin() - RESULT profit=$profit margin=$marginPercent%',
-      name: 'MARKET',
     );
 
     return result;
@@ -128,17 +128,17 @@ class TradeCalculator {
     _validatePercent(salesTaxPercent, 'salesTaxPercent');
     _validateDeductions(brokerFeePercent, salesTaxPercent);
 
-    log(
+    Log.d(
+      'MARKET',
       'breakEvenSellPrice() - START buy=$buyPrice '
       'brokerFee=$brokerFeePercent% tax=$salesTaxPercent%',
-      name: 'MARKET',
     );
 
     final buyTotal = buyPrice * (1 + brokerFeePercent / 100);
     final result =
         buyTotal / (1 - brokerFeePercent / 100 - salesTaxPercent / 100);
 
-    log('breakEvenSellPrice() - RESULT breakEven=$result', name: 'MARKET');
+    Log.d('MARKET', 'breakEvenSellPrice() - RESULT breakEven=$result');
 
     return result;
   }

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -140,14 +140,14 @@ void main() {
     });
 
     test('calculates break-even sell price with custom fees', () {
-      // buyTotal = 1000000 * 1.005 = 1005000; 1005000 / 0.98 ≈ 1025510.2041
+      // buyTotal = 1000000 * 1.005 = 1005000; 1005000 / 0.98 = 1025510.2040816326...
       final result = TradeCalculator.breakEvenSellPrice(
         buyPrice: 1000000.0,
         brokerFeePercent: 0.5,
         salesTaxPercent: 1.5,
       );
 
-      expect(result, closeTo(1025510.2041, 0.001));
+      expect(result, closeTo(1025510.2040816326, 0.000001));
     });
 
     test('throws ArgumentError when deductions make break-even impossible', () {

--- a/test/features/market/calculators/margin_calculator_test.dart
+++ b/test/features/market/calculators/margin_calculator_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mimir/features/market/calculators/margin_calculator.dart';
+
+void main() {
+  group('TradeCalculator.calculateMargin', () {
+    test('calculates profitable station trade margin with default fees', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 120.0,
+      );
+
+      expect(result.buyTotal, closeTo(101.0, 0.000001));
+      expect(result.sellNet, closeTo(116.4, 0.000001));
+      expect(result.profit, closeTo(15.4, 0.000001));
+      expect(result.marginPercent, closeTo(15.2475247525, 0.000001));
+      expect(result.brokerFee, closeTo(2.2, 0.000001));
+      expect(result.salesTax, closeTo(2.4, 0.000001));
+      expect(result.isProfitable, true);
+    });
+
+    test('calculates loss-making margin as not profitable', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 100.0,
+        sellPrice: 100.0,
+      );
+
+      expect(result.buyTotal, closeTo(101.0, 0.000001));
+      expect(result.sellNet, closeTo(97.0, 0.000001));
+      expect(result.profit, closeTo(-4.0, 0.000001));
+      expect(result.marginPercent, closeTo(-3.9603960396, 0.000001));
+      expect(result.brokerFee, closeTo(2.0, 0.000001));
+      expect(result.salesTax, closeTo(2.0, 0.000001));
+      expect(result.isProfitable, false);
+    });
+
+    test('uses custom broker fee and sales tax percentages', () {
+      final result = TradeCalculator.calculateMargin(
+        buyPrice: 1000000.0,
+        sellPrice: 1250000.0,
+        brokerFeePercent: 0.5,
+        salesTaxPercent: 1.5,
+      );
+
+      expect(result.buyTotal, closeTo(1005000.0, 0.000001));
+      expect(result.sellNet, closeTo(1225000.0, 0.000001));
+      expect(result.profit, closeTo(220000.0, 0.000001));
+      expect(result.marginPercent, closeTo(21.8905472637, 0.000001));
+      expect(result.brokerFee, closeTo(11250.0, 0.000001));
+      expect(result.salesTax, closeTo(18750.0, 0.000001));
+      expect(result.isProfitable, true);
+    });
+
+    test('throws ArgumentError for invalid prices', () {
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: 0.0, sellPrice: 120.0),
+        throwsArgumentError,
+      );
+
+      expect(
+        () =>
+            TradeCalculator.calculateMargin(buyPrice: -50.0, sellPrice: 120.0),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(buyPrice: 100.0, sellPrice: 0.0),
+        throwsArgumentError,
+      );
+
+      expect(
+        () =>
+            TradeCalculator.calculateMargin(buyPrice: 100.0, sellPrice: -10.0),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: double.nan,
+          sellPrice: 120.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: double.infinity,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError for invalid fee percentages', () {
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: -1.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          salesTaxPercent: -0.5,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.calculateMargin(
+          buyPrice: 100.0,
+          sellPrice: 120.0,
+          brokerFeePercent: 100.0,
+          salesTaxPercent: 0.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('TradeCalculator.breakEvenSellPrice', () {
+    test('calculates break-even sell price with default fees', () {
+      // buyTotal = 100 * 1.01 = 101; 101 / 0.97 ≈ 104.1237113402
+      final result = TradeCalculator.breakEvenSellPrice(buyPrice: 100.0);
+
+      expect(result, closeTo(104.1237113402, 0.000001));
+    });
+
+    test('calculates break-even sell price with custom fees', () {
+      // buyTotal = 1000000 * 1.005 = 1005000; 1005000 / 0.98 ≈ 1025510.2041
+      final result = TradeCalculator.breakEvenSellPrice(
+        buyPrice: 1000000.0,
+        brokerFeePercent: 0.5,
+        salesTaxPercent: 1.5,
+      );
+
+      expect(result, closeTo(1025510.2041, 0.001));
+    });
+
+    test('throws ArgumentError when deductions make break-even impossible', () {
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 50.0,
+          salesTaxPercent: 50.0,
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => TradeCalculator.breakEvenSellPrice(
+          buyPrice: 100.0,
+          brokerFeePercent: 100.0,
+          salesTaxPercent: 0.0,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Linked card

Closes #545

## What changed

- Added `lib/features/market/calculators/margin_calculator.dart` — new pure Dart calculator module with `TradeCalculator` (static methods) and `TradeMargin` (immutable result model)
- Added `test/features/market/calculators/margin_calculator_test.dart` — 8 unit tests covering profitable trades, loss-making trades, custom fees, break-even calculation, and input validation

## How verified

```bash
cd ~/workspace/infiquetra/mimir

# Format check
dart format lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
# → Formatted 2 files (0 changed)

# Static analysis
flutter analyze lib/features/market/calculators/margin_calculator.dart test/features/market/calculators/margin_calculator_test.dart
# → No issues found!

# Focused tests
flutter test test/features/market/calculators/margin_calculator_test.dart
# → 00:00 +8: All tests passed!

# Coverage
flutter test --coverage test/features/market/calculators/margin_calculator_test.dart
# → 8 tests passed, 97.56% line coverage on margin_calculator.dart
```

## Acceptance criteria coverage

- AC 1 (Implementation matches all behaviors described in the task body): `TradeCalculator.calculateMargin` computes `buyTotal`, `sellNet`, `profit`, `marginPercent`, `brokerFee`, `salesTax` per spec formulas; `breakEvenSellPrice` computes `buyTotal / (1 - brokerFeePercent/100 - salesTaxPercent/100)`; `TradeMargin.isProfitable` returns `profit > 0`; input validation throws `ArgumentError` for invalid inputs
- AC 2 (All named tests pass the verification command): 8 named tests in `margin_calculator_test.dart` all pass — 3 calculateMargin happy-path, 2 calculateMargin validation, 2 breakEvenSellPrice happy-path, 1 breakEvenSellPrice validation
- AC 3 (No dependencies added unless absolutely required): No pubspec changes. Uses `Log.d()` from existing `package:mimir/core/logging/logger.dart` (R2 fix: replaced `dart:developer log` with project's Log utility per plan spec)

## Non-goals acknowledged

- Do NOT modify files beyond the expected set: not violated — only the two expected files were changed
- Do NOT add third-party dependencies unless required by the task body: not violated — no new dependencies
- Do NOT refactor unrelated code in the touched files: not violated — both files are net-new

## R2 Changes

- **F-1 (MAJOR)**: Replaced `dart:developer log` with project's `Log.d()` from `package:mimir/core/logging/logger.dart`. The `Log` class exists in the repo and is the standard debug logging utility used across the codebase.
- **F-2 (MINOR)**: Changed `closeTo(1025510.2041, 0.001)` to `closeTo(1025510.2040816326, 0.000001)` in the custom-fees break-even test. Uses the full computed value (`1005000 / 0.98`) with the plan-mandated `0.000001` tolerance.

### Coverage

- Implementation matches all behaviors described in the task body: ✓ `lib/features/market/calculators/margin_calculator.dart` — TradeCalculator.calculateMargin, TradeCalculator.breakEvenSellPrice, TradeMargin.isProfitable
- All named tests pass the verification command: ✓ `test/features/market/calculators/margin_calculator_test.dart` — 8/8 tests pass
- No dependencies added unless absolutely required: ✓ — no pubspec.yaml changes; uses existing `Log.d()` from project's logging utility