### PR TITLE
Phase 1 validation: Apollo team kanban architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ This application uses data from EVE Online under the [CCP Developer License](htt
 - [Blueprint & Specifications](https://github.com/infiquetra/mimir-blueprint)
 - [ESI API Documentation](https://docs.esi.evetech.net/)
 - [EVE Developers](https://developers.eveonline.com/)
+<!-- Phase 1 validation: Apollo team kanban architecture works (2026-05-08) -->


### PR DESCRIPTION
Phase 1 validation marker for the Apollo team-of-teams kanban architecture. Apollo team (apollo-orchestrator + asclepius-se + aristaeus-test + iamus-security + idmon-skeptic + linus-polish) decomposed this card into 3 sub-tasks (implement / review / polish) via kanban_create + kanban_link, asclepius-se did the actual edit. Trivial single-comment diff to README.md.\n\nValidation epic: t_98a076bb\nWorker: apollo-orchestrator (run #7, 391755)\nBody source: ~/.claude/plans/ok-lets-take-linear-mist.md