### PR TITLE
docs(agents): backfill AGENTS.md to the context-floor (context-fleet audit)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,32 @@
 # AGENTS.md
 
 This file provides guidance to Codex when working with code in this repository.
-Also read `CLAUDE.md`; it contains the Mimir architecture, build commands,
-testing patterns, logging rules, and EVE-specific implementation guidance.
+
+## Purpose
+
+Mimir is a Flutter-based EVE Online companion app (macOS first, mobile to follow):
+character dashboard, skill-queue monitoring, wallet history, and multi-character
+switching. Also read `CLAUDE.md`; it carries the full Mimir architecture, the
+data-refresh and AsyncValue patterns, logging rules, and the EVE ID-resolution
+guidance that this file deliberately does not duplicate.
+
+## Commands
+
+```bash
+flutter pub get          # install dependencies
+flutter run -d macos     # run on macOS
+flutter test             # run unit + widget tests
+flutter analyze          # static analysis
+dart format .            # format
+```
+
+## Repo-specific rule
+
+Every code change MUST add appropriate debug logging via
+`package:mimir/core/logging/logger.dart` with a `[FEATURE]` tag (see `CLAUDE.md`
+> Debug Logging Requirements). Resolve EVE numeric IDs to names — never display
+raw IDs (`skillNameProvider` for skills, `itemNameProvider`/`locationNameProvider`
+otherwise).
 
 ## 📓 Engineering journal — auto-maintain
 


### PR DESCRIPTION
## Context-fleet audit — mimir remediation

Part of the org-wide context-fleet audit (infiquetra-context-library
`docs/plans/2026-06-20-context-fleet-audit-plan.md`). One PR, one finding.

### What changed
`AGENTS.md` delegated all build/test guidance to `CLAUDE.md` and tripped
`context_census.py` as a thin stub (7 substantive lines, no Commands marker —
EC-4 content-floor breach). Backfilled with:
- a **Purpose** summary of the Flutter EVE-companion app,
- the real **flutter command block** (verified against `pubspec.yaml`),
- an explicit **repo-specific rule** (debug-logging + EVE ID resolution).

No content removed; `CLAUDE.md` stays the canonical deep reference.

### Audit findings (the rest are clean)
- **EC-1 Olympus/Asgard:** zero references anywhere in the repo (markdown, Dart,
  config, journal). No banned phrases, no protected-name concerns.
- **EC-3/EC-4 link-dont-copy:** no canon restatements to dedup; the
  engineering-journal link already uses an absolute GitHub URL.
- **Journal:** no retired terms to reconcile.

### Gate (EC-2, merge_mode=auto)
- Census: `context_census.py --repo-root .` passes, 0 violations.
- Hygiene: `git diff --check` clean.
- Positive content: net +24 lines; file now satisfies Purpose + Commands + repo-specific rule.
- CI: Analyze + Test required checks will run.

https://claude.ai/code/session_01B2Usx8EZXBhB1ek9Ae4WSF