### PR TITLE
chore: update context library repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Mimir aims to replace the need for multiple disconnected EVE tools (EVEMon, Pyfa
 - Phase 3 (Market Tools): Backend complete, UI pending
 - Phase 4 (Ship Fitting): Backend complete (Dogma Engine, Formats), UI pending
 
-See the [mimir-blueprint](https://github.com/infiquetra/mimir-blueprint) repository for detailed specifications and roadmap.
+See the [mimir-context-library](https://github.com/infiquetra/mimir-context-library) repository for detailed specifications and roadmap.
 
 ## Getting Started
 
@@ -88,6 +88,6 @@ This application uses data from EVE Online under the [CCP Developer License](htt
 
 ## Links
 
-- [Blueprint & Specifications](https://github.com/infiquetra/mimir-blueprint)
+- [Blueprint & Specifications](https://github.com/infiquetra/mimir-context-library)
 - [ESI API Documentation](https://docs.esi.evetech.net/)
 - [EVE Developers](https://developers.eveonline.com/)


### PR DESCRIPTION
## Summary

- Update tracked references from the old blueprint repository names to the renamed context-library repositories.
- Replace GitHub URLs, local path examples, mappings, tests, and docs that used `campps-blueprint` or `mimir-blueprint`.
- Leave generic blueprint terminology intact where it refers to an artifact type rather than the renamed repositories.

## Verification

- `git diff --check`
- `git grep -n -I -e 'campps-blueprint' -e 'mimir-blueprint' -- .` returned no tracked matches
- Repo-specific checks were run where applicable: docs validation, targeted SDLC-manager tests, and Python syntax compilation.
