### PR TITLE
Phase 2 validation: Apollo team DAG fires correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Mimir aims to replace the need for multiple disconnected EVE tools (EVEMon, Pyfa
 ## Status
 
 **Currently in early development (Phase 1)**
+<!-- Phase 2 validation: Apollo team DAG fires correctly (2026-05-08) -->
 
 See the [mimir-blueprint](https://github.com/infiquetra/mimir-blueprint) repository for detailed specifications and roadmap.
 


### PR DESCRIPTION
Validates Phase 2 of the team-of-teams architecture: Apollo team
DAG fires correctly under v0.13 kanban primitives.

## What this validates

Apollo team-lead orchestrator decomposed the validation card into 4
sub-tasks (asclepius-se / aristaeus-test / idmon-skeptic / linus-polish),
linked them with the correct semantic shape (sub-task → epic, sub-task
chain via kanban_link), and the kanban dispatcher spawned each worker
on its named profile.

Surfaced behaviors:
- ✅ Decomposition: 4 sub-tasks, role-matched to expertise
- ✅ Link semantics: epic blocks on all sub-tasks; sub-task chain
  serializes implementation → verify → review → polish
- ✅ Workers spawn correctly: each subprocess runs on its own profile
  (asclepius-se, aristaeus-test, idmon-skeptic, linus-polish)
- ✅ Reviewer feedback loop fires: aristaeus FAIL ("diff shows two +
  lines, not one") + idmon REVISE both caught the stale-branch issue
  on the original implementation
- ✅ Fix-task pattern: orchestrator handled REVISE per SOUL.md
  prescription — created `t_22174ea3` with detailed force-reset
  steps, linked as parent of subsequent reviews
- ✅ Emergent reverify pattern: orchestrator extrapolated beyond SOUL,
  created `t_7c1ea695` (reverify) + `t_43fe87ca` (rereview) on the
  fixed branch — both PASSED
- ✅ Apollo did NOT step into IC role this time (Phase 1B regression)

Surfaced bug (separately tracked):
- ❌ Pattern A polling orchestrator hits max_turns mid-finalize.
  Subprocess exited rc=0 after 21 min / 90 turns with todo
  list showing "Open PR myself" as in_progress. PR opened manually
  to complete the validation. Phase 3 will switch to Pattern B
  (re-entrant orchestrator) or pattern C (dedicated finalize task)
  to avoid this.

## Files changed

README.md gains one comment marker:
```
<!-- Phase 2 validation: Apollo team DAG fires correctly (2026-05-08) -->
```

## Refs

- Apollo team SOUL.md: `ansible/roles/hermes/files/souls/apollo.md`
  (276 lines, deployed in commit `e0de460`)
- Phase 1B narrative: `docs/engineering-journal/narratives/2026-05-08-team-of-teams-phase-1-execution.md`
- Phase 1 PR (orchestrator-as-IC reference): #551